### PR TITLE
fix(search): harden rebuild against null frontmatter values

### DIFF
--- a/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
+++ b/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Locale;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -189,10 +190,10 @@ public class PostgresFullTextQueryService implements SearchQueryService {
                 nativeQuery.setParameter("tsQuery", tsQuery);
             }
             if (useRelevanceOrdering) {
-                nativeQuery.setParameter("titleExact", normalizedKeyword.toLowerCase());
-                nativeQuery.setParameter("titlePrefix", normalizedKeyword.toLowerCase() + "%");
+                nativeQuery.setParameter("titleExact", normalizedKeyword.toLowerCase(Locale.ROOT));
+                nativeQuery.setParameter("titlePrefix", normalizedKeyword.toLowerCase(Locale.ROOT) + "%");
             }
-            nativeQuery.setParameter("titleLike", "%" + normalizedKeyword.toLowerCase() + "%");
+            nativeQuery.setParameter("titleLike", "%" + normalizedKeyword.toLowerCase(Locale.ROOT) + "%");
         }
 
         nativeQuery.setParameter("limit", sqlLimit);
@@ -230,7 +231,7 @@ public class PostgresFullTextQueryService implements SearchQueryService {
             if (hasTsQuery) {
                 countQuery.setParameter("tsQuery", tsQuery);
             }
-            countQuery.setParameter("titleLike", "%" + normalizedKeyword.toLowerCase() + "%");
+            countQuery.setParameter("titleLike", "%" + normalizedKeyword.toLowerCase(Locale.ROOT) + "%");
         }
 
         long total = ((Number) countQuery.getSingleResult()).longValue();
