### PR TITLE
fix(db): recreate search vector before search column alters

### DIFF
--- a/server/skillhub-app/src/main/resources/db/migration/V30__expand_skill_search_keywords_storage.sql
+++ b/server/skillhub-app/src/main/resources/db/migration/V30__expand_skill_search_keywords_storage.sql
@@ -1,2 +1,7 @@
+DROP INDEX IF EXISTS idx_search_vector;
+
+ALTER TABLE skill_search_document
+    DROP COLUMN search_vector;
+
 ALTER TABLE skill_search_document
     ALTER COLUMN keywords TYPE TEXT;

--- a/server/skillhub-app/src/main/resources/db/migration/V31__expand_skill_search_title_storage.sql
+++ b/server/skillhub-app/src/main/resources/db/migration/V31__expand_skill_search_title_storage.sql
@@ -1,2 +1,13 @@
 ALTER TABLE skill_search_document
     ALTER COLUMN title TYPE VARCHAR(512);
+
+ALTER TABLE skill_search_document
+ADD COLUMN search_vector tsvector
+GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(summary, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(keywords, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(search_text, '')), 'C')
+) STORED;
+
+CREATE INDEX idx_search_vector ON skill_search_document USING GIN (search_vector);


### PR DESCRIPTION
## Summary
- fix Flyway migrations `V30` and `V31` for PostgreSQL generated-column rules
- drop `search_vector` before altering dependent columns
- recreate `search_vector` and its GIN index after the type changes

## Why
PostgreSQL rejects `ALTER COLUMN ... TYPE` when the column is referenced by a generated column. In production, `skill_search_document.keywords` and `title` are both referenced by generated column `search_vector`, so the original migrations fail during startup.

## Details
- `V30` now drops `idx_search_vector` and generated column `search_vector` before altering `keywords`
- `V31` now alters `title`, then recreates generated column `search_vector` and `idx_search_vector`

## Verification
- verified against PostgreSQL constraint semantics from the production error
- no application code changes in this PR; migration-only fix
