### PR TITLE
fix(auth): use SimpleUrlAuthenticationSuccessHandler for OAuth2 login

### DIFF
--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -1,23 +1,29 @@
 package com.iflytek.skillhub.auth.oauth;
 
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.auth.session.PlatformSessionService;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
-import org.springframework.stereotype.Component;
-
-import java.io.IOException;
 
 /**
  * Login success handler that copies the resolved platform principal into the
- * HTTP session and then redirects to the stored return target.
+ * HTTP session and then redirects to the stored return target or default URL.
+ * 
+ * <p>This handler extends {@link SimpleUrlAuthenticationSuccessHandler} and only
+ * uses the returnTo parameter stored in session and the default target URL for
+ * redirect decisions, ignoring any saved request from Spring Security's RequestCache.
  */
 @Component
-public class OAuth2LoginSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final PlatformSessionService platformSessionService;
     private final OAuthLoginFlowService oauthLoginFlowService;
@@ -41,9 +47,10 @@ public class OAuth2LoginSuccessHandler extends SavedRequestAwareAuthenticationSu
         String returnTo = oauthLoginFlowService.consumeReturnTo(request.getSession(false));
         if (returnTo != null) {
             getRedirectStrategy().sendRedirect(request, response, returnTo);
-            clearAuthenticationAttributes(request);
             return;
         }
+        
+        // Use default target URL (/dashboard)
         super.onAuthenticationSuccess(request, response, authentication);
     }
 }

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -47,10 +47,10 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String returnTo = oauthLoginFlowService.consumeReturnTo(request.getSession(false));
         if (returnTo != null) {
             getRedirectStrategy().sendRedirect(request, response, returnTo);
+            // The default branch below clears these via super; clear here too so both paths behave consistently.
+            clearAuthenticationAttributes(request);
             return;
         }
-        
-        // Use default target URL (/dashboard)
         super.onAuthenticationSuccess(request, response, authentication);
     }
 }

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginHandlersTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuth2LoginHandlersTest.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,42 @@ class OAuth2LoginHandlersTest {
         assertThat(session.getAttribute(OAuthLoginRedirectSupport.SESSION_RETURN_TO_ATTRIBUTE)).isNull();
         assertThat(session.getAttribute("platformPrincipal")).isEqualTo(principal);
         assertThat(session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY)).isNotNull();
+    }
+
+    /**
+     * Regression test: when an unauthenticated client hits a protected API endpoint, Spring Security
+     * caches that request. With {@code SavedRequestAwareAuthenticationSuccessHandler} the post-login
+     * redirect would resolve to the cached API URL, leaving the user staring at raw JSON instead of
+     * the dashboard. The handler must ignore the saved request and fall back to the default target.
+     */
+    @Test
+    void successHandler_ignoresSavedApiRequestAndRedirectsToDefault() throws Exception {
+        OAuthLoginFlowService oauthLoginFlowService = mock(OAuthLoginFlowService.class);
+        OAuth2LoginSuccessHandler handler = new OAuth2LoginSuccessHandler(
+                new com.iflytek.skillhub.auth.session.PlatformSessionService(),
+                oauthLoginFlowService
+        );
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setRequestURI("/api/web/skills");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        // Simulate Spring Security saving the API request that triggered login.
+        new HttpSessionRequestCache().saveRequest(request, response);
+
+        var principal = new com.iflytek.skillhub.auth.rbac.PlatformPrincipal(
+                "user-1", "User", "user@example.com", null, "github", Set.of()
+        );
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                new DefaultOAuth2User(List.of(), Map.of("platformPrincipal", principal, "login", "user"), "login"),
+                null,
+                List.of()
+        );
+        org.mockito.Mockito.when(oauthLoginFlowService.consumeReturnTo(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(null);
+
+        handler.onAuthenticationSuccess(request, response, authentication);
+
+        assertThat(response.getRedirectedUrl()).isEqualTo("/dashboard");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- What changed?

Replace SavedRequestAwareAuthenticationSuccessHandler with SimpleUrlAuthenticationSuccessHandler to prevent redirecting to saved API requests after OAuth2 login.

- Why is this needed?

Previously, when a user accessed a protected API endpoint (e.g., /api/web/skills) without authentication, Spring Security would save that request. After OAuth2 login, the handler would redirect back to the API endpoint instead of the dashboard.

Now the handler only uses:
- returnTo parameter from session (if present)
- default target URL (/dashboard) as fallback

## Validation

- [x] Backend tests passed
- [x] Frontend typecheck/build passed
- [x] OpenAPI SDK regenerated or checked when API contracts changed
- [x] Smoke test run when relevant

Commands run:

```bash
make test
```

## Risk

- User-facing impact:
- Deployment or migration impact:
- Rollback approach:

## Notes

- Related issue:
- Follow-up work:
- Docs or operator runbooks updated when behavior changed:
