### PR TITLE
fix: environment variable name for the registry

### DIFF
--- a/web/src/docs/skill.md
+++ b/web/src/docs/skill.md
@@ -29,7 +29,7 @@ Key facts:
 Point `clawhub` at the SkillHub base URL:
 
 ```bash
-export CLAWHUB_REGISTRY_URL=https://skillhub.your-company.com
+export CLAWHUB_REGISTRY=https://skillhub.your-company.com
 ```
 
 Alternatively, use the `--registry` parameter every time, for example:


### PR DESCRIPTION
## Summary

- What changed?
- Why is this needed?

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
# paste commands here
```

## Risk

- User-facing impact:
- Deployment or migration impact:
- Rollback approach:

## Notes

- Related issue:
- Follow-up work:
- Docs or operator runbooks updated when behavior changed:
