### PR TITLE
docs: align clawhub env vars with public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,9 @@ SkillHub works as a skill registry backend for several agent platforms. Point an
 ```bash
 # Configure registry URL
 export CLAWHUB_REGISTRY=https://skillhub.your-company.com
-export CLAWHUB_API_TOKEN=YOUR_API_TOKEN
+
+# Authenticate once if needed
+clawhub login --token YOUR_API_TOKEN
 
 # Search and install skills
 npx clawhub search email

--- a/README_zh.md
+++ b/README_zh.md
@@ -266,7 +266,9 @@ SkillHub 设计为与各种智能体平台和框架无缝集成。
 ```bash
 # 配置注册中心地址
 export CLAWHUB_REGISTRY=https://skillhub.your-company.com
-export CLAWHUB_API_TOKEN=YOUR_API_TOKEN
+
+# 如需认证，先登录一次
+clawhub login --token YOUR_API_TOKEN
 
 # 搜索和安装技能
 npx clawhub search email

--- a/docs/openclaw-integration-en.md
+++ b/docs/openclaw-integration-en.md
@@ -31,8 +31,8 @@ For **global namespace (@global) PUBLIC skills**, no login is required to downlo
 - Write operations like publishing, starring, etc.
 
 ```bash
-# Using API Token
-export CLAWHUB_API_TOKEN=YOUR_API_TOKEN
+# Log in with an API token
+clawhub login --token YOUR_API_TOKEN
 ```
 
 #### Obtaining an API Token
@@ -142,7 +142,9 @@ ClawHub CLI is configured via environment variables:
 ```bash
 # Registry configuration
 export CLAWHUB_REGISTRY=https://skillhub.your-company.com
-export CLAWHUB_API_TOKEN=sk_your_api_token_here
+
+# Authenticate once if needed
+clawhub login --token sk_your_api_token_here
 ```
 
 ### Environment Variables
@@ -150,10 +152,9 @@ export CLAWHUB_API_TOKEN=sk_your_api_token_here
 ```bash
 # Registry configuration
 export CLAWHUB_REGISTRY=https://skillhub.your-company.com
-export CLAWHUB_API_TOKEN=sk_your_api_token_here
 
-# Optional: Skip SSL verification (development only)
-export CLAWHUB_SKIP_SSL_VERIFY=false
+# Optionally log in before running authenticated commands
+clawhub login --token sk_your_api_token_here
 ```
 
 ## FAQ
@@ -177,12 +178,12 @@ Possible causes:
 
 Solution:
 ```bash
-# Set new token
-export CLAWHUB_API_TOKEN=YOUR_NEW_TOKEN
+# Log in again with a new token
+clawhub login --token YOUR_NEW_TOKEN
 
 # Test connection
 curl https://skillhub.your-company.com/api/v1/whoami \
-  -H "Authorization: Bearer $CLAWHUB_API_TOKEN"
+  -H "Authorization: Bearer YOUR_NEW_TOKEN"
 ```
 
 **Tip**: Global namespace (@global) PUBLIC skills can be downloaded anonymously without authentication.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -31,8 +31,8 @@ export CLAWHUB_REGISTRY=https://skillhub.your-company.com
 - 发布、收藏等写操作
 
 ```bash
-# 使用 API Token
-export CLAWHUB_API_TOKEN=YOUR_API_TOKEN
+# 使用 API Token 登录
+clawhub login --token YOUR_API_TOKEN
 ```
 
 #### 获取 API Token
@@ -142,7 +142,9 @@ ClawHub CLI 通过环境变量配置：
 ```bash
 # Registry 配置
 export CLAWHUB_REGISTRY=https://skillhub.your-company.com
-export CLAWHUB_API_TOKEN=sk_your_api_token_here
+
+# 如需认证，先登录一次
+clawhub login --token sk_your_api_token_here
 ```
 
 ### 环境变量配置
@@ -150,10 +152,9 @@ export CLAWHUB_API_TOKEN=sk_your_api_token_here
 ```bash
 # Registry 配置
 export CLAWHUB_REGISTRY=https://skillhub.your-company.com
-export CLAWHUB_API_TOKEN=sk_your_api_token_here
 
-# 可选：跳过 SSL 验证（仅用于开发环境）
-export CLAWHUB_SKIP_SSL_VERIFY=false
+# 可选：登录后再执行需要认证的命令
+clawhub login --token sk_your_api_token_here
 ```
 
 ## 常见问题
@@ -177,12 +178,12 @@ unset CLAWHUB_REGISTRY
 
 解决方法：
 ```bash
-# 设置新的 Token
-export CLAWHUB_API_TOKEN=YOUR_NEW_TOKEN
+# 设置新的 Token 并重新登录
+clawhub login --token YOUR_NEW_TOKEN
 
 # 测试连接
 curl https://skillhub.your-company.com/api/v1/whoami \
-  -H "Authorization: Bearer $CLAWHUB_API_TOKEN"
+  -H "Authorization: Bearer YOUR_NEW_TOKEN"
 ```
 
 **提示**：全局命名空间（@global）的 PUBLIC 技能可以匿名下载，无需认证。

--- a/web/src/docs/skill.md
+++ b/web/src/docs/skill.md
@@ -42,7 +42,7 @@ npx clawhub install my-skill --registry https://skillhub.your-company.com
 If you need authenticated access, provide an API token:
 
 ```bash
-export CLAWHUB_API_TOKEN=sk_your_api_token_here
+clawhub login --token sk_your_api_token_here
 ```
 
 Optional local check:


### PR DESCRIPTION
## Summary
- remove non-public ClawHub CLI environment variables from SkillHub docs
- replace token env var examples with `clawhub login --token ...`
- keep documented ClawHub env vars aligned with the public docs

## Testing
- not run (docs-only change)
