### PR TITLE
fix(review): defer skill visibility changes until approval

### DIFF
--- a/server/skillhub-app/src/main/resources/db/migration/V32__add_requested_visibility_to_skill_version.sql
+++ b/server/skillhub-app/src/main/resources/db/migration/V32__add_requested_visibility_to_skill_version.sql
@@ -1,0 +1,2 @@
+ALTER TABLE skill_version
+    ADD COLUMN requested_visibility VARCHAR(20);

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/PromotionService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/PromotionService.java
@@ -207,6 +207,7 @@ public class PromotionService {
                 sourceVersion.getCreatedBy());
         newVersion.setStatus(SkillVersionStatus.PUBLISHED);
         newVersion.setPublishedAt(currentTime());
+        newVersion.setRequestedVisibility(SkillVisibility.PUBLIC);
         newVersion.setChangelog(sourceVersion.getChangelog());
         newVersion.setParsedMetadataJson(sourceVersion.getParsedMetadataJson());
         newVersion.setManifestJson(sourceVersion.getManifestJson());

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewService.java
@@ -202,6 +202,9 @@ public class ReviewService {
         skillVersionRepository.save(skillVersion);
 
         skill.setLatestVersionId(skillVersion.getId());
+        if (skillVersion.getRequestedVisibility() != null) {
+            skill.setVisibility(skillVersion.getRequestedVisibility());
+        }
         applyPublishedMetadata(skill, skillVersion);
         skill.setUpdatedBy(reviewerId);
         skillRepository.save(skill);

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/SkillVersion.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/SkillVersion.java
@@ -35,6 +35,10 @@ public class SkillVersion {
     @Column(name = "manifest_json", columnDefinition = "jsonb")
     private String manifestJson;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "requested_visibility", length = 20)
+    private SkillVisibility requestedVisibility;
+
     @Column(name = "file_count", nullable = false)
     private Integer fileCount = 0;
 
@@ -109,6 +113,10 @@ public class SkillVersion {
         return manifestJson;
     }
 
+    public SkillVisibility getRequestedVisibility() {
+        return requestedVisibility;
+    }
+
     public Integer getFileCount() {
         return fileCount;
     }
@@ -164,6 +172,10 @@ public class SkillVersion {
 
     public void setManifestJson(String manifestJson) {
         this.manifestJson = manifestJson;
+    }
+
+    public void setRequestedVisibility(SkillVisibility requestedVisibility) {
+        this.requestedVisibility = requestedVisibility;
     }
 
     public void setFileCount(Integer fileCount) {

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
@@ -236,9 +236,6 @@ public class SkillPublishService {
                     return skillRepository.save(newSkill);
                 });
 
-        // Update visibility to match the latest publish request
-        skill.setVisibility(visibility);
-
         if (skill.getStatus() == SkillStatus.ARCHIVED) {
             throw new DomainBadRequestException("error.skill.publish.archived", skillSlug);
         }
@@ -265,6 +262,7 @@ public class SkillPublishService {
 
         // 8. Create SkillVersion
         SkillVersion version = new SkillVersion(skill.getId(), metadata.version(), publisherId);
+        version.setRequestedVisibility(visibility);
         boolean autoPublish = forceAutoPublish || isSuperAdmin;
         if (autoPublish) {
             version.setStatus(SkillVersionStatus.PUBLISHED);
@@ -355,6 +353,7 @@ public class SkillPublishService {
         skill.setSummary(metadata.description());
         if (autoPublish) {
             skill.setLatestVersionId(version.getId());
+            skill.setVisibility(visibility);
         }
         skill.setUpdatedBy(publisherId);
         skillRepository.save(skill);

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewServiceTest.java
@@ -258,6 +258,34 @@ class ReviewServiceTest {
         }
 
         @Test
+        void shouldApplyRequestedVisibilityOnlyWhenReviewIsApproved() {
+            ReviewTask task = createPendingReviewTask();
+            Namespace ns = createTeamNamespace();
+            SkillVersion sv = createPendingReviewSkillVersion();
+            Skill skill = createSkill();
+            skill.setVisibility(SkillVisibility.PUBLIC);
+            sv.setRequestedVisibility(SkillVisibility.PRIVATE);
+
+            when(reviewTaskRepository.findById(REVIEW_TASK_ID)).thenReturn(Optional.of(task));
+            when(namespaceRepository.findById(NAMESPACE_ID)).thenReturn(Optional.of(ns));
+            when(permissionChecker.canReview(eq(task), eq(REVIEWER_ID), eq(ns.getType()), anyMap(), anySet()))
+                    .thenReturn(true);
+            when(reviewTaskRepository.updateStatusWithVersion(
+                    REVIEW_TASK_ID, ReviewTaskStatus.APPROVED, REVIEWER_ID, "LGTM", task.getVersion()))
+                    .thenReturn(1);
+            when(skillVersionRepository.findById(SKILL_VERSION_ID)).thenReturn(Optional.of(sv));
+            when(skillRepository.findById(SKILL_ID)).thenReturn(Optional.of(skill));
+            when(skillRepository.findByNamespaceIdAndSlug(NAMESPACE_ID, "my-skill")).thenReturn(List.of(skill));
+            when(reviewTaskRepository.findById(REVIEW_TASK_ID)).thenReturn(Optional.of(task));
+
+            reviewService.approveReview(
+                    REVIEW_TASK_ID, REVIEWER_ID, "LGTM",
+                    Map.of(NAMESPACE_ID, NamespaceRole.ADMIN), Set.of());
+
+            assertEquals(SkillVisibility.PRIVATE, skill.getVisibility());
+        }
+
+        @Test
         void shouldPublishCorrectEvent() {
             ReviewTask task = createPendingReviewTask();
             Namespace ns = createTeamNamespace();

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillPublishServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillPublishServiceTest.java
@@ -733,7 +733,7 @@ class SkillPublishServiceTest {
     }
 
     @Test
-    void testPublishFromEntries_ShouldUpdateVisibilityOnExistingSkill() throws Exception {
+    void testPublishFromEntries_ShouldDeferVisibilityChangeUntilApproval() throws Exception {
         // Arrange
         String namespaceSlug = "test-ns";
         String publisherId = "user-100";
@@ -768,11 +768,18 @@ class SkillPublishServiceTest {
         });
         when(skillRepository.save(any())).thenReturn(skill);
 
-        // Act — publish with PUBLIC visibility on an existing PRIVATE skill
-        service.publishFromEntries(namespaceSlug, entries, publisherId, SkillVisibility.PUBLIC, Set.of());
+        // Act — submit with PUBLIC visibility on an existing PRIVATE skill
+        SkillPublishService.PublishResult result = service.publishFromEntries(
+                namespaceSlug,
+                entries,
+                publisherId,
+                SkillVisibility.PUBLIC,
+                Set.of()
+        );
 
-        // Assert — visibility should be updated to PUBLIC
-        assertEquals(SkillVisibility.PUBLIC, skill.getVisibility());
+        // Assert — current published visibility stays unchanged until approval
+        assertEquals(SkillVisibility.PRIVATE, skill.getVisibility());
+        assertEquals(SkillVisibility.PUBLIC, result.version().getRequestedVisibility());
     }
 
     private void setId(Object entity, Long id) throws Exception {


### PR DESCRIPTION
## Summary
- defer skill visibility changes until review approval instead of applying them at submission time
- persist requested visibility on skill versions and apply it when the review is approved
- add regression tests covering pending private/public visibility transitions

## Verification
- `make test`
