### PR TITLE
Allow namespace admins to review their own submissions

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
@@ -28,7 +28,12 @@ public class ReviewPermissionChecker {
                              Map<Long, NamespaceRole> userNamespaceRoles,
                              Set<String> platformRoles) {
         if (task.getSubmittedBy().equals(userId)) {
-            return platformRoles.contains("SUPER_ADMIN");
+            if (platformRoles.contains("SUPER_ADMIN")) {
+                return true;
+            }
+            NamespaceRole role = userNamespaceRoles.get(task.getNamespaceId());
+            return hasPlatformReviewRole(platformRoles)
+                    && (role == NamespaceRole.ADMIN || role == NamespaceRole.OWNER);
         }
         return canReviewNamespace(task.getNamespaceId(), namespaceType, userNamespaceRoles, platformRoles);
     }

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewPermissionCheckerTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewPermissionCheckerTest.java
@@ -26,11 +26,35 @@ class ReviewPermissionCheckerTest {
     }
 
     @Test
-    void skillAdminCannotReviewOwnSubmission() {
+    void skillAdminCannotReviewOwnSubmissionWithoutNamespaceRole() {
         String userId = "user-1";
         ReviewTask task = new ReviewTask(1L, 10L, userId);
         assertFalse(checker.canReview(task, userId,
                 NamespaceType.TEAM, Map.of(), Set.of("SKILL_ADMIN")));
+    }
+
+    @Test
+    void skillAdminNamespaceAdminCanReviewOwnSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertTrue(checker.canReview(task, userId,
+                NamespaceType.TEAM, Map.of(10L, NamespaceRole.ADMIN), Set.of("SKILL_ADMIN")));
+    }
+
+    @Test
+    void skillAdminNamespaceOwnerCanReviewOwnSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertTrue(checker.canReview(task, userId,
+                NamespaceType.TEAM, Map.of(10L, NamespaceRole.OWNER), Set.of("SKILL_ADMIN")));
+    }
+
+    @Test
+    void skillAdminNamespaceMemberCannotReviewOwnSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertFalse(checker.canReview(task, userId,
+                NamespaceType.TEAM, Map.of(10L, NamespaceRole.MEMBER), Set.of("SKILL_ADMIN")));
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes #276. Namespace admins couldn't approve skills in their own namespaces even though they had the SKILL_ADMIN role. The old code only let SUPER_ADMIN bypass the "can't review your own submission" rule.

Fixed it by adding a check for namespace admin/owner roles. Now you can approve your own submission if you're an admin or owner in that namespace and have the reviewer role. Makes sense since you should be able to handle your own namespace.

## Type of change
- Bug fix

## How has this been tested?
Updated the test to be more specific about what it checks. Added two new tests for admins and owners being able to review their own submissions.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have tested this locally