### PR TITLE
feat: setup CLA Assistant Lite via GitHub Actions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/iflytek/skillhub/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: 'dependabot[bot],renovate[bot],github-actions[bot]'
+          create-file-commit-message: 'docs: creating file for storing CLA Signatures'
+          signed-commit-message: 'docs: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,13 @@
+# Contributor License Agreement (CLA)
+
+By contributing to this project, you agree to the following terms:
+
+1. **Grant of License**: You grant to the project maintainers a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your contributions and such derivative works.
+
+2. **Original Creation**: You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual property that you create that includes your contributions, you represent that you have received permission to make contributions on behalf of that employer, that your employer has waived such rights for your contributions to the project, or that your employer has executed a separate Corporate CLA with the project.
+
+3. **Moral Rights**: If your local laws recognize "moral rights," you hereby waive them to the maximum extent permitted by law.
+
+4. **Disclaimer**: Your contributions are provided on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+By commenting "I have read the CLA Document and I hereby sign the CLA" in your Pull Request, you accept this agreement.


### PR DESCRIPTION
This PR sets up the [CLA Assistant Lite](https://github.com/marketplace/actions/cla-assistant-lite) GitHub Action, which natively replicates the functionality of `cla-assistant.io` entirely within GitHub Actions.

When contributors submit a PR, the CLA check will automatically appear and guide them through signing within the PR comments. No additional action or third-party web service setup is needed.

Changes included:
- Added `.github/workflows/cla.yml` to trigger the CLA verification.
- Added a standard `CLA.md` file in the root to serve as the default Contributor License Agreement document.