### PR TITLE
fix: handle numeric search terms in downloads sort

### DIFF
--- a/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
+++ b/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
@@ -62,6 +62,7 @@ public class PostgresFullTextQueryService implements SearchQueryService {
         String tsQuery = buildPrefixTsQuery(normalizedKeyword);
         boolean hasKeyword = normalizedKeyword != null;
         boolean hasTsQuery = tsQuery != null;
+        boolean useRelevanceOrdering = "relevance".equals(query.sortBy()) && hasKeyword;
         boolean useShortPrefixTitleSearch = hasTsQuery && normalizedKeyword.length() <= SHORT_PREFIX_LENGTH;
         boolean useSemanticRerank = semanticEnabled
                 && hasKeyword
@@ -126,7 +127,7 @@ public class PostgresFullTextQueryService implements SearchQueryService {
             sql.append("ORDER BY (SELECT rating_avg FROM skill WHERE id = skill_id) DESC ");
         } else if ("newest".equals(query.sortBy())) {
             sql.append("ORDER BY (SELECT updated_at FROM skill WHERE id = skill_id) DESC ");
-        } else if ("relevance".equals(query.sortBy()) && hasKeyword) {
+        } else if (useRelevanceOrdering) {
             sql.append("ORDER BY CASE ");
             sql.append("WHEN ").append(TITLE_SQL).append(" = :titleExact THEN 4 ");
             sql.append("WHEN ").append(TITLE_SQL).append(" LIKE :titlePrefix THEN 3 ");
@@ -163,8 +164,10 @@ public class PostgresFullTextQueryService implements SearchQueryService {
             if (hasTsQuery) {
                 nativeQuery.setParameter("tsQuery", tsQuery);
             }
-            nativeQuery.setParameter("titleExact", normalizedKeyword.toLowerCase());
-            nativeQuery.setParameter("titlePrefix", normalizedKeyword.toLowerCase() + "%");
+            if (useRelevanceOrdering) {
+                nativeQuery.setParameter("titleExact", normalizedKeyword.toLowerCase());
+                nativeQuery.setParameter("titlePrefix", normalizedKeyword.toLowerCase() + "%");
+            }
             nativeQuery.setParameter("titleLike", "%" + normalizedKeyword.toLowerCase() + "%");
         }
 

--- a/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryServiceTest.java
+++ b/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryServiceTest.java
@@ -203,6 +203,35 @@ class PostgresFullTextQueryServiceTest {
     }
 
     @Test
+    void downloadsSortShouldNotBindRelevanceOnlyParameters() {
+        EntityManager entityManager = mock(EntityManager.class);
+        Query nativeQuery = mock(Query.class);
+        Query countQuery = mock(Query.class);
+        when(entityManager.createNativeQuery(anyString()))
+                .thenReturn(nativeQuery)
+                .thenReturn(countQuery);
+        when(nativeQuery.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(nativeQuery);
+        when(countQuery.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(countQuery);
+        when(nativeQuery.getResultList()).thenReturn(List.of());
+        when(countQuery.getSingleResult()).thenReturn(0L);
+
+        PostgresFullTextQueryService service = new PostgresFullTextQueryService(entityManager);
+
+        service.search(new SearchQuery(
+                "51222222333",
+                null,
+                new SearchVisibilityScope(null, Set.of(), Set.of()),
+                "downloads",
+                0,
+                12
+        ));
+
+        verify(nativeQuery, never()).setParameter(org.mockito.ArgumentMatchers.eq("titleExact"), anyString());
+        verify(nativeQuery, never()).setParameter(org.mockito.ArgumentMatchers.eq("titlePrefix"), anyString());
+        verify(nativeQuery).setParameter("titleLike", "%51222222333%");
+    }
+
+    @Test
     void semanticRerankShouldPromoteSemanticallyRelevantCandidate() {
         EntityManager entityManager = mock(EntityManager.class);
         Query nativeQuery = mock(Query.class);


### PR DESCRIPTION
## Summary
- fix search requests with numeric-only keywords when sorting by downloads
- avoid binding relevance-only SQL parameters for non-relevance ordering
- add regression coverage for numeric keyword plus downloads sort

## Verification
- ./mvnw -pl skillhub-search -Dtest=PostgresFullTextQueryServiceTest -DforkCount=0 test
- ./mvnw -pl skillhub-search -DskipTests compile