### PR TITLE
fix(storage): support path-style by s3 force-path-style config

### DIFF
--- a/server/skillhub-storage/src/main/java/com/iflytek/skillhub/storage/S3StorageService.java
+++ b/server/skillhub-storage/src/main/java/com/iflytek/skillhub/storage/S3StorageService.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -54,17 +55,24 @@ public class S3StorageService implements ObjectStorageService {
             builder.endpointOverride(URI.create(properties.getEndpoint()));
         }
         this.s3Client = builder.build();
+        this.s3Presigner = buildPresigner();
+        ensureBucketExists();
+    }
+
+    S3Presigner buildPresigner() {
         var presignerBuilder = S3Presigner.builder()
                 .region(Region.of(properties.getRegion()))
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())));
+                        AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(properties.isForcePathStyle())
+                        .build());
         if (properties.getPublicEndpoint() != null && !properties.getPublicEndpoint().isBlank()) {
             presignerBuilder.endpointOverride(URI.create(properties.getPublicEndpoint()));
         } else if (properties.getEndpoint() != null && !properties.getEndpoint().isBlank()) {
             presignerBuilder.endpointOverride(URI.create(properties.getEndpoint()));
         }
-        this.s3Presigner = presignerBuilder.build();
-        ensureBucketExists();
+        return presignerBuilder.build();
     }
 
     private void ensureBucketExists() {

--- a/server/skillhub-storage/src/test/java/com/iflytek/skillhub/storage/S3StorageServiceTest.java
+++ b/server/skillhub-storage/src/test/java/com/iflytek/skillhub/storage/S3StorageServiceTest.java
@@ -1,0 +1,56 @@
+package com.iflytek.skillhub.storage;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.net.URI;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class S3StorageServiceTest {
+
+    @Test
+    void shouldUsePathStylePresignedUrlWhenForcePathStyleEnabled() {
+        URI presignedUrl = presignGetObjectUrl(true);
+
+        assertThat(presignedUrl.getHost()).isEqualTo("s3.us-east-1.amazonaws.com");
+        assertThat(presignedUrl.getPath()).isEqualTo("/test-bucket/artifacts/package.tgz");
+    }
+
+    @Test
+    void shouldUseHostStylePresignedUrlWhenForcePathStyleDisabled() {
+        URI presignedUrl = presignGetObjectUrl(false);
+
+        assertThat(presignedUrl.getHost()).isEqualTo("test-bucket.s3.us-east-1.amazonaws.com");
+        assertThat(presignedUrl.getPath()).isEqualTo("/artifacts/package.tgz");
+    }
+
+    private URI presignGetObjectUrl(boolean forcePathStyle) {
+        S3StorageService storageService = new S3StorageService(createProperties(forcePathStyle));
+        try (var presigner = storageService.buildPresigner()) {
+            var request = presigner.presignGetObject(
+                    GetObjectPresignRequest.builder()
+                            .signatureDuration(Duration.ofMinutes(10))
+                            .getObjectRequest(GetObjectRequest.builder()
+                                    .bucket("test-bucket")
+                                    .key("artifacts/package.tgz")
+                                    .build())
+                            .build()
+            );
+            return URI.create(request.url().toString());
+        }
+    }
+
+    private S3StorageProperties createProperties(boolean forcePathStyle) {
+        S3StorageProperties properties = new S3StorageProperties();
+        properties.setRegion("us-east-1");
+        properties.setBucket("test-bucket");
+        properties.setAccessKey("test-access-key");
+        properties.setSecretKey("test-secret-key");
+        properties.setEndpoint("https://s3.us-east-1.amazonaws.com");
+        properties.setForcePathStyle(forcePathStyle);
+        return properties;
+    }
+}


### PR DESCRIPTION
## 概述
修复 S3Presigner 未读取 `forcePathStyle` 配置导致预签名 URL 始终使用 host-style 的问题。

## 变更内容

### 后端实现
- 在 `S3StorageService` 中抽取 `buildPresigner()`，统一构建 `S3Presigner`
- 为 presigner 增加 `S3Configuration.pathStyleAccessEnabled(properties.isForcePathStyle())`
- 保持现有 endpoint/publicEndpoint 选择逻辑不变，确保兼容原有配置

### 前端实现
- 无

### 测试覆盖
- 后端单测：新增 `S3StorageServiceTest`
  - `forcePathStyle=true` 时断言生成 path-style URL（`/bucket/key`）
  - `forcePathStyle=false` 时断言生成 host-style URL（`bucket.host/key`）
- 前端单测：无
- E2E 测试：无（本次无前端改动）

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] `make test-frontend` 通过
- [x] `make test-backend-app` 通过（如有后端变更）
- [x] Playwright E2E（`web/e2e`）关键路径通过（如有 UI 交互变更）
- [x] `make generate-api` 已执行且 `schema.d.ts` 已提交（如有 Controller 变更）

## 安全考虑
本次变更不涉及安全敏感内容。

## 相关 Issue
Closes #248

## 测试说明

### 本地验证步骤
1. 设置 `skillhub.storage.provider=s3` 并配置 S3/MinIO endpoint 与凭证
2. 切换 `skillhub.storage.s3.force-path-style=true/false`
3. 调用下载预签名 URL 生成流程，检查 URL 形态是否分别为 path-style/host-style

### 回归测试范围
- S3 预签名 URL 生成逻辑
- 现有 endpoint/publicEndpoint 场景

### 截图/录屏（如有 UI 变更）
无
