### PR TITLE
fix(label): refresh i18n label queries and visible filters

### DIFF
--- a/server/skillhub-app/src/main/resources/messages.properties
+++ b/server/skillhub-app/src/main/resources/messages.properties
@@ -61,6 +61,7 @@ label.translation.empty=At least one label translation is required
 label.translation.locale.blank=Label translation locale cannot be blank
 label.translation.display_name.blank=Label translation display name cannot be blank
 label.translation.locale.duplicate=Duplicate label translation locale: {0}
+label.translation.locale.conflict=Duplicate label translation locale
 error.namespace.slug.exists=Namespace slug ''{0}'' already exists
 error.namespace.id.notFound=Namespace not found: {0}
 error.namespace.slug.notFound=Namespace not found: {0}

--- a/server/skillhub-app/src/main/resources/messages_zh.properties
+++ b/server/skillhub-app/src/main/resources/messages_zh.properties
@@ -61,6 +61,7 @@ label.translation.empty=至少需要一个标签翻译
 label.translation.locale.blank=标签翻译 locale 不能为空
 label.translation.display_name.blank=标签翻译显示名不能为空
 label.translation.locale.duplicate=标签翻译 locale 重复：{0}
+label.translation.locale.conflict=标签翻译 locale 重复
 error.namespace.slug.exists=命名空间 slug ''{0}'' 已存在
 error.namespace.id.notFound=未找到命名空间：{0}
 error.namespace.slug.notFound=未找到命名空间：{0}

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/LabelControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/LabelControllerTest.java
@@ -34,12 +34,18 @@ class LabelControllerTest {
     @Test
     void listVisibleLabelsShouldUseUnifiedEnvelope() throws Exception {
         when(publicLabelAppService.listVisibleFilters())
-                .thenReturn(List.of(new SkillLabelDto("code-generation", "RECOMMENDED", "Code Generation")));
+                .thenReturn(List.of(
+                        new SkillLabelDto("code-generation", "RECOMMENDED", "Code Generation"),
+                        new SkillLabelDto("verified", "PRIVILEGED", "Verified")
+                ));
 
         mockMvc.perform(get("/api/web/labels"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0))
                 .andExpect(jsonPath("$.data[0].slug").value("code-generation"))
-                .andExpect(jsonPath("$.data[0].displayName").value("Code Generation"));
+                .andExpect(jsonPath("$.data[0].displayName").value("Code Generation"))
+                .andExpect(jsonPath("$.data[1].slug").value("verified"))
+                .andExpect(jsonPath("$.data[1].type").value("PRIVILEGED"))
+                .andExpect(jsonPath("$.data[1].displayName").value("Verified"));
     }
 }

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/LabelDefinitionService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/LabelDefinitionService.java
@@ -33,7 +33,7 @@ public class LabelDefinitionService {
     }
 
     public List<LabelDefinition> listVisibleFilters() {
-        return labelDefinitionRepository.findByVisibleInFilterTrueAndTypeOrderBySortOrderAscIdAsc(LabelType.RECOMMENDED);
+        return labelDefinitionRepository.findByVisibleInFilterTrueOrderBySortOrderAscIdAsc();
     }
 
     public List<LabelDefinition> listByIds(List<Long> labelIds) {
@@ -142,6 +142,7 @@ public class LabelDefinitionService {
         List<LabelTranslation> existingTranslations = labelTranslationRepository.findByLabelId(labelId);
         if (!existingTranslations.isEmpty()) {
             labelTranslationRepository.deleteAll(existingTranslations);
+            labelTranslationRepository.flush();
         }
         if (!translations.isEmpty()) {
             labelTranslationRepository.saveAll(translations.stream()
@@ -197,7 +198,7 @@ public class LabelDefinitionService {
     private DomainBadRequestException mapConstraintViolation(String slug, DataIntegrityViolationException ex) {
         String message = ex.getMostSpecificCause() != null ? ex.getMostSpecificCause().getMessage() : ex.getMessage();
         if (message != null && message.contains("label_translation")) {
-            return new DomainBadRequestException("label.translation.locale.duplicate");
+            return new DomainBadRequestException("label.translation.locale.conflict");
         }
         return new DomainBadRequestException("label.slug.duplicate", slug);
     }

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/LabelTranslationRepository.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/LabelTranslationRepository.java
@@ -8,4 +8,5 @@ public interface LabelTranslationRepository {
     <S extends LabelTranslation> List<S> saveAll(Iterable<S> translations);
     void deleteAll(Iterable<? extends LabelTranslation> translations);
     void deleteByLabelId(Long labelId);
+    void flush();
 }

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/label/LabelDefinitionServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/label/LabelDefinitionServiceTest.java
@@ -9,6 +9,8 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -89,5 +91,55 @@ class LabelDefinitionServiceTest {
         ));
 
         assertEquals("label.not_found", ex.messageCode());
+    }
+
+    @Test
+    void updateShouldFlushDeletedTranslationsBeforeSavingReplacements() {
+        when(labelPermissionChecker.canManageDefinitions(Set.of("SUPER_ADMIN"))).thenReturn(true);
+        LabelDefinition definition = new LabelDefinition("official", LabelType.RECOMMENDED, true, 0, "admin");
+        setField(definition, "id", 10L);
+        when(labelDefinitionRepository.findBySlugIgnoreCase("official")).thenReturn(Optional.of(definition));
+        when(labelDefinitionRepository.save(definition)).thenReturn(definition);
+        when(labelTranslationRepository.findByLabelId(10L)).thenReturn(List.of(
+                new LabelTranslation(10L, "en", "Official")
+        ));
+
+        service.update(
+                "official",
+                LabelType.RECOMMENDED,
+                true,
+                1,
+                List.of(new LabelTranslation(null, "en", "Official Updated")),
+                Set.of("SUPER_ADMIN")
+        );
+
+        var inOrder = inOrder(labelTranslationRepository);
+        inOrder.verify(labelTranslationRepository).deleteAll(org.mockito.ArgumentMatchers.any());
+        inOrder.verify(labelTranslationRepository).flush();
+        inOrder.verify(labelTranslationRepository).saveAll(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void listVisibleFiltersShouldIncludePrivilegedLabelsWhenVisible() {
+        List<LabelDefinition> expected = List.of(
+                new LabelDefinition("official", LabelType.RECOMMENDED, true, 0, "admin"),
+                new LabelDefinition("verified", LabelType.PRIVILEGED, true, 1, "admin")
+        );
+        when(labelDefinitionRepository.findByVisibleInFilterTrueOrderBySortOrderAscIdAsc()).thenReturn(expected);
+
+        List<LabelDefinition> actual = service.listVisibleFilters();
+
+        assertEquals(expected, actual);
+        verify(labelDefinitionRepository).findByVisibleInFilterTrueOrderBySortOrderAscIdAsc();
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 }

--- a/web/src/shared/hooks/use-skill-queries.test.ts
+++ b/web/src/shared/hooks/use-skill-queries.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import i18n from '@/i18n/config'
+import {
+  getAdminLabelDefinitionsQueryKey,
+  getSkillDetailQueryKey,
+  getSkillLabelsQueryKey,
+  getVisibleLabelsQueryKey,
+} from './use-skill-queries'
+
+describe('localized label query keys', () => {
+  const originalLanguage = i18n.language
+  const originalResolvedLanguage = i18n.resolvedLanguage
+
+  afterEach(() => {
+    i18n.language = originalLanguage
+    i18n.resolvedLanguage = originalResolvedLanguage
+  })
+
+  it('includes the current language so localized label data refetches after language switches', () => {
+    i18n.language = 'en'
+    i18n.resolvedLanguage = 'en'
+
+    expect(getVisibleLabelsQueryKey()).toEqual(['labels', 'visible', 'en'])
+    expect(getSkillLabelsQueryKey('team', 'demo')).toEqual(['labels', 'skill', 'team', 'demo', 'en'])
+    expect(getSkillDetailQueryKey('team', 'demo')).toEqual(['skills', 'team', 'demo', 'en'])
+    expect(getAdminLabelDefinitionsQueryKey()).toEqual(['labels', 'admin', 'en'])
+
+    i18n.language = 'zh-CN'
+    i18n.resolvedLanguage = 'zh-CN'
+
+    expect(getVisibleLabelsQueryKey()).toEqual(['labels', 'visible', 'zh-CN'])
+    expect(getSkillLabelsQueryKey('team', 'demo')).toEqual(['labels', 'skill', 'team', 'demo', 'zh-CN'])
+    expect(getSkillDetailQueryKey('team', 'demo')).toEqual(['skills', 'team', 'demo', 'zh-CN'])
+    expect(getAdminLabelDefinitionsQueryKey()).toEqual(['labels', 'admin', 'zh-CN'])
+  })
+})

--- a/web/src/shared/hooks/use-skill-queries.ts
+++ b/web/src/shared/hooks/use-skill-queries.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { SkillSummary, SkillDetail, SkillVersion, SkillVersionDetail, SkillFile, SearchParams, PagedResponse, PublishResult, Namespace, NamespaceMember, ManagedNamespace, CreateNamespaceRequest, NamespaceCandidateUser, NamespaceRole, LabelItem, LabelDefinition } from '@/api/types'
 import { fetchJson, fetchText, getCsrfHeaders, labelApi, meApi, namespaceApi, promotionApi, skillLifecycleApi, WEB_API_PREFIX } from '@/api/client'
 import { appendNamespaceMember, replaceNamespaceMemberRole } from '@/shared/lib/namespace-member-cache'
+import i18n from '@/i18n/config'
 import { buildSkillSearchUrl, shouldEnableNamespaceMemberCandidates } from './skill-query-helpers'
 
 /**
@@ -11,6 +12,26 @@ import { buildSkillSearchUrl, shouldEnableNamespaceMemberCandidates } from './sk
  * backend fetchers, and invalidation rules used throughout the app.
  */
 const PUBLISH_REQUEST_TIMEOUT_MS = 60_000
+
+export function getI18nCacheKey() {
+  return i18n.resolvedLanguage || i18n.language || 'en'
+}
+
+export function getSkillDetailQueryKey(namespace: string, slug: string) {
+  return ['skills', namespace, slug, getI18nCacheKey()] as const
+}
+
+export function getVisibleLabelsQueryKey() {
+  return ['labels', 'visible', getI18nCacheKey()] as const
+}
+
+export function getSkillLabelsQueryKey(namespace: string, slug: string) {
+  return ['labels', 'skill', namespace, slug, getI18nCacheKey()] as const
+}
+
+export function getAdminLabelDefinitionsQueryKey() {
+  return ['labels', 'admin', getI18nCacheKey()] as const
+}
 
 async function searchSkills(params: SearchParams): Promise<PagedResponse<SkillSummary>> {
   return fetchJson<PagedResponse<SkillSummary>>(buildSkillSearchUrl(params))
@@ -141,7 +162,7 @@ export function useSearchSkills(params: SearchParams) {
 
 export function useSkillDetail(namespace: string, slug: string) {
   return useQuery({
-    queryKey: ['skills', namespace, slug],
+    queryKey: getSkillDetailQueryKey(namespace, slug),
     queryFn: () => getSkillDetail(namespace, slug),
     enabled: !!namespace && !!slug,
   })
@@ -149,7 +170,7 @@ export function useSkillDetail(namespace: string, slug: string) {
 
 export function useVisibleLabels(enabled = true) {
   return useQuery({
-    queryKey: ['labels', 'visible'],
+    queryKey: getVisibleLabelsQueryKey(),
     queryFn: getVisibleLabels,
     enabled,
   })
@@ -157,7 +178,7 @@ export function useVisibleLabels(enabled = true) {
 
 export function useSkillLabels(namespace: string, slug: string, enabled = true) {
   return useQuery({
-    queryKey: ['labels', 'skill', namespace, slug],
+    queryKey: getSkillLabelsQueryKey(namespace, slug),
     queryFn: () => getSkillLabels(namespace, slug),
     enabled: enabled && !!namespace && !!slug,
   })
@@ -165,7 +186,7 @@ export function useSkillLabels(namespace: string, slug: string, enabled = true) 
 
 export function useAdminLabelDefinitions(enabled = true) {
   return useQuery({
-    queryKey: ['labels', 'admin'],
+    queryKey: getAdminLabelDefinitionsQueryKey(),
     queryFn: getAdminLabelDefinitions,
     enabled,
   })


### PR DESCRIPTION
## Summary
- refresh label-related query cache entries when locale changes so translated labels refetch correctly
- flush deleted translations before re-inserting updates and map locale conflicts to stable user-facing errors
- include visible privileged labels in the public search filter list

## Testing
- pnpm test -- src/pages/search.test.tsx src/shared/hooks/use-skill-queries.test.ts
- ./mvnw -pl skillhub-domain -am -Dtest=LabelDefinitionServiceTest -Dsurefire.failIfNoSpecifiedTests=false test
- ./mvnw -pl skillhub-app -am -Dtest=LabelControllerTest -Dsurefire.failIfNoSpecifiedTests=false test
- make test