### PR TITLE
docs: add Support section to README (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,14 @@ what you'd like to change.
 - Contribution guide: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 - Code of conduct: [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md)
 
+## 📞 Support
+
+- 💬 **Community Discussion**: [GitHub Discussions](https://github.com/iflytek/skillhub/discussions)
+- 🐛 **Bug Reports**: [Issues](https://github.com/iflytek/skillhub/issues)
+- 👥 **WeChat Work Group**:
+
+  ![WeChat Work Group](https://github.com/iflytek/astron-agent/raw/main/docs/imgs/WeCom_Group.png)
+
 ## License
 
 Apache License 2.0


### PR DESCRIPTION
* Initial plan

* docs: add Support section to README with community links



---------

## Summary

- What changed?
- Why is this needed?

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
# paste commands here
```

## Risk

- User-facing impact:
- Deployment or migration impact:
- Rollback approach:

## Notes

- Related issue:
- Follow-up work:
- Docs or operator runbooks updated when behavior changed:
