### PR TITLE
Fix user profile test isolation and app module workflow docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,12 @@ build-backend: ## 构建后端
 test-backend: ## 运行后端单元测试
 	cd server && JDK_JAVA_OPTIONS="$(BACKEND_TEST_JAVA_OPTIONS)" ./mvnw test
 
+build-backend-app: ## 构建 skillhub-app 及其依赖模块
+	cd server && ./mvnw -pl skillhub-app -am clean package -DskipTests
+
+test-backend-app: ## 运行 skillhub-app 及其依赖模块测试
+	cd server && JDK_JAVA_OPTIONS="$(BACKEND_TEST_JAVA_OPTIONS)" ./mvnw -pl skillhub-app -am test
+
 build: build-backend build-frontend ## 完整构建前后端
 
 test: test-backend test-frontend ## 运行前后端完整单元测试

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ make dev-all-reset
 
 Run `make help` to see all available commands.
 
+Useful backend commands:
+
+```bash
+make test
+make test-backend-app
+make build-backend-app
+```
+
+Do not run `./mvnw -pl skillhub-app clean test` directly under `server/`.
+`skillhub-app` depends on sibling modules in the same repo, and a standalone clean build
+can fall back to stale artifacts from the local Maven repository, which surfaces misleading
+`cannot find symbol` and signature-mismatch errors. Use `-am`, or the `make test-backend-app`
+and `make build-backend-app` targets above.
+
 For the full development workflow (local dev → staging → PR), see [docs/dev-workflow.md](docs/dev-workflow.md).
 
 ### API Contract Sync

--- a/README_zh.md
+++ b/README_zh.md
@@ -110,12 +110,16 @@ make dev-web        # 仅前端
 ```bash
 make help                    # 显示所有可用命令
 make test                    # 运行后端测试
+make test-backend-app        # 运行 skillhub-app 及其依赖模块测试
+make build-backend-app       # 构建 skillhub-app 及其依赖模块
 make typecheck-web          # TypeScript 类型检查
 make build-web              # 构建前端
 make generate-api           # 重新生成 OpenAPI 类型
 ./scripts/check-openapi-generated.sh  # 验证 API 契约同步
 ./scripts/smoke-test.sh http://localhost:8080  # 运行冒烟测试
 ```
+
+说明：不要在 `server/` 下直接执行 `./mvnw -pl skillhub-app clean test`。`skillhub-app` 依赖同仓库的 sibling modules，单独 clean 构建时会回退到本地 Maven 仓库里的旧产物并出现大量 `cannot find symbol` / 签名不匹配错误。需要使用 `-am`，或者直接使用上面的 `make test-backend-app` / `make build-backend-app`。
 
 ### 项目结构
 

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/UserProfileControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/UserProfileControllerTest.java
@@ -3,6 +3,7 @@ package com.iflytek.skillhub.controller;
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.auth.repository.UserRoleBindingRepository;
 import com.iflytek.skillhub.auth.session.PlatformSessionService;
+import com.iflytek.skillhub.domain.audit.AuditLogService;
 import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
 import com.iflytek.skillhub.domain.user.ProfileChangeRequestRepository;
 import com.iflytek.skillhub.domain.user.ProfileChangeStatus;
@@ -78,6 +79,9 @@ class UserProfileControllerTest {
 
     @MockBean
     private PlatformSessionService platformSessionService;
+
+    @MockBean
+    private AuditLogService auditLogService;
 
     // -- Helper --
 
@@ -225,4 +229,3 @@ class UserProfileControllerTest {
                 .andExpect(status().isBadRequest());
     }
 }
-


### PR DESCRIPTION
## Summary
- isolate the user profile controller success-path test by mocking audit logging
- add dedicated make targets for building and testing skillhub-app with sibling modules
- document the safe skillhub-app Maven workflow in English and Chinese READMEs

## Testing
- make test
- make test-backend-app