### PR TITLE
fix(web): align header SkillHub font with homepage

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -72,7 +72,7 @@ export function Layout() {
 
       {/* Header */}
       <header className={getAppHeaderClassName(isHeaderElevated)} style={{ borderColor: 'hsl(var(--border))' }}>
-        <Link to="/" className="text-xl font-semibold tracking-tight text-brand-gradient">
+        <Link to="/" className="text-xl font-bold tracking-tight text-brand-gradient">
           SkillHub
         </Link>
 


### PR DESCRIPTION
## Summary\n- align header brand text (\SkillHub\) font weight with homepage brand title\n- update \web/src/app/layout.tsx\ from \ont-semibold\ to \ont-bold\\n\n## Verification\n- make typecheck-web\n- make lint-web\n- pnpm run test (in \web/\)