### PR TITLE
fix: 断网时显示友好的网络错误提示

### DIFF
--- a/web/src/shared/lib/api-error.ts
+++ b/web/src/shared/lib/api-error.ts
@@ -40,7 +40,7 @@ function isAccountDisabledError(error: ApiError): boolean {
     || accountDisabledMessages.includes(error.message)
     || normalizedServerMessage.includes('disabled')
     || normalizedMessage.includes('disabled')
-    || (error.serverMessage ?? '').includes('禁琨')
+    || (error.serverMessage ?? '').includes('禁用')
     || error.message.includes('禁用')
 }
 


### PR DESCRIPTION
## Summary

- 在 `handleApiError` 中添加 `status === 0` 的网络错误处理
- 使用已有的 `apiError.networkError` 翻译
- 修复断网时显示"操作失败"的问题

## Test plan

- [ ] 断开网络后操作页面，验证提示"网络连接失败，请检查网络"

Closes #160