### PR TITLE
fix(staging): align smoke admin creds and validate label limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,8 @@ staging: ## 构建并启动 staging 环境，运行 smoke test（混合模式：
 	@echo "=== [4/5] Starting staging services ==="
 	$(STAGING_COMPOSE) up -d --wait server web
 	@echo "=== [5/5] Running smoke tests ==="
-	@if bash scripts/smoke-test.sh $(STAGING_API_URL); then \
+	@if BOOTSTRAP_ADMIN_USERNAME=admin BOOTSTRAP_ADMIN_PASSWORD='Admin@staging2026' \
+		bash scripts/smoke-test.sh $(STAGING_API_URL); then \
 		echo ""; \
 		echo "Staging passed. Environment is running:"; \
 		echo "  Web UI:  $(STAGING_WEB_URL)"; \

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/LabelDefinitionService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/LabelDefinitionService.java
@@ -28,7 +28,7 @@ public class LabelDefinitionService {
         this.labelDefinitionRepository = labelDefinitionRepository;
         this.labelTranslationRepository = labelTranslationRepository;
         this.labelPermissionChecker = labelPermissionChecker;
-        this.maxLabelDefinitions = maxLabelDefinitions;
+        this.maxLabelDefinitions = requirePositive(maxLabelDefinitions, "skillhub.label.max-definitions");
     }
 
     public List<LabelDefinition> listAll() {
@@ -204,6 +204,13 @@ public class LabelDefinitionService {
             return new DomainBadRequestException("label.translation.locale.conflict");
         }
         return new DomainBadRequestException("label.slug.duplicate", slug);
+    }
+
+    private int requirePositive(int value, String propertyName) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(propertyName + " must be greater than 0");
+        }
+        return value;
     }
 
     public record LabelSortOrderUpdate(Long labelId, int sortOrder) {

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/SkillLabelService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/label/SkillLabelService.java
@@ -31,7 +31,7 @@ public class SkillLabelService {
         this.labelDefinitionRepository = labelDefinitionRepository;
         this.skillLabelRepository = skillLabelRepository;
         this.labelPermissionChecker = labelPermissionChecker;
-        this.maxLabelsPerSkill = maxLabelsPerSkill;
+        this.maxLabelsPerSkill = requirePositive(maxLabelsPerSkill, "skillhub.label.max-per-skill");
     }
 
     public List<SkillLabel> listSkillLabels(Long skillId) {
@@ -94,5 +94,12 @@ public class SkillLabelService {
         if (!labelPermissionChecker.canManageSkillLabel(skill, labelDefinition, operatorId, userNamespaceRoles, platformRoles)) {
             throw new DomainForbiddenException("label.skill.no_permission");
         }
+    }
+
+    private int requirePositive(int value, String propertyName) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(propertyName + " must be greater than 0");
+        }
+        return value;
     }
 }

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/label/LabelDefinitionServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/label/LabelDefinitionServiceTest.java
@@ -27,6 +27,18 @@ class LabelDefinitionServiceTest {
     );
 
     @Test
+    void constructorShouldRejectNonPositiveDefinitionLimit() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new LabelDefinitionService(
+                labelDefinitionRepository,
+                labelTranslationRepository,
+                labelPermissionChecker,
+                0
+        ));
+
+        assertEquals("skillhub.label.max-definitions must be greater than 0", ex.getMessage());
+    }
+
+    @Test
     void createShouldRejectDuplicateLocalesIgnoringCase() {
         when(labelPermissionChecker.canManageDefinitions(Set.of("SUPER_ADMIN"))).thenReturn(true);
         when(labelDefinitionRepository.count()).thenReturn(0L);

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/label/SkillLabelServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/label/SkillLabelServiceTest.java
@@ -1,0 +1,29 @@
+package com.iflytek.skillhub.domain.label;
+
+import com.iflytek.skillhub.domain.skill.SkillRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class SkillLabelServiceTest {
+
+    private final SkillRepository skillRepository = mock(SkillRepository.class);
+    private final LabelDefinitionRepository labelDefinitionRepository = mock(LabelDefinitionRepository.class);
+    private final SkillLabelRepository skillLabelRepository = mock(SkillLabelRepository.class);
+    private final LabelPermissionChecker labelPermissionChecker = mock(LabelPermissionChecker.class);
+
+    @Test
+    void constructorShouldRejectNonPositivePerSkillLimit() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new SkillLabelService(
+                skillRepository,
+                labelDefinitionRepository,
+                skillLabelRepository,
+                labelPermissionChecker,
+                0
+        ));
+
+        assertEquals("skillhub.label.max-per-skill must be greater than 0", ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- pass the staging bootstrap admin credentials into `scripts/smoke-test.sh` so `make staging` uses the same login as the staging compose stack
- fail fast when `skillhub.label.max-definitions` or `skillhub.label.max-per-skill` are configured to non-positive values
- add domain tests covering the new label limit validation paths

## Testing
- cd server && ./mvnw -q -pl skillhub-domain -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=LabelDefinitionServiceTest,SkillLabelServiceTest test