### PR TITLE
fix(review): correct review queue totals

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/ReviewPortalAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/ReviewPortalAppService.java
@@ -119,6 +119,7 @@ public class ReviewPortalAppService {
                                                         Map<Long, NamespaceRole> userNsRoles) {
         ReviewTaskStatus reviewStatus = ReviewTaskStatus.valueOf(status.toUpperCase());
         Map<Long, NamespaceRole> namespaceRoles = normalizeRoles(userNsRoles);
+        Set<String> platformRoles = platformRoles(userId);
         Pageable pageable = buildReviewPageable(reviewStatus, page, size, sortDirection);
 
         Page<ReviewTask> tasks;
@@ -131,11 +132,14 @@ public class ReviewPortalAppService {
                     userId,
                     namespace.getType(),
                     namespaceRoles,
-                    platformRoles(userId))) {
+                    platformRoles)) {
                 throw new DomainForbiddenException("review.no_permission");
             }
             tasks = reviewTaskRepository.findByNamespaceIdAndStatus(namespaceId, reviewStatus, pageable);
         } else {
+            if (!hasPlatformReviewRole(platformRoles)) {
+                throw new DomainForbiddenException("review.no_permission");
+            }
             tasks = reviewTaskRepository.findByStatus(reviewStatus, pageable);
         }
 
@@ -146,7 +150,7 @@ public class ReviewPortalAppService {
         return PageResponse.from(new PageImpl<>(
                 governanceQueryRepository.getReviewTaskResponses(visibleItems),
                 tasks.getPageable(),
-                visibleItems.size()
+                tasks.getTotalElements()
         ));
     }
 
