### PR TITLE
fix:change 'Start Building' to 'Publish Skill'

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -16,7 +16,7 @@
       "subtitle": "Build powerful AI agents with community-driven skills",
       "searchPlaceholder": "Search skills...",
       "exploreSkills": "Explore Skills",
-      "publishSkill": "Start Building"
+      "publishSkill": "Publish Skill"
     },
     "features": {
       "secure": {


### PR DESCRIPTION
## Summary

- What changed?
- Why is this needed?

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
# paste commands here
```

## Risk

- User-facing impact:
- Deployment or migration impact:
- Rollback approach:

## Notes

- Related issue:
- Follow-up work:
- Docs or operator runbooks updated when behavior changed:
