### PR TITLE
chore(ci): trigger image publish only on release events

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,12 +1,8 @@
 name: Publish Images
 
 on:
-  push:
-    branches:
-      - main
-      - feature/project-init
-    tags:
-      - "v*.*.*"
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Changes

Modify the GitHub Actions workflow to only trigger image builds on release events instead of every push to main branch.

### What Changed
- Changed workflow trigger from `push` events to `release` (published) events
- Removed automatic builds on main branch merges and feature branches
- Kept manual `workflow_dispatch` option for flexibility

### Why
- Reduces unnecessary CI runs on every PR merge
- Aligns image publishing with actual release cadence
- Saves CI resources and time

### Testing
- Workflow will trigger on next release publish
- Can be manually tested via workflow_dispatch