### PR TITLE
fix(web): 改进断网时的错误提示 (#160)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -213,7 +213,7 @@ export async function fetchJson<T>(input: RequestInfo | URL, init?: RequestWithT
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw new ApiError('error.request.timeout', 408)
     }
-    throw new ApiError('Network error', 0)
+    throw new ApiError('apiError.networkError', 0)
   } finally {
     cleanup()
   }

--- a/web/src/shared/lib/api-error.test.ts
+++ b/web/src/shared/lib/api-error.test.ts
@@ -53,4 +53,14 @@ describe('handleApiError', () => {
 
     expect(errorSpy).toHaveBeenLastCalledWith('Server said no')
   })
+
+  it('shows network error message for status 0', async () => {
+    const { ApiError, handleApiError } = await import('./api-error')
+
+    handleApiError(new ApiError('apiError.networkError', 0))
+
+    expect(errorSpy).toHaveBeenCalled()
+    const lastCall = errorSpy.mock.calls[errorSpy.mock.calls.length - 1][0]
+    expect(lastCall).toMatch(/network|网络/)
+  })
 })

--- a/web/src/shared/lib/api-error.ts
+++ b/web/src/shared/lib/api-error.ts
@@ -52,6 +52,11 @@ export function handleApiError(error: unknown): void {
 
   const { status } = error
 
+  if (status === 0) {
+    toast.error(i18n.t('apiError.networkError'))
+    return
+  }
+
   if (status === 401) {
     if (isAccountDisabledError(error)) {
       window.location.href = `/login?reason=${ACCOUNT_DISABLED_REASON}`


### PR DESCRIPTION
## Summary

- 修复断网时页面提示"操作失败"而非友好错误信息的问题
- 将网络错误（fetch 失败，status 0）改为使用 i18n key `apiError.networkError`，展示"网络连接失败，请检查网络是否正常"

## Validation

- [x] Backend tests passed
- [x] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
make typecheck-web   # 0 errors
make lint-web        # 0 errors, 0 warnings
make test-frontend   # 171 files, 500 tests passed
```

## Risk

- User-facing impact: 断网时错误提示更友好，无功能性变更
- Deployment or migration impact: 无
- Rollback approach: 还原 `client.ts` 和 `api-error.ts` 的改动

## Notes

- Related issue: #160
- Follow-up work: 无
- Docs or operator runbooks updated when behavior changed: 不涉及