### PR TITLE
docs: update runtime bootstrap script URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Start the full local stack with one of the following commands:
 Official images:
 ```bash
 rm -rf /tmp/skillhub-runtime
-curl -fsSL https://raw.githubusercontent.com/iflytek/skillhub/main/scripts/runtime.sh | sh -s -- up
+curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime-github.sh | sh -s -- up
 ```
 
 The default command pulls the `latest` stable release images. Use


### PR DESCRIPTION
## Summary

- Update the README startup command to fetch the runtime bootstrap script from the OSS-hosted URL.
- Keep the documented local runtime bootstrap source aligned with the current distribution path.

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
git diff -- README.md
git diff --staged -- README.md
```

Docs-only change; no backend/frontend build or runtime smoke test was required.

## Risk

- User-facing impact: Documentation-only update to the local runtime startup command.
- Deployment or migration impact: None.
- Rollback approach: Revert this PR to restore the previous documented URL.

## Notes

- Related issue: None.
- Follow-up work: None.
- Docs or operator runbooks updated when behavior changed: README updated.
