### PR TITLE
chore(runtime): default release runtime to latest

### DIFF
--- a/.env.release.example
+++ b/.env.release.example
@@ -1,6 +1,7 @@
-# `edge` tracks the latest build from the default branch.
+# `latest` tracks the latest stable release image.
 # For deterministic environments, pin a release tag like `v0.1.0`.
-SKILLHUB_VERSION=edge
+# Use `edge` only when you explicitly want the latest build from `main`.
+SKILLHUB_VERSION=latest
 SKILLHUB_SERVER_IMAGE=ghcr.io/iflytek/skillhub-server
 SKILLHUB_WEB_IMAGE=ghcr.io/iflytek/skillhub-web
 POSTGRES_IMAGE=postgres:16-alpine

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ rm -rf /tmp/skillhub-runtime
 curl -fsSL https://raw.githubusercontent.com/iflytek/skillhub/main/scripts/runtime.sh | sh -s -- up
 ```
 
+The default command pulls the `latest` stable release images. Use
+`--version edge` if you want the newest build from `main`.
+
 Aliyun mirror shortcut:
 ```bash
 rm -rf /tmp/skillhub-aliyun

--- a/README_zh.md
+++ b/README_zh.md
@@ -45,10 +45,13 @@ rm -rf /tmp/skillhub-runtime
 curl -fsSL https://raw.githubusercontent.com/iflytek/skillhub/main/scripts/runtime.sh | sh -s -- up
 ```
 
+默认命令会拉取 `latest` 稳定版镜像；如果你想跟随 `main`
+的最新构建，请显式传 `--version edge`。
+
 阿里云镜像快捷方式：
 ```bash
 rm -rf /tmp/skillhub-aliyun
-curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --home /tmp/skillhub-aliyun --aliyun --version edge
+curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --home /tmp/skillhub-aliyun --aliyun --version latest
 ```
 
 如果部署遇到问题，请清除现有的运行时目录并重试。

--- a/compose.release.yml
+++ b/compose.release.yml
@@ -31,7 +31,7 @@ services:
       retries: 10
 
   server:
-    image: ${SKILLHUB_SERVER_IMAGE:-ghcr.io/iflytek/skillhub-server}:${SKILLHUB_VERSION:-edge}
+    image: ${SKILLHUB_SERVER_IMAGE:-ghcr.io/iflytek/skillhub-server}:${SKILLHUB_VERSION:-latest}
     restart: unless-stopped
     ports:
       - "${API_PORT:-8080}:8080"
@@ -79,7 +79,7 @@ services:
       start_period: 60s
 
   web:
-    image: ${SKILLHUB_WEB_IMAGE:-ghcr.io/iflytek/skillhub-web}:${SKILLHUB_VERSION:-edge}
+    image: ${SKILLHUB_WEB_IMAGE:-ghcr.io/iflytek/skillhub-web}:${SKILLHUB_VERSION:-latest}
     restart: unless-stopped
     ports:
       - "${WEB_PORT:-80}:80"

--- a/docs/09-deployment.md
+++ b/docs/09-deployment.md
@@ -134,8 +134,9 @@ docker compose --env-file .env.release -f compose.release.yml up -d
 
 推荐：
 
+- 默认快速启动：`SKILLHUB_VERSION=latest`
 - 团队内部试用：`SKILLHUB_VERSION=edge`
-- 对外演示或文档引用：固定为某个 `vX.Y.Z`
+- 对外演示或严格可复现环境：固定为某个 `vX.Y.Z`
 
 ## 6 GitHub Actions 发布流程
 
@@ -143,8 +144,7 @@ docker compose --env-file .env.release -f compose.release.yml up -d
 
 触发条件：
 
-- push 到 `main`
-- push 语义化版本 tag，例如 `v1.2.0`
+- `release.published`
 - 手动 `workflow_dispatch`
 
 流程：


### PR DESCRIPTION
## Summary

- change the release runtime default from `edge` to `latest`
- align `.env.release.example`, runtime compose defaults, README, and deployment docs with the stable-release-first behavior
- keep `edge` available as an explicit opt-in for following `main`

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
git diff origin/main..origin/chore/release-v0.1.0 -- compose.release.yml .env.release.example README.md README_zh.md docs/09-deployment.md
gh run view 23294580844 --json status,conclusion,jobs,url
```

## Risk

- User-facing impact: the default runtime quick-start will now pull `latest` stable release images instead of `edge`
- Deployment or migration impact: none, but users who relied on implicit `edge` should now pass `--version edge` explicitly
- Rollback approach: revert this PR

## Notes

- Related issue: none
- Follow-up work: none
- Docs or operator runbooks updated when behavior changed: yes