@@ -231,6 +235,11 @@ public class ReviewPortalAppService {
 
     private Set<String> platformRoles(String userId) {
         return rbacService.getUserRoleCodes(userId);
+    }
+
+    private boolean hasPlatformReviewRole(Set<String> platformRoles) {
+        return platformRoles.contains("SKILL_ADMIN")
+                || platformRoles.contains("SUPER_ADMIN");
     }
 
     private Map<Long, NamespaceRole> normalizeRoles(Map<Long, NamespaceRole> userNsRoles) {

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/NamespaceWorkflowContractTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/NamespaceWorkflowContractTest.java
@@ -12,6 +12,8 @@ import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.namespace.NamespaceService;
 import com.iflytek.skillhub.domain.namespace.NamespaceStatus;
 import com.iflytek.skillhub.domain.namespace.NamespaceType;
+import com.iflytek.skillhub.domain.user.UserAccount;
+import com.iflytek.skillhub.domain.user.UserAccountRepository;
 import com.iflytek.skillhub.dto.NamespaceCandidateUserResponse;
 import com.iflytek.skillhub.service.NamespaceMemberCandidateService;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -67,6 +70,9 @@ class NamespaceWorkflowContractTest {
     private NamespaceMemberCandidateService namespaceMemberCandidateService;
 
     @MockBean
+    private UserAccountRepository userAccountRepository;
+
+    @MockBean
     private DeviceAuthService deviceAuthService;
 
     @Test
@@ -92,6 +98,8 @@ class NamespaceWorkflowContractTest {
                 .willReturn(new org.springframework.data.domain.PageImpl<>(List.of(adminMember)));
         given(namespaceMemberService.updateMemberRole(7L, "user-admin", NamespaceRole.ADMIN, "owner-1"))
                 .willReturn(adminMember);
+        given(userAccountRepository.findById("user-admin"))
+                .willReturn(Optional.of(new UserAccount("user-admin", "Admin", "admin@example.com", null)));
 
         mockMvc.perform(post("/api/web/namespaces")
                         .with(csrf())

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/ReviewPortalControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/ReviewPortalControllerTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -221,6 +222,7 @@ class ReviewPortalControllerTest {
     @Test
     void listReviews_appliesRequestedTimeSortDirection() throws Exception {
         stubNamespaceRoles("admin", List.of());
+        given(rbacService.getUserRoleCodes("admin")).willReturn(Set.of("SKILL_ADMIN"));
         PageRequest pageable = PageRequest.of(
                 1,
                 5,
@@ -245,6 +247,35 @@ class ReviewPortalControllerTest {
     }
 
     @Test
+    void listReviews_preservesRepositoryTotalForDefaultPageSize() throws Exception {
+        assertReviewTotalPreservedForDefaultPageSize(ReviewTaskStatus.PENDING);
+    }
+
+    @Test
+    void listApprovedReviews_preservesRepositoryTotalForDefaultPageSize() throws Exception {
+        assertReviewTotalPreservedForDefaultPageSize(ReviewTaskStatus.APPROVED);
+    }
+
+    @Test
+    void listRejectedReviews_preservesRepositoryTotalForDefaultPageSize() throws Exception {
+        assertReviewTotalPreservedForDefaultPageSize(ReviewTaskStatus.REJECTED);
+    }
+
+    @Test
+    void listReviews_forbidsGlobalQueueForNonPlatformReviewer() throws Exception {
+        stubNamespaceRoles("namespace-admin", List.of());
+        given(rbacService.getUserRoleCodes("namespace-admin")).willReturn(Set.of("NAMESPACE_ADMIN"));
+
+        mockMvc.perform(get("/api/v1/reviews")
+                        .param("status", "PENDING")
+                        .with(auth("namespace-admin")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403));
+
+        verify(reviewTaskRepository, never()).findByStatus(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
     void downloadReviewVersion_streamsZipForAuthorizedReviewer() throws Exception {
         stubNamespaceRoles("admin", List.of());
         given(reviewSkillDetailAppService.downloadReviewPackage(1L, "admin", Map.of()))
@@ -264,21 +295,7 @@ class ReviewPortalControllerTest {
     }
 
     private void stubReviewResponse(ReviewTask task) {
-        given(governanceQueryRepository.getReviewTaskResponse(task)).willReturn(new ReviewTaskResponse(
-                task.getId(),
-                task.getSkillVersionId(),
-                "team-a",
-                "skill-a",
-                "1.0.0",
-                task.getStatus().name(),
-                task.getSubmittedBy(),
-                "Submitter",
-                task.getReviewedBy(),
-                null,
-                task.getReviewComment(),
-                task.getSubmittedAt(),
-                task.getReviewedAt()
-        ));
+        given(governanceQueryRepository.getReviewTaskResponse(task)).willReturn(toReviewResponse(task));
     }
 
     private void stubNamespaceRoles(String userId, List<NamespaceMember> members) {
@@ -309,10 +326,74 @@ class ReviewPortalControllerTest {
         return task;
     }
 
+    private ReviewTask createReviewTask(Long id, Long namespaceId, String submittedBy, ReviewTaskStatus status) {
+        ReviewTask task = createReviewTask(id, namespaceId, submittedBy);
+        setField(task, "status", status);
+        return task;
+    }
+
     private Namespace createNamespace(Long id, String slug) {
         Namespace namespace = new Namespace(slug, "Team", "owner-1");
         setField(namespace, "id", id);
         return namespace;
+    }
+
+    private ReviewTaskResponse toReviewResponse(ReviewTask task) {
+        return new ReviewTaskResponse(
+                task.getId(),
+                task.getSkillVersionId(),
+                "team-a",
+                "skill-a",
+                "1.0.0",
+                task.getStatus().name(),
+                task.getSubmittedBy(),
+                "Submitter",
+                task.getReviewedBy(),
+                null,
+                task.getReviewComment(),
+                task.getSubmittedAt(),
+                task.getReviewedAt()
+        );
+    }
+
+    private void assertReviewTotalPreservedForDefaultPageSize(ReviewTaskStatus status) throws Exception {
+        stubNamespaceRoles("admin", List.of());
+        Namespace namespace = createNamespace(20L, "team-a");
+        List<ReviewTask> tasks = IntStream.rangeClosed(1, 20)
+                .mapToObj(index -> createReviewTask((long) index, 20L, "submitter-" + index, status))
+                .toList();
+        List<ReviewTaskResponse> responses = tasks.stream()
+                .map(this::toReviewResponse)
+                .toList();
+        PageRequest pageable = PageRequest.of(
+                0,
+                20,
+                Sort.by(
+                        new Sort.Order(Sort.Direction.DESC, status == ReviewTaskStatus.PENDING ? "submittedAt" : "reviewedAt"),
+                        new Sort.Order(Sort.Direction.DESC, "id")
+                )
+        );
+
+        given(reviewTaskRepository.findByStatus(status, pageable))
+                .willReturn(new PageImpl<>(tasks, pageable, 42));
+        given(namespaceRepository.findById(20L)).willReturn(Optional.of(namespace));
+        given(rbacService.getUserRoleCodes("admin")).willReturn(Set.of("SKILL_ADMIN"));
+        tasks.forEach(task -> given(reviewService.canViewReview(
+                task,
+                "admin",
+                namespace.getType(),
+                Map.of(),
+                Set.of("SKILL_ADMIN"))).willReturn(true));
+        given(governanceQueryRepository.getReviewTaskResponses(tasks)).willReturn(responses);
+
+        mockMvc.perform(get("/api/v1/reviews")
+                        .param("status", status.name())
+                        .with(auth("admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.data.total").value(42))
+                .andExpect(jsonPath("$.data.size").value(20))
+                .andExpect(jsonPath("$.data.items.length()").value(20));
     }
 
     private void setField(Object target, String fieldName, Object value) {


### PR DESCRIPTION
## 概述
修复 `/dashboard/reviews` 技能审核列表在待审核数量远超 20 条时，`total` 仍错误返回 20 的问题，并补齐全局审核队列的权限边界。

## 变更内容

### 后端实现
- 修正技能审核列表分页响应的 `total` 计算，改为返回仓库分页的真实总数，而不是当前页条数。
- 收紧无 `namespaceId` 的全局技能审核列表访问权限，仅允许 `SKILL_ADMIN` / `SUPER_ADMIN` 访问，避免对部分可见用户暴露错误总数或幽灵分页。
- 保持 namespace 范围审核列表行为不变。

### 前端实现
- 本次变更不涉及前端代码。

### 测试覆盖
- 后端单测：扩展 `ReviewPortalControllerTest`，覆盖 `PENDING` / `APPROVED` / `REJECTED` 三种状态下默认 `size=20` 但总数大于 20 的场景。
- 后端单测：新增非平台审核员访问全局技能审核列表返回 403 的回归用例。
- 后端单测：补齐 `NamespaceWorkflowContractTest` 的 `UserAccountRepository` mock，确保全量后端门禁稳定通过。
- E2E 测试：本次无前端页面交互变更，不涉及。

## 质量门禁

- [ ] `make typecheck-web` 通过（0 errors）
- [ ] `make lint-web` 通过（0 errors, 0 warnings）
- [ ] `make test-frontend` 通过
- [x] `make test-backend-app` 通过
- [ ] Playwright E2E（`web/e2e`）关键路径通过（如有 UI 交互变更）
- [ ] `make generate-api` 已执行且 `schema.d.ts` 已提交（如有 Controller 变更）

说明：本次未修改前端代码，也未变更 Controller API 契约，因此前端 E2E 和 `generate-api` 不适用。

## 安全考虑
- 收紧了全局技能审核列表接口权限，避免非平台审核员看到不可见审核任务的总量信息。
- 本次变更不涉及敏感信息处理、鉴权凭据或输入验证新增风险。

## 相关 Issue
None

## 测试说明

### 本地验证步骤
1. 以 `SKILL_ADMIN` 或 `SUPER_ADMIN` 身份访问 `/dashboard/reviews`。
2. 分别切换“待审核 / 已通过 / 已拒绝”三个 tab，确认分页文案中的总数与真实队列总量一致，不再固定为 20。
3. 使用非平台技能审核员身份调用 `GET /api/v1/reviews?status=PENDING`，预期返回 403。

### 回归测试范围
- 技能审核列表分页
- 全局技能审核队列权限控制
- namespace 成员工作流合同测试

### 截图/录屏（如有 UI 变更）
无