@@ -293,7 +294,7 @@ public class PostgresFullTextQueryService implements SearchQueryService {
         if (keyword == null || keyword.isBlank()) {
             return null;
         }
-        return keyword.trim().toLowerCase();
+        return keyword.trim().toLowerCase(Locale.ROOT);
     }
 
     private String buildPrefixTsQuery(String keyword) {

--- a/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildService.java
+++ b/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildService.java
@@ -17,13 +17,14 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 /**
  * Reconstructs PostgreSQL search documents from canonical skill and namespace records.
@@ -125,9 +126,13 @@ public class PostgresSearchRebuildService implements SearchRebuildService {
     @SuppressWarnings("unchecked")
     private Map<String, Object> asMap(Object value) {
         if (value instanceof Map<?, ?> map) {
-            return map.entrySet().stream()
-                    .filter(entry -> entry.getKey() != null)
-                    .collect(Collectors.toMap(entry -> String.valueOf(entry.getKey()), Map.Entry::getValue));
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (entry.getKey() != null) {
+                    normalized.put(String.valueOf(entry.getKey()), entry.getValue());
+                }
+            }
+            return normalized;
         }
         return Map.of();
     }
@@ -139,8 +144,9 @@ public class PostgresSearchRebuildService implements SearchRebuildService {
             if (value == null) {
                 continue;
             }
+            String normalizedFieldName = fieldName.toLowerCase(Locale.ROOT);
 
-            if (KEYWORD_FIELD_NAMES.contains(fieldName.toLowerCase())) {
+            if (KEYWORD_FIELD_NAMES.contains(normalizedFieldName)) {
                 flattenToStrings(value).forEach(keyword -> {
                     String normalized = keyword.trim();
                     if (!normalized.isBlank()) {
@@ -149,7 +155,7 @@ public class PostgresSearchRebuildService implements SearchRebuildService {
                 });
             }
 
-            if (!RESERVED_FRONTMATTER_FIELDS.contains(fieldName.toLowerCase())) {
+            if (!RESERVED_FRONTMATTER_FIELDS.contains(normalizedFieldName)) {
                 addPart(searchParts, fieldName);
                 flattenToStrings(value).forEach(text -> addPart(searchParts, text));
             }
@@ -157,6 +163,9 @@ public class PostgresSearchRebuildService implements SearchRebuildService {
     }
 
     private List<String> flattenToStrings(Object value) {
+        if (value == null) {
+            return List.of();
+        }
         if (value instanceof String text) {
             return List.of(text);
         }
@@ -169,7 +178,9 @@ public class PostgresSearchRebuildService implements SearchRebuildService {
                 if (entry.getKey() != null) {
                     values.add(String.valueOf(entry.getKey()));
                 }
-                values.addAll(flattenToStrings(entry.getValue()));
+                if (entry.getValue() != null) {
+                    values.addAll(flattenToStrings(entry.getValue()));
+                }
             }
             return values;
         }

--- a/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildServiceTest.java
+++ b/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildServiceTest.java
@@ -145,4 +145,61 @@ class PostgresSearchRebuildServiceTest {
         assertThat(document.searchText()).contains("maintainer");
         assertThat(document.searchText()).contains("新版维护者");
     }
+
+    @Test
+    void rebuildBySkill_shouldIgnoreNullFrontmatterValues() {
+        SkillRepository skillRepository = mock(SkillRepository.class);
+        NamespaceRepository namespaceRepository = mock(NamespaceRepository.class);
+        SkillVersionRepository skillVersionRepository = mock(SkillVersionRepository.class);
+        SearchIndexService searchIndexService = mock(SearchIndexService.class);
+
+        Skill skill = new Skill(7L, "smart-agent", "owner-1", SkillVisibility.PUBLIC);
+        skill.setDisplayName("Smart Agent");
+        skill.setSummary("Builds workflows");
+        skill.setLatestVersionId(101L);
+
+        Namespace namespace = new Namespace("team-ai", "Team AI", "owner-1");
+
+        SkillVersion version = new SkillVersion(1L, "1.4.0", "owner-1");
+        version.setParsedMetadataJson("""
+                {
+                  "name": "Smart Agent",
+                  "description": "Builds workflows",
+                  "version": "1.4.0",
+                  "frontmatter": {
+                    "tags": ["automation"],
+                    "maintainer": null,
+                    "config": {
+                      "provider": "openai",
+                      "region": null
+                    }
+                  }
+                }
+                """);
+
+        when(skillRepository.findById(1L)).thenReturn(Optional.of(skill));
+        when(namespaceRepository.findById(7L)).thenReturn(Optional.of(namespace));
+        when(skillVersionRepository.findById(101L)).thenReturn(Optional.of(version));
+
+        PostgresSearchRebuildService service = new PostgresSearchRebuildService(
+                skillRepository,
+                namespaceRepository,
+                skillVersionRepository,
+                searchIndexService,
+                new SearchTextTokenizer()
+        );
+
+        service.rebuildBySkill(1L);
+
+        ArgumentCaptor<SkillSearchDocument> captor = ArgumentCaptor.forClass(SkillSearchDocument.class);
+        verify(searchIndexService).index(captor.capture());
+
+        SkillSearchDocument document = captor.getValue();
+        assertThat(document.keywords()).contains("automation");
+        assertThat(document.searchText()).contains("config");
+        assertThat(document.searchText()).contains("provider");
+        assertThat(document.searchText()).contains("openai");
+        assertThat(document.searchText()).doesNotContain("maintainer");
+        assertThat(document.searchText()).doesNotContain("region null");
+    }
 }


### PR DESCRIPTION
## Summary
- make search rebuild resilient to `null` values inside parsed frontmatter metadata
- avoid indexing nested `null` values as the literal string `"null"`
- normalize search query lowercasing with `Locale.ROOT`

## Details
- replace `Collectors.toMap(...)` in `PostgresSearchRebuildService.asMap()` with explicit map normalization so frontmatter objects may contain null values safely
- skip nested null values in `flattenToStrings()` during frontmatter expansion
- use `Locale.ROOT` for search keyword normalization and title match parameters in `PostgresFullTextQueryService`
- add regression coverage for frontmatter objects containing null fields

## Verification
- `cd server && ./mvnw -pl skillhub-search test -Dtest=SearchTextTokenizerTest,SearchIndexEventListenerTest,PostgresSearchRebuildServiceTest,PostgresFullTextQueryServiceTest`
