### PR TITLE
fix: remove duplicate CSS classes in InstallCommand component

### DIFF
--- a/web/src/features/skill/install-command.tsx
+++ b/web/src/features/skill/install-command.tsx
@@ -60,7 +60,7 @@ export function InstallCommand({ namespace, slug }: InstallCommandProps) {
         {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
       </Button>
       <pre className="px-4 py-3 pr-14 whitespace-pre-wrap break-all">
-        <code className="font-mono text-[13px] leading-relaxed text-foreground whitespace-pre-wrap break-all sm:text-sm">
+        <code className="font-mono text-[13px] leading-relaxed text-foreground sm:text-sm">
           {command}
         </code>
       </pre>


### PR DESCRIPTION
Fixes #213

## Changes
- Removed duplicate `whitespace-pre-wrap` and `break-all` classes from `<code>` element
- These classes are already applied to parent `<pre>` element and cascade down

## Impact
- Code quality improvement with no functional changes