### PR TITLE
fix(ops): resolve storage permission and audit log JSONB type issues

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,7 +24,10 @@ WORKDIR /app
 
 COPY --from=build /app/skillhub-app/target/*.jar app.jar
 
-RUN chown -R app:app /app
+# Create storage directory and set permissions
+RUN mkdir -p /var/lib/skillhub/storage && \
+    chown -R app:app /app /var/lib/skillhub/storage
+
 USER app
 
 EXPOSE 8080

--- a/server/skillhub-app/src/main/resources/db/migration/V7__fix_audit_log_jsonb_type.sql
+++ b/server/skillhub-app/src/main/resources/db/migration/V7__fix_audit_log_jsonb_type.sql
@@ -1,0 +1,12 @@
+-- Fix audit_log detail_json column to properly handle JSONB type
+-- This migration ensures existing data is compatible with the JSONB type
+
+-- The column is already defined as jsonb in V1, but we need to ensure
+-- any existing string data can be properly cast to jsonb
+ALTER TABLE audit_log
+ALTER COLUMN detail_json TYPE jsonb
+USING CASE
+    WHEN detail_json IS NULL THEN NULL
+    WHEN detail_json = '' THEN NULL
+    ELSE detail_json::jsonb
+END;

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/audit/AuditLog.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/audit/AuditLog.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import java.time.Instant;
 
 @Entity
@@ -38,7 +40,8 @@ public class AuditLog {
     @Column(name = "user_agent", length = 512)
     private String userAgent;
 
-    @Column(name = "detail_json", columnDefinition = "jsonb")
+    @Column(name = "detail_json")
+    @JdbcTypeCode(SqlTypes.JSON)
     private String detailJson;
 
     @Column(name = "created_at", nullable = false, updatable = false)


### PR DESCRIPTION
## 问题描述

使用 `runtime.sh` 部署时遇到两个关键问题：

### 1. 存储目录权限错误
```
java.nio.file.AccessDeniedException: /var/lib/skillhub/storage/skills
```

**原因**:
- Docker 容器中应用以 `app` 用户运行
- 但 `/var/lib/skillhub/storage` 目录在 volume 挂载后属于 `root` 用户
- `app` 用户无法创建子目录，导致发布 skill 失败

### 2. 审计日志 JSONB 类型错误
```
ERROR: column "detail_json" is of type jsonb but expression is of type character varying
```

**原因**:
- `audit_log` 表的 `detail_json` 列是 JSONB 类型
- JPA 实体类中未正确配置类型映射
- Hibernate 尝试将字符串直接插入 JSONB 列，导致类型不匹配

## 修复方案

### 1. Dockerfile 修复
在 `server/Dockerfile` 中预先创建存储目录并设置正确的权限：

\`\`\`dockerfile
# Create storage directory and set permissions
RUN mkdir -p /var/lib/skillhub/storage && \\
    chown -R app:app /app /var/lib/skillhub/storage
\`\`\`

### 2. AuditLog 实体类修复
在 `AuditLog.java` 中添加 `@JdbcTypeCode` 注解：

\`\`\`java
@Column(name = "detail_json")
@JdbcTypeCode(SqlTypes.JSON)
private String detailJson;
\`\`\`

### 3. 数据库迁移脚本
添加 `V7__fix_audit_log_jsonb_type.sql` 确保已有部署的数据兼容性。

## 影响范围

- **新部署**: 完全修复，无需手动干预
- **已有部署**: Flyway 自动执行 V7 迁移脚本修复

## 测试验证

- [x] 本地使用 runtime.sh 部署测试
- [x] 发布 skill 功能正常
- [x] 审核 skill 功能正常
- [x] 审计日志正常记录

## 相关文件

- `server/Dockerfile` - 添加存储目录权限设置
- `server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/audit/AuditLog.java` - 添加 JSONB 类型注解
- `server/skillhub-app/src/main/resources/db/migration/V7__fix_audit_log_jsonb_type.sql` - 数据库迁移脚本