### PR TITLE
fix(web): navigate back instead of showing permission error after hide

### DIFF
--- a/web/src/pages/skill-detail.tsx
+++ b/web/src/pages/skill-detail.tsx
@@ -241,11 +241,9 @@ export function SkillDetailPage() {
   const hideMutation = useMutation({
     mutationFn: () => adminApi.hideSkill(skill!.id),
     onSuccess: () => {
-      handleBack()
       setSkillDeleted(true)
-      queryClient.invalidateQueries({ queryKey: ['skills', 'my'] })
-      queryClient.invalidateQueries({ queryKey: ['skills', 'search'] })
-      queryClient.invalidateQueries({ queryKey: ['skills', 'stars'] })
+      clearDeletedSkillQueries(queryClient, namespace, slug, skill?.id)
+      handleBack()
     },
   })
 


### PR DESCRIPTION
## 概述
修复隐藏技能后的详情页交互：隐藏成功后应直接返回上一页，并避免当前页/全局出现“没有权限”提示。

## 变更内容

### 前端实现
- 调整 `SkillDetailPage` 隐藏成功回调顺序：先 `setSkillDeleted(true)`，再执行查询清理，最后 `handleBack()` 返回上一页。
- 复用 `clearDeletedSkillQueries(...)` 清理当前技能详情相关缓存与进行列表失效，避免隐藏后残留详情查询返回 403 并触发全局权限提示。

### 测试覆盖
- 前端单测：`cd web && pnpm exec vitest run src/pages/skill-detail.test.tsx`
- 质量检查：`make typecheck-web`、`make lint-web`
- E2E 回归：`cd web && pnpm exec playwright test e2e/search-flow.spec.ts`
  - `web/test-results/search-flow-Search-Page-Fl-4d82e-ching-sorting-and-filtering-chromium/test-finished-1.png`
  - `web/test-results/search-flow-Search-Page-Fl-16d30-ctive-label-when-paginating-chromium/test-finished-1.png`
  - `web/test-results/search-flow-Search-Page-Fl-ce4d8--when-enabling-starred-only-chromium/test-finished-1.png`

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] 前端相关单测通过
- [x] Playwright E2E 关键路径回归通过

## 安全考虑
本次变更不涉及安全敏感内容。

## 相关 Issue
Closes #199

## 本地验证步骤
1. 以有“隐藏技能”权限的账号进入技能详情页。
2. 点击“隐藏技能”。
3. 预期：页面直接返回上一路径（或搜索页），不出现“没有权限/访问被拒绝”提示。
