### PR TITLE
fix: hide skill 后详情页回退，避免权限错误页

### DIFF
--- a/web/src/pages/skill-detail.test.tsx
+++ b/web/src/pages/skill-detail.test.tsx
@@ -252,6 +252,20 @@ describe('SkillDetailPage', () => {
     expect(html).not.toContain('__RATING_WIDGET__')
   })
 
+  it('does not render access denied content for logged-in forbidden responses', () => {
+    useSkillDetailMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new Error('HTTP 403'),
+    })
+
+    const html = renderToStaticMarkup(<SkillDetailPage />)
+
+    expect(html).toBe('')
+    expect(html).not.toContain('skillDetail.accessDenied')
+  })
+
   it('renders rejected owner preview without pending-review copy', () => {
     useSkillDetailMock.mockReturnValue({
       data: createSkill({

--- a/web/src/pages/skill-detail.tsx
+++ b/web/src/pages/skill-detail.tsx
@@ -240,7 +240,17 @@ export function SkillDetailPage() {
 
   const hideMutation = useMutation({
     mutationFn: () => adminApi.hideSkill(skill!.id),
-    onSuccess: refreshSkill,
+    onSuccess: () => {
+      // After hiding, this detail route can become inaccessible for current viewer context.
+      // Navigate away immediately to avoid landing on an access-denied state.
+      queryClient.invalidateQueries({ queryKey: ['skills'] })
+      const returnTo = normalizeSkillDetailReturnTo(search.returnTo)
+      if (returnTo) {
+        void navigate({ to: returnTo, replace: true })
+        return
+      }
+      void navigate({ to: '/search', search: getSkillSquareSearch(), replace: true })
+    },
   })
 
   const unhideMutation = useMutation({
@@ -392,6 +402,9 @@ export function SkillDetailPage() {
   const isLastVersion = versions?.length === 1
   const canWithdrawVersion = (status?: string) => status === 'PENDING_REVIEW'
   const canRereleaseVersion = (status?: string) => status === 'PUBLISHED'
+  const isForbiddenError = skillError instanceof ApiError
+    ? skillError.status === 403
+    : skillError instanceof Error && skillError.message.includes('403')
   const isNotFoundError = skillError instanceof ApiError
     ? skillError.status === 400 || skillError.status === 404 || skillError.serverMessageKey === 'skill.not_found'
     : false
@@ -402,6 +415,18 @@ export function SkillDetailPage() {
     }
     clearDeletedSkillQueries(queryClient, namespace, slug, skill?.id)
   }, [isNotFoundError, namespace, queryClient, skill?.id, slug])
+
+  useEffect(() => {
+    if (!isForbiddenError || !user) {
+      return
+    }
+    const returnTo = normalizeSkillDetailReturnTo(search.returnTo)
+    if (returnTo) {
+      void navigate({ to: returnTo, replace: true })
+      return
+    }
+    void navigate({ to: '/search', search: getSkillSquareSearch(), replace: true })
+  }, [isForbiddenError, navigate, search.returnTo, user])
 
   const metadataDiffEntries = (() => {
     const source = parseMetadataJson(diffSourceDetail?.parsedMetadataJson)
@@ -610,9 +635,7 @@ export function SkillDetailPage() {
   }
 
   if (skillError) {
-    const isForbidden = skillError instanceof Error && skillError.message.includes('403')
-
-    if (isForbidden && !user) {
+    if (isForbiddenError && !user) {
       return (
         <div className="text-center py-20 animate-fade-up">
           <h2 className="text-2xl font-bold font-heading mb-2">{t('skillDetail.loginRequired')}</h2>
@@ -620,6 +643,10 @@ export function SkillDetailPage() {
           <Button onClick={requireLogin}>{t('common.login')}</Button>
         </div>
       )
+    }
+
+    if (isForbiddenError) {
+      return null
     }
 
     if (isNotFoundError) {


### PR DESCRIPTION
## 概述变更目标
修复在技能详情页执行“隐藏 skill”后，当前页面突变为“没有权限”提示的问题，改为按预期直接返回上一页面。

## 变更内容
- 在 `web/src/pages/skill-detail.tsx` 中调整隐藏操作成功后的行为：
  - 隐藏成功后不再刷新当前详情页，而是优先跳回 `returnTo` 来源页；无来源页时回到搜索页。
- 增加 403 兜底回退逻辑：
  - 当详情页已登录用户遇到 403 时，自动导航回来源页/搜索页，并避免渲染“没有权限”内容。
- 新增测试：
  - `web/src/pages/skill-detail.test.tsx` 增加用例，覆盖登录用户遇到 403 时不渲染 access denied 内容。

## 测试覆盖
- 新增单测：`SkillDetailPage` 在登录态 403 场景不渲染权限错误块。
- 本地执行：
  - `pnpm -C web test -- src/pages/skill-detail.test.tsx`

## 质量门禁检查清单
- [x] `pnpm -C web typecheck`
- [x] `pnpm -C web lint`
- [x] 相关测试通过

## 相关 Issue
Closes #199
