### PR TITLE
docs: simplify skillhub registry guide

### DIFF
--- a/web/src/docs/skill.md
+++ b/web/src/docs/skill.md
@@ -1,24 +1,27 @@
 ---
 name: skillhub-registry
-description: Use this when you need to search, inspect, install, or publish agent skills against a SkillHub registry. SkillHub is a self-hosted skill registry with a ClawHub-compatible API layer, so prefer the `clawhub` CLI for registry operations instead of making raw HTTP calls.
+description: Use this when you need to search, inspect, install, or publish agent skills against a SkillHub registry. SkillHub is a skill registry with a ClawHub-compatible API layer, so prefer the `clawhub` CLI for registry operations instead of making raw HTTP calls.
 ---
 
 # SkillHub Registry
 
-Use this skill when you need to work with a SkillHub deployment: search skills, inspect metadata, install a package, or publish a new version.
+Use this skill when you need to work with a SkillHub registry: search skills, inspect metadata, install a package, or publish a new version.
 
 > Important: Prefer the `clawhub` CLI for registry workflows. SkillHub exposes a ClawHub-compatible API surface and a discovery endpoint at `/.well-known/clawhub.json`, so the CLI is the safest path for auth, resolution, and download behavior. Only fall back to raw HTTP when debugging the server itself.
 
 ## What SkillHub Is
 
-SkillHub is a self-hosted, enterprise-oriented skill registry. It stores versioned skill packages, supports namespace-based governance, and keeps `SKILL.md` compatibility with OpenSkills-style packages.
+SkillHub is an enterprise-oriented skill registry. It stores versioned skill packages, supports namespace-based skill management, and keeps `SKILL.md` compatibility with OpenSkills-style packages.
 
 Key facts:
 
 - Internal coordinates use `@{namespace}/{skill_slug}`.
-- ClawHub-compatible clients use a canonical slug instead.
+- If using the clawhub CLI, the compatible format is `{namespace}--{skill_slug}`.
+- ClawHub-compatible clients use a `{namespace}--{skill_slug}` slug instead.
 - `latest` always means the latest published version, never draft or pending review.
 - Public skills in `@global` can be downloaded anonymously.
+- If no namespace is specified, it defaults to `@global`.
+- `{skill_slug}` can be used instead of `global--{skill_slug}`
 - Team namespace skills and non-public skills require authentication.
 
 ## Configure The CLI
@@ -28,6 +31,13 @@ Point `clawhub` at the SkillHub base URL:
 ```bash
 export CLAWHUB_REGISTRY_URL=https://skillhub.your-company.com
 ```
+
+Alternatively, use the `--registry` parameter every time, for example:
+
+```bash
+npx clawhub install my-skill --registry https://skillhub.your-company.com
+```
+
 
 If you need authenticated access, provide an API token:
 
@@ -44,10 +54,10 @@ curl https://skillhub.your-company.com/.well-known/clawhub.json
 Expected response:
 
 ```json
-{ "apiBase": "/api/v1" }
+{"apiBase":"/api/v1"}
 ```
 
-## Coordinate Rules
+## Coordinate Rules - IMPORTANT
 
 SkillHub has two naming forms:
 
@@ -130,64 +140,6 @@ If a request fails with `403`, check:
 
 SkillHub expects OpenSkills-style packages with `SKILL.md` as the entry point.
 
-Minimum valid `SKILL.md` frontmatter:
-
-```yaml
----
-name: my-skill
-description: When to use this skill
----
-```
-
-Required structure:
-
-```text
-my-skill/
-├── SKILL.md
-├── references/
-├── scripts/
-└── assets/
-```
-
-Contract notes:
-
-- `name` and `description` are required.
-- `name` becomes the immutable skill slug on first publish.
-- `description` becomes the registry summary.
-- `references/`, `scripts/`, and `assets/` are optional.
-- The package is treated as a text-first resource bundle, not a binary artifact bucket.
-
 ## Publishing Guidance
 
-Before publishing:
-
-1. Ensure `SKILL.md` exists at the package root.
-2. Keep the skill name in kebab-case.
-3. Make sure the version you are publishing is semver-compatible.
-4. Avoid relying on `latest` as a rollback tool; SkillHub keeps `latest` automatically pinned to the newest published version.
-5. Use custom tags like `beta` or `stable` for release channels when needed.
-
-## When To Use Raw HTTP
-
-Use direct HTTP only for server debugging, contract testing, or compatibility work. Relevant endpoints exposed by the current codebase include:
-
-- `GET /.well-known/clawhub.json`
-- `GET /api/v1/search`
-- `GET /api/v1/resolve`
-- `GET /api/v1/download/{slug}`
-- `GET /api/v1/skills/{slug}`
-- `POST /api/v1/publish`
-- `GET /api/v1/whoami`
-
-For normal registry usage, stay on the `clawhub` CLI.
-
-## Project References
-
-Read these local documents when you need more detail about SkillHub behavior:
-
-- `docs/00-product-direction.md`
-- `docs/06-api-design.md`
-- `docs/07-skill-protocol.md`
-- `docs/14-skill-lifecycle.md`
-- `docs/openclaw-integration.md`
-- `README.md`
+Just need to follow the OpenSkills-style standards.


### PR DESCRIPTION
## Summary
- simplify the SkillHub registry skill wording from self-hosted deployment language to generic registry language
- clarify namespace and slug rules for clawhub-compatible usage
- remove duplicated packaging and raw HTTP guidance from the doc

## Testing
- not run (docs-only change)