### PR TITLE
fix(web): preserve nginx subpath prefix for api/runtime config

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/shared/lib/api-error', () => ({
 import {
   WEB_API_PREFIX,
   buildApiUrl,
+  fetchText,
   getDirectAuthRuntimeConfig,
   getSessionBootstrapRuntimeConfig,
 } from './client'
@@ -45,6 +46,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.unstubAllGlobals()
+
   if (originalWindow) {
     Object.defineProperty(globalThis, 'window', {
       configurable: true,
@@ -78,6 +81,38 @@ describe('buildApiUrl', () => {
     window.__SKILLHUB_RUNTIME_CONFIG__ = { apiBaseUrl: 'https://api.example.com/' }
     const url = buildApiUrl('/api/v1/auth/me')
     expect(url).toBe('https://api.example.com/api/v1/auth/me')
+  })
+
+  it('preserves base URL path prefixes', () => {
+    window.__SKILLHUB_RUNTIME_CONFIG__ = { apiBaseUrl: 'https://api.example.com/skill_hub' }
+    const url = buildApiUrl('/api/v1/auth/me')
+    expect(url).toBe('https://api.example.com/skill_hub/api/v1/auth/me')
+  })
+
+  it('supports relative base URL path prefixes', () => {
+    window.__SKILLHUB_RUNTIME_CONFIG__ = { apiBaseUrl: '/skill_hub' }
+    const url = buildApiUrl('/api/v1/auth/me')
+    expect(url).toBe('/skill_hub/api/v1/auth/me')
+  })
+})
+
+describe('fetchText', () => {
+  it('applies base URL path prefixes for fetch requests', async () => {
+    window.__SKILLHUB_RUNTIME_CONFIG__ = { apiBaseUrl: 'https://api.example.com/skill_hub' }
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => 'ok',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchText('/api/v1/auth/me')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/skill_hub/api/v1/auth/me',
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    )
   })
 })
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -252,7 +252,7 @@ function withBaseUrl(input: RequestInfo | URL): RequestInfo | URL {
   if (!baseUrl || typeof input !== 'string' || !input.startsWith('/')) {
     return input
   }
-  return new URL(input, ensureTrailingSlash(baseUrl))
+  return prependApiBaseUrl(baseUrl, input)
 }
 
 export function buildApiUrl(path: string): string {
@@ -260,11 +260,20 @@ export function buildApiUrl(path: string): string {
   if (!baseUrl) {
     return path
   }
-  return new URL(path, ensureTrailingSlash(baseUrl)).toString()
+  return prependApiBaseUrl(baseUrl, path)
 }
 
-function ensureTrailingSlash(value: string): string {
-  return value.endsWith('/') ? value : `${value}/`
+function prependApiBaseUrl(baseUrl: string, path: string): string {
+  const normalizedBaseUrl = trimTrailingSlash(baseUrl)
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${normalizedBaseUrl}${normalizedPath}`
+}
+
+function trimTrailingSlash(value: string): string {
+  if (value.length > 1 && value.endsWith('/')) {
+    return value.slice(0, -1)
+  }
+  return value
 }
 
 export async function getCurrentUser(): Promise<User | null> {

--- a/web/src/bootstrap.ts
+++ b/web/src/bootstrap.ts
@@ -7,7 +7,7 @@
 async function loadRuntimeConfig() {
   await new Promise<void>((resolve, reject) => {
     const script = document.createElement('script')
-    script.src = '/runtime-config.js'
+    script.src = new URL('../runtime-config.js', import.meta.url).toString()
     script.async = false
     script.onload = () => resolve()
     script.onerror = () => reject(new Error('Failed to load runtime config'))


### PR DESCRIPTION
## 概述
修复 SkillHub 在 Nginx 子路径反向代理（如 `/skill_hub`）下 API 前缀失效与 runtime-config 加载路径错误的问题。

## 变更内容

### 后端实现
- 无后端代码变更。
- DB migration 变更：无。
- API 契约变更：无。

### 前端实现
- 修复 API URL 拼接逻辑，避免 `new URL('/path', baseUrl)` 覆盖 `baseUrl` 子路径前缀。
- `withBaseUrl` 与 `buildApiUrl` 统一改为前缀保留拼接逻辑（`prependApiBaseUrl`）。
- `bootstrap` 中 runtime 配置脚本改为基于 `import.meta.url` 解析，支持子路径部署下加载 `runtime-config.js`。
- 新增/更新单测覆盖：
  - `apiBaseUrl` 为 `https://api.example.com/skill_hub`
  - `apiBaseUrl` 为 `/skill_hub`
  - `fetchText` 请求路径前缀拼接

### 测试覆盖
- 后端单测：无后端变更，未执行。
- 前端单测：
  - `cd web && pnpm vitest run src/api/client.test.ts`
  - `make test-frontend`（172 files, 512 tests）
- E2E 测试：
  - `cd web && pnpm test:e2e`（33 passed）
  - 结果目录：`web/test-results/`

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] `make test-frontend` 通过
- [ ] `make test-backend-app` 通过（如有后端变更）
- [x] Playwright E2E（`web/e2e`）关键路径通过（如有 UI 交互变更）
- [ ] `make generate-api` 已执行且 `schema.d.ts` 已提交（如有 Controller 变更）

## 安全考虑
本次变更不涉及安全敏感内容。

## 相关 Issue
Closes #223

## 测试说明

### 本地验证步骤
1. 配置运行时变量：`SKILLHUB_WEB_API_BASE_URL=/skill_hub`。
2. 通过 Nginx 子路径访问 SkillHub 页面（例如 `https://<host>/skill_hub/`）。
3. 访问需要 API 请求的页面（登录态获取、列表页、详情页），确认请求路径为 `/skill_hub/api/...` 且可正常返回。

### 回归测试范围
- API 请求基址拼接逻辑（`withBaseUrl`、`buildApiUrl`）
- runtime 配置加载流程（`bootstrap`）
- Nginx 子路径部署访问链路

### 截图/录屏（如有 UI 变更）
无 UI 视觉变更；E2E 产物见 `web/test-results/`。
