### PR TITLE
fix(validation): avoid token false positives in pre-publish check

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidator.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidator.java
@@ -16,6 +16,12 @@ import java.util.regex.Pattern;
 @Component
 public class BasicPrePublishValidator implements PrePublishValidator {
 
+    private static final Pattern ASSIGNMENT_WITH_SENSITIVE_KEY = Pattern.compile(
+            "(?i)(api[_-]?key|access[_-]?key|secret|password|token)\\s*[:=]\\s*(.+)$"
+    );
+    private static final Pattern QUOTED_LITERAL = Pattern.compile("^(['\"])(.*)\\1$");
+    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+    private static final Pattern BARE_LITERAL = Pattern.compile("[A-Za-z0-9_\\-]{12,}");
     private static final Pattern PLACEHOLDER_VALUE = Pattern.compile(
             "(?i).*(your|example|sample|placeholder|changeme|replace|dummy|mock|test|fake|todo|xxx|redacted).*"
     );
@@ -23,10 +29,7 @@ public class BasicPrePublishValidator implements PrePublishValidator {
             new SecretRule(Pattern.compile("(AKIA[0-9A-Z]{16})"), 1, "cloud access key"),
             new SecretRule(Pattern.compile("(ghp_[A-Za-z0-9]{20,})"), 1, "GitHub token"),
             new SecretRule(Pattern.compile("(sk-[A-Za-z0-9]{20,})"), 1, "API key"),
-            new SecretRule(
-                    Pattern.compile("(?i)(api[_-]?key|access[_-]?key|secret|password|token)\\s*[:=]\\s*['\\\"]?([A-Za-z0-9_\\-]{12,})"),
-                    2,
-                    "secret or token")
+            new SecretRule(ASSIGNMENT_WITH_SENSITIVE_KEY, 0, "secret or token")
     );
 
     @Override
@@ -46,7 +49,10 @@ public class BasicPrePublishValidator implements PrePublishValidator {
                     if (!matcher.find()) {
                         continue;
                     }
-                    String matchedValue = matcher.group(rule.valueGroup());
+                    String matchedValue = extractMatchedValue(line, matcher, rule);
+                    if (matchedValue == null) {
+                        continue;
+                    }
                     if (isPlaceholderValue(matchedValue)) {
                         continue;
                     }
@@ -85,6 +91,65 @@ public class BasicPrePublishValidator implements PrePublishValidator {
         }
         return PLACEHOLDER_VALUE.matcher(value).matches()
                 || value.chars().allMatch(ch -> ch == 'x' || ch == 'X' || ch == '*' || ch == '-');
+    }
+
+    private String extractMatchedValue(String line, Matcher matcher, SecretRule rule) {
+        if (rule.valueGroup() > 0) {
+            return matcher.group(rule.valueGroup());
+        }
+
+        Matcher assignmentMatcher = ASSIGNMENT_WITH_SENSITIVE_KEY.matcher(line);
+        if (!assignmentMatcher.find()) {
+            return null;
+        }
+
+        String rawValue = assignmentMatcher.group(2).trim();
+        if (rawValue.isBlank()) {
+            return null;
+        }
+
+        Matcher quotedLiteralMatcher = QUOTED_LITERAL.matcher(rawValue);
+        if (quotedLiteralMatcher.matches()) {
+            return quotedLiteralMatcher.group(2);
+        }
+
+        rawValue = stripInlineComment(rawValue);
+        if (rawValue.isBlank()) {
+            return null;
+        }
+
+        quotedLiteralMatcher = QUOTED_LITERAL.matcher(rawValue);
+        if (quotedLiteralMatcher.matches()) {
+            return quotedLiteralMatcher.group(2);
+        }
+
+        if (looksLikeExpression(rawValue) || IDENTIFIER.matcher(rawValue).matches()) {
+            return null;
+        }
+
+        return BARE_LITERAL.matcher(rawValue).matches() ? rawValue : null;
+    }
+
+    private String stripInlineComment(String rawValue) {
+        int hashIndex = rawValue.indexOf('#');
+        if (hashIndex >= 0) {
+            return rawValue.substring(0, hashIndex).trim();
+        }
+        return rawValue;
+    }
+
+    private boolean looksLikeExpression(String rawValue) {
+        return rawValue.contains("(")
+                || rawValue.contains(")")
+                || rawValue.contains(".")
+                || rawValue.contains("[")
+                || rawValue.contains("]")
+                || rawValue.contains("{")
+                || rawValue.contains("}")
+                || rawValue.contains(",")
+                || rawValue.contains(" ")
+                || rawValue.contains("+")
+                || rawValue.contains("/");
     }
 
     private record SecretRule(Pattern pattern, int valueGroup, String label) {}

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidatorTest.java
@@ -98,4 +98,71 @@ class BasicPrePublishValidatorTest {
 
         assertTrue(result.passed());
     }
+
+    @Test
+    void shouldAllowFunctionCallAssignedToTokenVariable() {
+        PackageEntry script = new PackageEntry(
+                "scripts/f2e_mock.py",
+                """
+                token = extract_group_token_value(response, group_choice.group_id)
+                if token:
+                    return token
+                """.getBytes(StandardCharsets.UTF_8),
+                97,
+                "text/x-python"
+        );
+
+        ValidationResult result = validator.validate(new PrePublishValidator.SkillPackageContext(
+                List.of(script),
+                new SkillMetadata("Safe Skill", "desc", "1.0.0", "body", Map.of()),
+                "user-1",
+                1L
+        ));
+
+        assertTrue(result.passed());
+    }
+
+    @Test
+    void shouldAllowIdentifierAssignedToSecretNamedVariable() {
+        PackageEntry envTemplate = new PackageEntry(
+                "config.env",
+                """
+                token=generated_token_value
+                api_key=current_api_key
+                """.getBytes(StandardCharsets.UTF_8),
+                46,
+                "text/plain"
+        );
+
+        ValidationResult result = validator.validate(new PrePublishValidator.SkillPackageContext(
+                List.of(envTemplate),
+                new SkillMetadata("Safe Skill", "desc", "1.0.0", "body", Map.of()),
+                "user-1",
+                1L
+        ));
+
+        assertTrue(result.passed());
+    }
+
+    @Test
+    void shouldRejectQuotedSecretWithTrailingComment() {
+        PackageEntry script = new PackageEntry(
+                "scripts/publish.py",
+                """
+                token = "ghp_abcdefghijklmnopqrstuvwxyz1234" # do not commit real token
+                """.getBytes(StandardCharsets.UTF_8),
+                76,
+                "text/x-python"
+        );
+
+        ValidationResult result = validator.validate(new PrePublishValidator.SkillPackageContext(
+                List.of(script),
+                new SkillMetadata("Secret Skill", "desc", "1.0.0", "body", Map.of()),
+                "user-1",
+                1L
+        ));
+
+        assertFalse(result.passed());
+        assertTrue(result.errors().stream().anyMatch(error -> error.contains("scripts/publish.py")));
+    }
 }


### PR DESCRIPTION
## 概述
修复预发布校验器将函数调用/普通标识符赋值误判为泄露 token 的问题。

## 变更内容

### 后端实现
- 收紧 `BasicPrePublishValidator` 的敏感赋值检测逻辑，先识别敏感键赋值，再只对真实字面量进行告警。
- 显式跳过函数调用、普通标识符、属性访问等表达式，避免 `token = extract_group_token_value(...)` 这类代码被误判。
- 保持对明显硬编码凭据的拦截，并覆盖带尾注释的引号字面量场景。

### 前端实现
- 本次无前端改动。

### 测试覆盖
- 后端单测：补充 `BasicPrePublishValidatorTest`，覆盖函数调用赋值、普通标识符赋值、带尾注释的真实 secret。
- 前端单测：无。
- E2E 测试：无，本次未修改前端页面交互。

## 质量门禁

- [x] `make test-backend-app` 通过
- [ ] `make typecheck-web` 通过（未执行，本次无前端改动）
- [ ] `make lint-web` 通过（未执行，本次无前端改动）
- [ ] `make test-frontend` 通过（未执行，本次无前端改动）
- [ ] Playwright E2E（`web/e2e`）关键路径通过（未执行，本次无 UI 变更）
- [ ] `make generate-api` 已执行且 `schema.d.ts` 已提交（不适用，本次无 Controller 变更）

## 安全考虑

- 本次变更不涉及鉴权/授权逻辑调整。
- 修复后仍会拦截明显硬编码 secret，同时减少对正常代码的误报。

## 相关 Issue

Closes #234

## 测试说明

### 本地验证步骤
1. 在任意技能包文本文件中加入 `token = extract_group_token_value(response, group_choice.group_id)`。
2. 执行技能发布前校验或运行 `BasicPrePublishValidatorTest`。
3. 预期：上述函数调用赋值不再被判定为 secret；真实硬编码 token 仍会被拦截。

### 回归测试范围
- 预发布 secret 检测逻辑
- 技能发布前校验链路

### 截图/录屏（如有 UI 变更）
无
