### PR TITLE
Serve registry skill docs from nginx

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,6 +8,7 @@ RUN pnpm build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/src/docs/skill.md /usr/share/nginx/html/registry/skill.md
 COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY runtime-config.js.template /usr/share/nginx/html/runtime-config.js.template
 COPY docker-entrypoint.d/30-runtime-config.sh /docker-entrypoint.d/30-runtime-config.sh

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -45,6 +45,13 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    location = /registry/skill.md {
+        default_type text/plain;
+        add_header Content-Disposition "inline";
+        add_header X-Content-Type-Options "nosniff";
+        try_files $uri =404;
+    }
+
     location = /runtime-config.js {
         add_header Cache-Control "no-store";
         try_files $uri =404;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -10,14 +10,6 @@ export function Layout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const { user, isLoading } = useAuth()
 
-  if (pathname === '/registry/skill') {
-    return (
-      <Suspense fallback={null}>
-        <Outlet />
-      </Suspense>
-    )
-  }
-
   const navItems: Array<{
     label: string
     to: string

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -60,7 +60,6 @@ const SearchPage = createLazyRouteComponent(() => import('@/pages/search'), 'Sea
 const TermsOfServicePage = createLazyRouteComponent(() => import('@/pages/terms'), 'TermsOfServicePage')
 const NamespacePage = createLazyRouteComponent(() => import('@/pages/namespace'), 'NamespacePage')
 const SkillDetailPage = createLazyRouteComponent(() => import('@/pages/skill-detail'), 'SkillDetailPage')
-const RegistrySkillPage = createLazyRouteComponent(() => import('@/pages/registry-skill'), 'RegistrySkillPage')
 const DashboardPage = createLazyRouteComponent(() => import('@/pages/dashboard'), 'DashboardPage')
 const MySkillsPage = createLazyRouteComponent(() => import('@/pages/dashboard/my-skills'), 'MySkillsPage')
 const PublishPage = createLazyRouteComponent(() => import('@/pages/dashboard/publish'), 'PublishPage')
@@ -215,12 +214,6 @@ const skillDetailRoute = createRoute({
   component: SkillDetailPage,
 })
 
-const registrySkillRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/registry/skill',
-  component: RegistrySkillPage,
-})
-
 const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'dashboard',
@@ -367,7 +360,6 @@ const routeTree = rootRoute.addChildren([
   termsRoute,
   namespaceRoute,
   skillDetailRoute,
-  registrySkillRoute,
   dashboardRoute,
   dashboardSkillsRoute,
   dashboardPublishRoute,

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -107,7 +107,7 @@
       },
       "agent": {
         "description": "Send a prompt to your Agent to set up the SkillHub Registry",
-        "command": "Read https://www.example.com/registry/skill and follow the instructions to setup SkillHub Skills Registry"
+        "command": "Read https://www.example.com/registry/skill.md and follow the instructions to setup SkillHub Skills Registry"
       },
       "human": {
         "description": "Use the CLI tool to install Skills",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -107,7 +107,7 @@
       },
       "agent": {
         "description": "发送提示词给你的 Agent，以设置SkillHub Registry",
-        "command": "Read https://www.example.com/registry/skill and follow the instructions to setup SkillHub Skills Registry"
+        "command": "Read https://www.example.com/registry/skill.md and follow the instructions to setup SkillHub Skills Registry"
       },
       "human": {
         "description": "使用CLI工具安装Skills",

--- a/web/src/pages/registry-skill.tsx
+++ b/web/src/pages/registry-skill.tsx
@@ -1,9 +1,0 @@
-import skillContent from '@/docs/skill.md?raw'
-
-export function RegistrySkillPage() {
-  return (
-    <pre className="whitespace-pre-wrap break-words p-0 m-0 font-mono text-sm">
-      {skillContent}
-    </pre>
-  )
-}


### PR DESCRIPTION
## Summary
- remove the frontend route for 
- serve  from nginx at  as inline 
- update registry setup copy to point to the new static docs path

## Testing
- pnpm --dir web test
- pnpm --dir web build
