### PR TITLE
feat(i18n): set English as default fallback language

### DIFF
--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -12,7 +12,7 @@ i18n
       en: { translation: en },
       zh: { translation: zh },
     },
-    fallbackLng: 'zh',
+    fallbackLng: 'en',
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
Changes `fallbackLng` from `zh` to `en` in the i18n config.

Users without a stored language preference or a Chinese browser locale will now see the UI in English by default.