### PR TITLE
Fix dev-all-down not stopping Vite dev server

### DIFF
--- a/scripts/dev_process.py
+++ b/scripts/dev_process.py
@@ -17,6 +17,16 @@ def is_running(pid: int) -> bool:
     return True
 
 
+def is_process_group_running(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 def read_pid(pid_file: Path) -> int | None:
     if not pid_file.exists():
         return None
@@ -39,7 +49,7 @@ def start_process(args: argparse.Namespace) -> int:
     log_file = Path(args.log_file)
     cwd = Path(args.cwd)
     existing_pid = read_pid(pid_file)
-    if existing_pid and is_running(existing_pid):
+    if existing_pid and is_process_group_running(existing_pid):
         print(existing_pid)
         return 0
 
@@ -76,19 +86,19 @@ def stop_process(args: argparse.Namespace) -> int:
     if not pid:
         return 0
 
-    if not is_running(pid):
+    if not is_process_group_running(pid):
         pid_file.unlink(missing_ok=True)
         return 0
 
-    os.kill(pid, signal.SIGTERM)
+    os.killpg(pid, signal.SIGTERM)
     deadline = time.time() + args.timeout
     while time.time() < deadline:
-        if not is_running(pid):
+        if not is_process_group_running(pid):
             pid_file.unlink(missing_ok=True)
             return 0
         time.sleep(0.2)
 
-    os.kill(pid, signal.SIGKILL)
+    os.killpg(pid, signal.SIGKILL)
     pid_file.unlink(missing_ok=True)
     return 0
 
@@ -98,7 +108,7 @@ def status_process(args: argparse.Namespace) -> int:
     pid = read_pid(pid_file)
     if not pid:
         return 1
-    if not is_running(pid):
+    if not is_process_group_running(pid):
         pid_file.unlink(missing_ok=True)
         return 1
     print(pid)

--- a/scripts/test_dev_process.py
+++ b/scripts/test_dev_process.py
@@ -1,0 +1,62 @@
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "dev_process.py"
+
+
+class DevProcessTest(unittest.TestCase):
+    def run_dev_process(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["python3", str(SCRIPT_PATH), *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_status_and_stop_follow_process_group_after_leader_exits(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pid_file = Path(temp_dir) / "web.pid"
+            log_file = Path(temp_dir) / "web.log"
+
+            start_result = self.run_dev_process(
+                "start",
+                "--pid-file",
+                str(pid_file),
+                "--log-file",
+                str(log_file),
+                "--cwd",
+                str(REPO_ROOT),
+                "--",
+                "python3",
+                "-c",
+                (
+                    "import subprocess, time; "
+                    "subprocess.Popen(['/bin/sh', '-lc', 'sleep 30']); "
+                    "time.sleep(1)"
+                ),
+            )
+            self.assertEqual(start_result.returncode, 0, start_result.stderr)
+            self.assertTrue(pid_file.exists())
+
+            time.sleep(2)
+
+            status_result = self.run_dev_process("status", "--pid-file", str(pid_file))
+            self.assertEqual(status_result.returncode, 0, status_result.stderr)
+            self.assertEqual(status_result.stdout.strip(), pid_file.read_text().strip())
+
+            stop_result = self.run_dev_process("stop", "--pid-file", str(pid_file), "--timeout", "1")
+            self.assertEqual(stop_result.returncode, 0, stop_result.stderr)
+            self.assertFalse(pid_file.exists())
+
+            final_status = self.run_dev_process("status", "--pid-file", str(pid_file))
+            self.assertNotEqual(final_status.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stop tracked dev services by process group instead of only the original launcher PID
- keep status checks valid after the launcher exits but child processes in the same group keep running
- add a regression test covering the spawned-child case that was leaving Vite on port 3000

## Testing
- python3 -m unittest scripts/test_dev_process.py