### PR TITLE
fix: clarify global namespace visibility copy

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -839,6 +839,7 @@
     "visibilityOptions": {
       "public": "Public",
       "namespaceOnly": "Namespace Only",
+      "loggedInUsersOnly": "Logged-in Users Only",
       "private": "Private"
     },
     "file": "Skill Package File",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -839,6 +839,7 @@
     "visibilityOptions": {
       "public": "公开",
       "namespaceOnly": "仅命名空间",
+      "loggedInUsersOnly": "仅登录用户可见",
       "private": "私有"
     },
     "file": "技能包文件",

--- a/web/src/pages/dashboard/publish.tsx
+++ b/web/src/pages/dashboard/publish.tsx
@@ -50,6 +50,10 @@ export function PublishPage() {
 
   const { data: namespaces, isLoading: isLoadingNamespaces } = useMyNamespaces()
   const publishMutation = usePublishSkill()
+  const selectedNamespace = namespaces?.find((ns) => ns.slug === namespaceSlug)
+  const namespaceOnlyLabel = selectedNamespace?.type === 'GLOBAL'
+    ? t('publish.visibilityOptions.loggedInUsersOnly')
+    : t('publish.visibilityOptions.namespaceOnly')
 
   const handleRemoveSelectedFile = () => {
     setSelectedFile(null)
@@ -153,7 +157,7 @@ export function PublishPage() {
             onChange={(e) => setVisibility(e.target.value)}
           >
             <option value="PUBLIC">{t('publish.visibilityOptions.public')}</option>
-            <option value="NAMESPACE_ONLY">{t('publish.visibilityOptions.namespaceOnly')}</option>
+            <option value="NAMESPACE_ONLY">{namespaceOnlyLabel}</option>
             <option value="PRIVATE">{t('publish.visibilityOptions.private')}</option>
           </Select>
         </div>


### PR DESCRIPTION
## Summary
- update the publish page visibility copy for the global namespace
- show 'Logged-in Users Only' instead of 'Namespace Only' when the selected namespace is global
- add the matching i18n entries in English and Chinese

## Testing
- not run (web node_modules are not installed in this worktree)