### PR TITLE
Configure default session timeout

### DIFF
--- a/server/skillhub-app/src/main/resources/application.yml
+++ b/server/skillhub-app/src/main/resources/application.yml
@@ -4,11 +4,11 @@ server:
   forward-headers-strategy: framework
   servlet:
     session:
+      timeout: ${SERVER_SERVLET_SESSION_TIMEOUT:8h}
       cookie:
         http-only: true
         secure: ${SESSION_COOKIE_SECURE:false}
         same-site: lax
-        max-age: 28800
 
 spring:
   messages:


### PR DESCRIPTION
## Summary
- configure the default servlet session timeout explicitly to 8 hours
- keep environment variable override support via SERVER_SERVLET_SESSION_TIMEOUT
- remove the fixed session cookie max-age so active users are governed by sliding session expiry instead of an absolute cookie expiry

## Testing
- not run (config-only change)
