### PR TITLE
chore(release): bump repository version to v0.1.0

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.iflytek.skillhub</groupId>
     <artifactId>skillhub-parent</artifactId>
-    <version>0.1.0-beta.7</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/server/skillhub-app/pom.xml
+++ b/server/skillhub-app/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.iflytek.skillhub</groupId>
         <artifactId>skillhub-parent</artifactId>
-        <version>0.1.0-beta.7</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>skillhub-app</artifactId>

--- a/server/skillhub-auth/pom.xml
+++ b/server/skillhub-auth/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iflytek.skillhub</groupId>
         <artifactId>skillhub-parent</artifactId>
-        <version>0.1.0-beta.7</version>
+        <version>0.1.0</version>
     </parent>
     <artifactId>skillhub-auth</artifactId>
     <dependencies>

--- a/server/skillhub-domain/pom.xml
+++ b/server/skillhub-domain/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iflytek.skillhub</groupId>
         <artifactId>skillhub-parent</artifactId>
-        <version>0.1.0-beta.7</version>
+        <version>0.1.0</version>
     </parent>
     <artifactId>skillhub-domain</artifactId>
     <dependencies>

--- a/server/skillhub-infra/pom.xml
+++ b/server/skillhub-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iflytek.skillhub</groupId>
         <artifactId>skillhub-parent</artifactId>
-        <version>0.1.0-beta.7</version>
+        <version>0.1.0</version>
     </parent>
     <artifactId>skillhub-infra</artifactId>
     <dependencies>

--- a/server/skillhub-search/pom.xml
+++ b/server/skillhub-search/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iflytek.skillhub</groupId>
         <artifactId>skillhub-parent</artifactId>
-        <version>0.1.0-beta.7</version>
+        <version>0.1.0</version>
     </parent>
     <artifactId>skillhub-search</artifactId>
     <dependencies>

--- a/server/skillhub-storage/pom.xml
+++ b/server/skillhub-storage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iflytek.skillhub</groupId>
         <artifactId>skillhub-parent</artifactId>
-        <version>0.1.0-beta.7</version>
+        <version>0.1.0</version>
     </parent>
     <artifactId>skillhub-storage</artifactId>
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skillhub-web",
   "private": true,
-  "version": "0.1.0-beta.7",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "install:ci": "pnpm install --frozen-lockfile",


### PR DESCRIPTION
## Summary

- bump backend Maven module versions and `web/package.json` from `0.1.0-beta.7` to `0.1.0`
- align the repository package metadata with the already-published stable `v0.1.0` GitHub release

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
git status --short --branch
git log --oneline --decorate -2
```

## Risk

- User-facing impact: package/release version metadata now reports `0.1.0` instead of `0.1.0-beta.7`
- Deployment or migration impact: none
- Rollback approach: revert this PR

## Notes

- Related issue: none
- Follow-up work: none
- Docs or operator runbooks updated when behavior changed: not needed
