### PR TITLE
fix(scanner): wire timeout config and create dedicated scanner HttpClient

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/config/SkillScannerConfig.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/config/SkillScannerConfig.java
@@ -3,23 +3,61 @@ package com.iflytek.skillhub.config;
 import com.iflytek.skillhub.domain.security.ScanTaskProducer;
 import com.iflytek.skillhub.domain.security.SecurityScanner;
 import com.iflytek.skillhub.infra.http.HttpClient;
+import com.iflytek.skillhub.infra.http.WebClientHttpClient;
 import com.iflytek.skillhub.infra.scanner.ScanOptions;
 import com.iflytek.skillhub.infra.scanner.SkillScannerAdapter;
 import com.iflytek.skillhub.infra.scanner.SkillScannerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
 
 @Configuration
 public class SkillScannerConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(SkillScannerConfig.class);
+
     @Bean
     @ConditionalOnProperty(prefix = "skillhub.security.scanner", name = "enabled", havingValue = "true")
-    public SkillScannerService skillScannerService(HttpClient httpClient,
+    public HttpClient scannerHttpClient(SkillScannerProperties properties) {
+        int readTimeoutMs = properties.getReadTimeoutMs();
+        int connectTimeoutMs = properties.getConnectTimeoutMs();
+
+        log.info("Creating scanner-specific HttpClient with connectTimeout={}ms, readTimeout={}ms",
+                connectTimeoutMs, readTimeoutMs);
+
+        reactor.netty.http.client.HttpClient reactorClient = reactor.netty.http.client.HttpClient.create()
+                .followRedirect(false)
+                .responseTimeout(Duration.ofMillis(readTimeoutMs))
+                .option(io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs);
+
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+                .build();
+
+        WebClient webClient = WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(reactorClient))
+                .exchangeStrategies(strategies)
+                .build();
+
+        log.info("Scanner HttpClient created successfully with responseTimeout={}ms", readTimeoutMs);
+        return new WebClientHttpClient(webClient);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "skillhub.security.scanner", name = "enabled", havingValue = "true")
+    public SkillScannerService skillScannerService(HttpClient scannerHttpClient,
                                                    SkillScannerProperties properties) {
+        log.info("Creating SkillScannerService with baseUrl={}", properties.getBaseUrl());
         return new SkillScannerService(
-                httpClient,
+                scannerHttpClient,
                 properties.getBaseUrl(),
                 properties.getScanPath(),
                 properties.getHealthPath()


### PR DESCRIPTION
## Problem

Scanner requests timeout after 5 seconds in cloud environment, but work fine locally.

**Root cause**: The global  configuration with 5-minute  was not being properly applied to scanner requests.  defined  and  but they were never wired into the actual WebClient.

## Solution

- Create scanner-specific  bean ()
- Wire  timeout config into WebClient:
  -  (5 seconds)
  -  (5 minutes)
- Add logging to verify timeout configuration on startup

## Testing

Local testing confirmed scanner can process requests >10 seconds successfully. After this fix, cloud environment will have proper 5-minute response timeout.

## Logs

After deployment, verify with:
```bash
kubectl logs deploy/skillhub-server | grep 'scanner-specific HttpClient'
```

Expected output:
```
Creating scanner-specific HttpClient with connectTimeout=5000ms, readTimeout=300000ms
Scanner HttpClient created successfully with responseTimeout=300000ms
```