### PR TITLE
fix(compat): fix canonical query slug resolution for clawhub install

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatAppService.java
@@ -14,6 +14,7 @@ import com.iflytek.skillhub.controller.support.MultipartPackageExtractor;
 import com.iflytek.skillhub.controller.support.ZipPackageExtractor;
 import com.iflytek.skillhub.domain.audit.AuditLogService;
 import com.iflytek.skillhub.domain.namespace.NamespaceRole;
+import com.iflytek.skillhub.domain.shared.exception.DomainNotFoundException;
 import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.service.SkillPublishService;
@@ -93,11 +94,11 @@ public class ClawHubCompatAppService {
                                                  String hash,
                                                  String userId,
                                                  Map<Long, NamespaceRole> userNsRoles) {
-        CompatSkillLookupService.CompatSkillContext context = compatSkillLookupService.findByLegacySlug(slug);
+        SkillCoordinate coord = resolveQueryCoordinate(slug);
 
         SkillQueryService.ResolvedVersionDTO resolved = skillQueryService.resolveVersion(
-                context.namespace().getSlug(),
-                context.skill().getSlug(),
+                coord.namespace(),
+                coord.slug(),
                 "latest".equals(version) ? null : version,
                 "latest".equals(version) ? "latest" : null,
                 hash,
@@ -132,10 +133,22 @@ public class ClawHubCompatAppService {
     }
 
     public String downloadLocationByQuery(String slug, String version) {
-        CompatSkillLookupService.CompatSkillContext context = compatSkillLookupService.findByLegacySlug(slug);
+        SkillCoordinate coord = resolveQueryCoordinate(slug);
         return "latest".equals(version)
-                ? "/api/v1/skills/" + context.namespace().getSlug() + "/" + context.skill().getSlug() + "/download"
-                : "/api/v1/skills/" + context.namespace().getSlug() + "/" + context.skill().getSlug() + "/versions/" + version + "/download";
+                ? "/api/v1/skills/" + coord.namespace() + "/" + coord.slug() + "/download"
+                : "/api/v1/skills/" + coord.namespace() + "/" + coord.slug() + "/versions/" + version + "/download";
+    }
+
+    private SkillCoordinate resolveQueryCoordinate(String slug) {
+        if (slug != null && slug.contains("--")) {
+            return mapper.fromCanonical(slug);
+        }
+        try {
+            CompatSkillLookupService.CompatSkillContext context = compatSkillLookupService.findByLegacySlug(slug);
+            return new SkillCoordinate(context.namespace().getSlug(), context.skill().getSlug());
+        } catch (DomainNotFoundException ex) {
+            return mapper.fromCanonical(slug);
+        }
     }
 
     public ClawHubSkillListResponse listSkills(int page,

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.math.BigDecimal;
 import java.time.Instant;
 
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -103,6 +104,56 @@ class ClawHubCompatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.match.version").value("latest"))
                 .andExpect(jsonPath("$.latestVersion.version").value("latest"));
+    }
+
+    @Test
+    void resolve_query_with_canonical_slug_returns_correct_downloadUrl() throws Exception {
+        when(skillQueryService.resolveVersion("team-ai", "my-skill", null, "latest", null, null, java.util.Map.of()))
+                .thenReturn(new SkillQueryService.ResolvedVersionDTO(
+                        1L, "team-ai", "my-skill", "latest", 2L, "sha", true, "/api/v1/skills/team-ai/my-skill/download"));
+
+        mockMvc.perform(get("/api/v1/resolve")
+                        .param("slug", "team-ai--my-skill")
+                        .param("version", "latest"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.match.version").value("latest"))
+                .andExpect(jsonPath("$.latestVersion.version").value("latest"));
+
+        verify(skillQueryService).resolveVersion("team-ai", "my-skill", null, "latest", null, null, java.util.Map.of());
+    }
+
+    @Test
+    void resolve_query_with_legacy_slug_keeps_legacy_lookup_behavior() throws Exception {
+        when(skillQueryService.resolveVersion("global", "my-skill", null, "latest", null, null, java.util.Map.of()))
+                .thenReturn(new SkillQueryService.ResolvedVersionDTO(
+                        1L, "global", "my-skill", "latest", 2L, "sha", true, "/api/v1/skills/global/my-skill/download"));
+
+        mockMvc.perform(get("/api/v1/resolve")
+                        .param("slug", "my-skill")
+                        .param("version", "latest"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.match.version").value("latest"))
+                .andExpect(jsonPath("$.latestVersion.version").value("latest"));
+
+        verify(skillQueryService).resolveVersion("global", "my-skill", null, "latest", null, null, java.util.Map.of());
+    }
+
+    @Test
+    void download_query_with_canonical_slug_redirects_to_namespace_skill_download() throws Exception {
+        mockMvc.perform(get("/api/v1/download")
+                        .param("slug", "team-ai--my-skill")
+                        .param("version", "latest"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "/api/v1/skills/team-ai/my-skill/download"));
+    }
+
+    @Test
+    void download_query_with_legacy_slug_keeps_legacy_lookup_behavior() throws Exception {
+        mockMvc.perform(get("/api/v1/download")
+                        .param("slug", "my-skill")
+                        .param("version", "latest"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "/api/v1/skills/global/my-skill/download"));
     }
 
     @Test


### PR DESCRIPTION
## 概述
修复 #218：`clawhub install my-namespace--my-skill` 在 query 版 resolve/download 路径返回 404。

## 变更内容
- 修复 `/api/v1/resolve?slug=...` 与 `/api/v1/download?slug=...` 的 canonical slug 解析
- 保留 legacy slug 查询兼容行为（先 legacy 查找，未命中再 canonical/global 回退）
- 新增兼容层回归测试：canonical + legacy 的 resolve/download query 场景

## 测试覆盖
- `ClawHubCompatControllerTest`：9/9 通过
- `make test-backend-app`：371 tests, 0 failures

## API Drift
- 无 OpenAPI schema 变更

Related to #218
