### PR TITLE
perf(web): reduce react-query stale time to 30s

### DIFF
--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -7,7 +7,7 @@ import { router } from './router'
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 5 * 60 * 1000,
+      staleTime: 30 * 1000,
       retry: (failureCount, error) => {
         // Don't retry on 401/403/404
         if (error instanceof Error && /HTTP (401|403|404)/.test(error.message)) {


### PR DESCRIPTION
## Summary

- What changed?
- Why is this needed?

## Validation

- [ ] Backend tests passed
- [x] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
# paste commands here
```

## Risk

- User-facing impact:
- Deployment or migration impact:
- Rollback approach:

## Notes

- Related issue:
- Follow-up work:
- Docs or operator runbooks updated when behavior changed:
