### PR TITLE
fix(storage): tolerate headbucket 403 on s3-compatible providers

### DIFF
--- a/server/skillhub-storage/src/main/java/com/iflytek/skillhub/storage/S3StorageService.java
+++ b/server/skillhub-storage/src/main/java/com/iflytek/skillhub/storage/S3StorageService.java
@@ -30,53 +30,93 @@ import java.util.List;
 @ConditionalOnProperty(name = "skillhub.storage.provider", havingValue = "s3")
 public class S3StorageService implements ObjectStorageService {
     private static final Logger log = LoggerFactory.getLogger(S3StorageService.class);
+    private static final int HTTP_FORBIDDEN = 403;
+    private static final int HTTP_NOT_FOUND = 404;
     private final S3StorageProperties properties;
     private S3Client s3Client;
     private S3Presigner s3Presigner;
 
     public S3StorageService(S3StorageProperties properties) { this.properties = properties; }
 
+    S3StorageService(S3StorageProperties properties, S3Client s3Client, S3Presigner s3Presigner) {
+        this.properties = properties;
+        this.s3Client = s3Client;
+        this.s3Presigner = s3Presigner;
+    }
+
     @PostConstruct
     void init() {
-        ApacheHttpClient.Builder httpClientBuilder = ApacheHttpClient.builder()
-                .maxConnections(properties.getMaxConnections())
-                .connectionAcquisitionTimeout(properties.getConnectionAcquisitionTimeout());
-        var builder = S3Client.builder()
-                .region(Region.of(properties.getRegion()))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())))
-                .forcePathStyle(properties.isForcePathStyle())
-                .httpClientBuilder(httpClientBuilder)
-                .overrideConfiguration(config -> config
-                        .apiCallAttemptTimeout(properties.getApiCallAttemptTimeout())
-                        .apiCallTimeout(properties.getApiCallTimeout()));
-        if (properties.getEndpoint() != null && !properties.getEndpoint().isBlank()) {
-            builder.endpointOverride(URI.create(properties.getEndpoint()));
+        if (s3Client == null) {
+            ApacheHttpClient.Builder httpClientBuilder = ApacheHttpClient.builder()
+                    .maxConnections(properties.getMaxConnections())
+                    .connectionAcquisitionTimeout(properties.getConnectionAcquisitionTimeout());
+            var builder = S3Client.builder()
+                    .region(Region.of(properties.getRegion()))
+                    .credentialsProvider(StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())))
+                    .forcePathStyle(properties.isForcePathStyle())
+                    .httpClientBuilder(httpClientBuilder)
+                    .overrideConfiguration(config -> config
+                            .apiCallAttemptTimeout(properties.getApiCallAttemptTimeout())
+                            .apiCallTimeout(properties.getApiCallTimeout()));
+            if (properties.getEndpoint() != null && !properties.getEndpoint().isBlank()) {
+                builder.endpointOverride(URI.create(properties.getEndpoint()));
+            }
+            this.s3Client = builder.build();
         }
-        this.s3Client = builder.build();
-        var presignerBuilder = S3Presigner.builder()
-                .region(Region.of(properties.getRegion()))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())));
-        if (properties.getPublicEndpoint() != null && !properties.getPublicEndpoint().isBlank()) {
-            presignerBuilder.endpointOverride(URI.create(properties.getPublicEndpoint()));
-        } else if (properties.getEndpoint() != null && !properties.getEndpoint().isBlank()) {
-            presignerBuilder.endpointOverride(URI.create(properties.getEndpoint()));
+        if (s3Presigner == null) {
+            var presignerBuilder = S3Presigner.builder()
+                    .region(Region.of(properties.getRegion()))
+                    .credentialsProvider(StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())));
+            if (properties.getPublicEndpoint() != null && !properties.getPublicEndpoint().isBlank()) {
+                presignerBuilder.endpointOverride(URI.create(properties.getPublicEndpoint()));
+            } else if (properties.getEndpoint() != null && !properties.getEndpoint().isBlank()) {
+                presignerBuilder.endpointOverride(URI.create(properties.getEndpoint()));
+            }
+            this.s3Presigner = presignerBuilder.build();
         }
-        this.s3Presigner = presignerBuilder.build();
         ensureBucketExists();
     }
 
     private void ensureBucketExists() {
+        String bucket = properties.getBucket();
         if (!properties.isAutoCreateBucket()) {
-            s3Client.headBucket(HeadBucketRequest.builder().bucket(properties.getBucket()).build());
+            verifyBucketAccessForConfiguredProvider(bucket);
             return;
         }
-        try { s3Client.headBucket(HeadBucketRequest.builder().bucket(properties.getBucket()).build()); }
-        catch (NoSuchBucketException e) {
-            log.info("Bucket '{}' does not exist, creating...", properties.getBucket());
-            s3Client.createBucket(CreateBucketRequest.builder().bucket(properties.getBucket()).build());
+        try {
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(bucket).build());
+        } catch (NoSuchBucketException e) {
+            createBucket(bucket);
+        } catch (S3Exception e) {
+            if (e.statusCode() == HTTP_NOT_FOUND) {
+                createBucket(bucket);
+                return;
+            }
+            if (e.statusCode() == HTTP_FORBIDDEN) {
+                log.warn("Unable to verify bucket '{}' at startup because the storage provider returned 403 to HeadBucket. Continuing with configured S3-compatible storage and deferring validation to runtime object operations.", bucket);
+                return;
+            }
+            throw e;
         }
+    }
+
+    private void verifyBucketAccessForConfiguredProvider(String bucket) {
+        try {
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(bucket).build());
+        } catch (S3Exception e) {
+            if (e.statusCode() == HTTP_FORBIDDEN) {
+                log.warn("Storage provider returned 403 to HeadBucket for bucket '{}' during startup verification. Continuing because some S3-compatible providers deny bucket-level probes even when object operations are permitted.", bucket);
+                return;
+            }
+            throw e;
+        }
+    }
+
+    private void createBucket(String bucket) {
+        log.info("Bucket '{}' does not exist, creating...", bucket);
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
     }
 
     @Override public void putObject(String key, InputStream data, long size, String contentType) {

--- a/server/skillhub-storage/src/test/java/com/iflytek/skillhub/storage/S3StorageServiceTest.java
+++ b/server/skillhub-storage/src/test/java/com/iflytek/skillhub/storage/S3StorageServiceTest.java
@@ -1,0 +1,126 @@
+package com.iflytek.skillhub.storage;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class S3StorageServiceTest {
+
+    @Test
+    void initShouldIgnoreForbiddenHeadBucketWhenAutoCreateDisabled() {
+        S3Client s3Client = mock(S3Client.class);
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception(403, "AccessDenied"));
+
+        S3StorageService service = new S3StorageService(properties(false), s3Client, mock(S3Presigner.class));
+
+        assertDoesNotThrow(service::init);
+        verify(s3Client, never()).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void initShouldIgnoreForbiddenHeadBucketWhenAutoCreateEnabled() {
+        S3Client s3Client = mock(S3Client.class);
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception(403, "AccessDenied"));
+
+        S3StorageService service = new S3StorageService(properties(true), s3Client, mock(S3Presigner.class));
+
+        assertDoesNotThrow(service::init);
+        verify(s3Client, never()).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void initShouldCreateBucketWhenHeadBucketReturnsNotFound() {
+        S3Client s3Client = mock(S3Client.class);
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception(404, "NoSuchBucket"));
+        when(s3Client.createBucket(any(CreateBucketRequest.class))).thenReturn(CreateBucketResponse.builder().build());
+
+        S3StorageService service = new S3StorageService(properties(true), s3Client, mock(S3Presigner.class));
+
+        assertDoesNotThrow(service::init);
+        verify(s3Client).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void initShouldCreateBucketWhenHeadBucketThrowsNoSuchBucketException() {
+        S3Client s3Client = mock(S3Client.class);
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(
+                (NoSuchBucketException) NoSuchBucketException.builder()
+                        .statusCode(404)
+                        .awsErrorDetails(AwsErrorDetails.builder().errorCode("NoSuchBucket").build())
+                        .message("NoSuchBucket")
+                        .build()
+        );
+        when(s3Client.createBucket(any(CreateBucketRequest.class))).thenReturn(CreateBucketResponse.builder().build());
+
+        S3StorageService service = new S3StorageService(properties(true), s3Client, mock(S3Presigner.class));
+
+        assertDoesNotThrow(service::init);
+        verify(s3Client).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void initShouldPropagateNotFoundWhenAutoCreateDisabled() {
+        S3Client s3Client = mock(S3Client.class);
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception(404, "NoSuchBucket"));
+
+        S3StorageService service = new S3StorageService(properties(false), s3Client, mock(S3Presigner.class));
+
+        assertThrows(S3Exception.class, service::init);
+        verify(s3Client, never()).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void initShouldPropagateUnexpectedHeadBucketErrors() {
+        S3Client s3Client = mock(S3Client.class);
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception(500, "InternalError"));
+
+        S3StorageService service = new S3StorageService(properties(false), s3Client, mock(S3Presigner.class));
+
+        assertThrows(S3Exception.class, service::init);
+        verify(s3Client, never()).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    void initShouldPassWhenHeadBucketSucceeds() {
+        S3Client s3Client = mock(S3Client.class);
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(HeadBucketResponse.builder().build());
+
+        S3StorageService service = new S3StorageService(properties(false), s3Client, mock(S3Presigner.class));
+
+        assertDoesNotThrow(service::init);
+        verify(s3Client, never()).createBucket(any(CreateBucketRequest.class));
+    }
+
+    private static S3StorageProperties properties(boolean autoCreateBucket) {
+        S3StorageProperties properties = new S3StorageProperties();
+        properties.setBucket("skillhub-test");
+        properties.setRegion("us-east-1");
+        properties.setAccessKey("test-access-key");
+        properties.setSecretKey("test-secret-key");
+        properties.setAutoCreateBucket(autoCreateBucket);
+        return properties;
+    }
+
+    private static S3Exception s3Exception(int statusCode, String errorCode) {
+        return (S3Exception) S3Exception.builder()
+                .statusCode(statusCode)
+                .awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build())
+                .message(errorCode)
+                .build();
+    }
+}


### PR DESCRIPTION
## 概述
修复 #237：当 `storage.provider=s3` 且使用阿里云 OSS、腾讯云 COS 等 S3 兼容存储时，`HeadBucket` 返回 `403` 不再导致 SkillHub 在启动期硬失败。

## 变更内容

### 后端实现
- 调整 `S3StorageService.ensureBucketExists()`，将 `HeadBucket` 的 `403` 视为兼容性探测失败并记录 warning，继续启动。
- 保留 `404/NoSuchBucket` 的缺桶语义，在 `auto-create-bucket=true` 时继续自动创建 bucket。
- 保持其他 `S3Exception` 继续抛出，避免吞掉真实故障。
- 增加包级注入构造器，便于在单测中注入 mock 的 `S3Client` / `S3Presigner`。

### 前端实现
- 本次无前端变更。

### 测试覆盖
- 后端单测：新增 `server/skillhub-storage/src/test/java/com/iflytek/skillhub/storage/S3StorageServiceTest.java`，覆盖 `HeadBucket` 的 `200/403/404/500` 和 `auto-create-bucket` 分支。
- 后端回归：保留并联跑 `LocalFileStorageServiceTest`，确认存储模块现有逻辑不回归。
- 前端单测 / E2E：本次无前端改动，不适用。

## 质量门禁
- [x] `make test-backend-app` 通过
- [x] `cd server && JDK_JAVA_OPTIONS="-XX:+EnableDynamicAgentLoading" ./mvnw -pl skillhub-storage test -Dtest=S3StorageServiceTest,LocalFileStorageServiceTest` 通过
- [x] 本次无前端变更，`make typecheck-web` / `make lint-web` / `make test-frontend` / Playwright E2E 不适用
- [x] 本次无 Controller 变更，`make generate-api` 不适用

## 安全考虑
本次变更不涉及安全敏感内容。未新增鉴权逻辑、敏感数据处理或外部输入面；仅调整对象存储启动期探测策略。

## 相关 Issue
Closes #237

## 测试说明

### 本地验证步骤
1. 配置 `SKILLHUB_STORAGE_PROVIDER=s3` 和一组 OSS/COS/S3 兼容存储参数。
2. 启动服务，观察 `S3StorageService` 初始化阶段：当 `HeadBucket` 返回 `403` 时，服务应记录 warning 并继续启动。
3. 继续执行真实对象读写路径，确认错误会在运行时对象操作阶段暴露，而不是在启动期被 `HeadBucket` 阻断。
4. 若配置 `SKILLHUB_STORAGE_S3_AUTO_CREATE_BUCKET=true` 且 bucket 不存在，验证 `404/NoSuchBucket` 时仍会创建 bucket。

### 回归测试范围
- `skillhub-storage` 模块的 S3 兼容存储初始化流程
- `auto-create-bucket` 的缺桶处理逻辑
- OSS/COS/MinIO/AWS S3 在启动期 bucket 探测上的差异化行为

### 截图/录屏（如有 UI 变更）
无 UI 变更。