### PR TITLE
fix(auth): stabilize oauth session after callback

### DIFF
--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -35,7 +35,7 @@ public class OAuth2LoginSuccessHandler extends SavedRequestAwareAuthenticationSu
         if (authentication.getPrincipal() instanceof OAuth2User oAuth2User) {
             PlatformPrincipal principal = (PlatformPrincipal) oAuth2User.getAttributes().get("platformPrincipal");
             if (principal != null) {
-                platformSessionService.attachToAuthenticatedSession(principal, authentication, request, true);
+                platformSessionService.attachToAuthenticatedSession(principal, authentication, request);
             }
         }
         String returnTo = oauthLoginFlowService.consumeReturnTo(request.getSession(false));

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginHandlersTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginHandlersTest.java
@@ -6,6 +6,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
@@ -52,11 +53,15 @@ class OAuth2LoginHandlersTest {
 
         handler.onAuthenticationSuccess(request, response, authentication);
 
+        SecurityContext securityContext = (SecurityContext) session.getAttribute(
+                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY
+        );
         assertThat(response.getRedirectedUrl()).isEqualTo("/dashboard/publish");
-        assertThat(request.getSession(false).getId()).isNotEqualTo(originalSessionId);
+        assertThat(request.getSession(false).getId()).isEqualTo(originalSessionId);
         assertThat(session.getAttribute(OAuthLoginRedirectSupport.SESSION_RETURN_TO_ATTRIBUTE)).isNull();
         assertThat(session.getAttribute("platformPrincipal")).isEqualTo(principal);
-        assertThat(session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY)).isNotNull();
+        assertThat(securityContext).isNotNull();
+        assertThat(securityContext.getAuthentication()).isSameAs(authentication);
     }
 
     @Test


### PR DESCRIPTION
## 概述
修复 Cloudflare Tunnel 场景下 GitHub OAuth 授权成功后会话丢失，导致回到登录页的问题。

## 变更内容

### 后端实现
- 调整 OAuth 登录成功处理逻辑：不再在成功回调中额外执行一次会话 ID 轮换。
- 由 `attachToAuthenticatedSession(..., true)` 改为 `attachToAuthenticatedSession(...)`，避免与 Spring Security 默认会话固定防护叠加，导致代理场景下 Cookie/Session 不稳定。
- 涉及文件：
  - `server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginSuccessHandler.java`

### 前端实现
- 无前端代码变更。

### 测试覆盖
- 后端单测：更新 `OAuth2LoginHandlersTest`，校验 OAuth 成功后 Session 仍写入 `platformPrincipal` 与 `SecurityContext`，并验证不依赖额外 session rotate。
  - `server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginHandlersTest.java`
- 执行定向测试：
  - `cd server && ./mvnw -pl skillhub-auth -am test -Dtest=OAuth2LoginHandlersTest,OAuthLoginFlowServiceTest -Dsurefire.failIfNoSpecifiedTests=false`

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] `make test-frontend` 通过
- [x] `make test-backend-app` 通过
- [ ] Playwright E2E（`web/e2e`）关键路径通过（本次无前端改动，不适用）
- [x] `make generate-api` 已执行且 `schema.d.ts` 已提交（本次无 Controller 变更，不适用）

## 安全考虑
- 变更保持现有认证链路，仅去除 OAuth 成功回调中的重复 session rotate，降低代理环境下 session 丢失风险。
- 不涉及鉴权放宽、不涉及敏感信息处理变更。

## 相关 Issue
Closes #238

## 测试说明

### 本地验证步骤
1. 配置 `OAUTH2_GITHUB_CLIENT_ID` 与 `OAUTH2_GITHUB_CLIENT_SECRET`。
2. 启动服务并通过 GitHub OAuth 登录。
3. 登录成功后确认不再跳回登录页，并验证 `/api/v1/auth/me` 返回 200。

### 回归测试范围
- OAuth 登录成功回调与会话建立。
- `/api/v1/auth/me` 登录态读取。

### 截图/录屏（如有 UI 变更）
- 无 UI 变更。
