### PR TITLE
fix(review): allow namespace admins to review own submissions

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SecurityAuditController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SecurityAuditController.java
@@ -103,6 +103,10 @@ public class SecurityAuditController extends BaseApiController {
             return true;
         }
         Map<Long, NamespaceRole> namespaceRoles = userNsRoles != null ? userNsRoles : Map.of();
+        NamespaceRole namespaceRole = namespaceRoles.get(skill.getNamespaceId());
+        if (namespaceRole == NamespaceRole.ADMIN || namespaceRole == NamespaceRole.OWNER) {
+            return true;
+        }
         return visibilityChecker.canAccess(skill, principal.userId(), namespaceRoles);
     }
 

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/SecurityAuditControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/SecurityAuditControllerTest.java
@@ -1,6 +1,8 @@
 package com.iflytek.skillhub.controller.portal;
 
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
+import com.iflytek.skillhub.domain.namespace.NamespaceMember;
+import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
 import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.security.ScannerType;
 import com.iflytek.skillhub.domain.security.SecurityAudit;
@@ -55,6 +57,9 @@ class SecurityAuditControllerTest {
 
     @MockBean
     private ScanTaskProducer scanTaskProducer;
+
+    @MockBean
+    private NamespaceMemberRepository namespaceMemberRepository;
 
     @Test
     void getSecurityAudit_returnsAuditPayload() throws Exception {
@@ -127,6 +132,29 @@ class SecurityAuditControllerTest {
         mockMvc.perform(get("/api/v1/skills/8/versions/42/security-audit").with(auth("viewer-1")))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(403));
+    }
+
+    @Test
+    void getSecurityAudit_allowsNamespaceAdminForPendingUnpublishedSkill() throws Exception {
+        SecurityAudit audit = new SecurityAudit(42L, ScannerType.SKILL_SCANNER);
+        setField(audit, "id", 9L);
+        audit.setScanId("scan-team-admin");
+        audit.setVerdict(SecurityVerdict.SAFE);
+        audit.setIsSafe(true);
+        audit.setMaxSeverity("LOW");
+        audit.setFindingsCount(0);
+        given(skillVersionRepository.findById(42L)).willReturn(java.util.Optional.of(skillVersion(42L, 8L)));
+        given(skillRepository.findById(8L)).willReturn(java.util.Optional.of(skill(8L, "owner-1")));
+        given(securityAuditRepository.findLatestActiveByVersionId(42L)).willReturn(List.of(audit));
+        given(namespaceMemberRepository.findByUserId("team-admin"))
+                .willReturn(List.of(new NamespaceMember(5L, "team-admin", NamespaceRole.ADMIN)));
+
+        mockMvc.perform(get("/api/v1/skills/8/versions/42/security-audit")
+                        .with(auth("team-admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.data[0].id").value(9L))
+                .andExpect(jsonPath("$.data[0].scanId").value("scan-team-admin"));
     }
 
     private RequestPostProcessor auth(String userId) {

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/SkillApprovalVisibilityFlowIntegrationTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/SkillApprovalVisibilityFlowIntegrationTest.java
@@ -7,6 +7,7 @@ import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.auth.rbac.RbacService;
 import com.iflytek.skillhub.domain.namespace.Namespace;
 import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
+import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.namespace.NamespaceRepository;
 import com.iflytek.skillhub.domain.namespace.NamespaceType;
 import com.iflytek.skillhub.domain.review.ReviewTask;
@@ -128,6 +129,37 @@ class SkillApprovalVisibilityFlowIntegrationTest {
         assertThat(indexedDocument.getTitle()).isEqualTo(graph.skill().getDisplayName());
     }
 
+    @Test
+    void namespaceAdminCanApproveOwnTeamReview() throws Exception {
+        PendingSkillGraph graph = createPendingTeamSkill("team-admin");
+        when(namespaceMemberRepository.findByUserId("team-admin"))
+                .thenReturn(List.of(new com.iflytek.skillhub.domain.namespace.NamespaceMember(
+                        graph.namespace().getId(),
+                        "team-admin",
+                        NamespaceRole.ADMIN
+                )));
+        when(rbacService.getUserRoleCodes("team-admin")).thenReturn(Set.of());
+
+        mockMvc.perform(post("/api/v1/reviews/" + graph.reviewTask().getId() + "/approve")
+                        .contentType("application/json")
+                        .content("{\"comment\":\"approved by namespace admin\"}")
+                        .with(authentication(apiAuth("team-admin")))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.data.id").value(graph.reviewTask().getId()))
+                .andExpect(jsonPath("$.data.status").value("APPROVED"))
+                .andExpect(jsonPath("$.data.reviewedBy").value("team-admin"))
+                .andExpect(jsonPath("$.data.reviewComment").value("approved by namespace admin"));
+
+        Skill savedSkill = skillRepository.findById(graph.skill().getId()).orElseThrow();
+        SkillVersion savedVersion = skillVersionRepository.findById(graph.version().getId()).orElseThrow();
+
+        assertThat(savedSkill.getLatestVersionId()).isEqualTo(graph.version().getId());
+        assertThat(savedVersion.getStatus()).isEqualTo(SkillVersionStatus.PUBLISHED);
+        assertThat(savedVersion.getPublishedAt()).isNotNull();
+    }
+
     private PendingSkillGraph createPendingGlobalSkill(String ownerId) {
         String suffix = UUID.randomUUID().toString().substring(0, 8);
 
@@ -138,6 +170,31 @@ class SkillApprovalVisibilityFlowIntegrationTest {
         Skill skill = new Skill(namespace.getId(), "approval-skill-" + suffix, ownerId, SkillVisibility.PUBLIC);
         skill.setDisplayName("Approval Skill " + suffix);
         skill.setSummary("Visible in search only after approval.");
+        skill.setCreatedBy(ownerId);
+        skill.setUpdatedBy(ownerId);
+        skill = skillRepository.save(skill);
+        skillRepository.flush();
+
+        SkillVersion version = new SkillVersion(skill.getId(), "1.0.0", ownerId);
+        version.setStatus(SkillVersionStatus.PENDING_REVIEW);
+        version.setRequestedVisibility(SkillVisibility.PUBLIC);
+        version = skillVersionRepository.save(version);
+        skillVersionRepository.flush();
+
+        ReviewTask reviewTask = reviewTaskJpaRepository.saveAndFlush(new ReviewTask(version.getId(), namespace.getId(), ownerId));
+
+        return new PendingSkillGraph(namespace, skill, version, reviewTask);
+    }
+
+    private PendingSkillGraph createPendingTeamSkill(String ownerId) {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+
+        Namespace namespace = new Namespace("team-approval-" + suffix, "Team Approval " + suffix, ownerId);
+        namespace = namespaceRepository.save(namespace);
+
+        Skill skill = new Skill(namespace.getId(), "approval-skill-" + suffix, ownerId, SkillVisibility.PUBLIC);
+        skill.setDisplayName("Approval Skill " + suffix);
+        skill.setSummary("Team namespace self-review should be allowed for namespace admins.");
         skill.setCreatedBy(ownerId);
         skill.setUpdatedBy(ownerId);
         skill = skillRepository.save(skill);

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
@@ -28,12 +28,8 @@ public class ReviewPermissionChecker {
                              Map<Long, NamespaceRole> userNamespaceRoles,
                              Set<String> platformRoles) {
         if (task.getSubmittedBy().equals(userId)) {
-            if (platformRoles.contains("SUPER_ADMIN")) {
-                return true;
-            }
-            NamespaceRole role = userNamespaceRoles.get(task.getNamespaceId());
-            return hasPlatformReviewRole(platformRoles)
-                    && (role == NamespaceRole.ADMIN || role == NamespaceRole.OWNER);
+            return platformRoles.contains("SUPER_ADMIN")
+                    || canSelfReviewNamespace(task.getNamespaceId(), namespaceType, userNamespaceRoles);
         }
         return canReviewNamespace(task.getNamespaceId(), namespaceType, userNamespaceRoles, platformRoles);
     }
@@ -139,5 +135,16 @@ public class ReviewPermissionChecker {
     private boolean hasPlatformReviewRole(Set<String> platformRoles) {
         return platformRoles.contains("SKILL_ADMIN")
                 || platformRoles.contains("SUPER_ADMIN");
+    }
+
+    private boolean canSelfReviewNamespace(Long namespaceId,
+                                           NamespaceType namespaceType,
+                                           Map<Long, NamespaceRole> userNamespaceRoles) {
+        if (namespaceType == NamespaceType.GLOBAL) {
+            return false;
+        }
+
+        NamespaceRole role = userNamespaceRoles.get(namespaceId);
+        return role == NamespaceRole.OWNER || role == NamespaceRole.ADMIN;
     }
 }

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
@@ -28,7 +28,12 @@ public class ReviewPermissionChecker {
                              Map<Long, NamespaceRole> userNamespaceRoles,
                              Set<String> platformRoles) {
         if (task.getSubmittedBy().equals(userId)) {
-            return platformRoles.contains("SUPER_ADMIN");
+            if (platformRoles.contains("SUPER_ADMIN")) {
+                return true;
+            }
+            NamespaceRole role = userNamespaceRoles.get(task.getNamespaceId());
+            return hasPlatformReviewRole(platformRoles)
+                    && (role == NamespaceRole.ADMIN || role == NamespaceRole.OWNER);
         }
         return canReviewNamespace(task.getNamespaceId(), namespaceType, userNamespaceRoles, platformRoles);
     }

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewPermissionCheckerTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewPermissionCheckerTest.java
@@ -82,6 +82,24 @@ class ReviewPermissionCheckerTest {
     }
 
     @Test
+    void teamAdminCanReviewOwnTeamSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertTrue(checker.canReview(task, userId,
+                NamespaceType.TEAM,
+                Map.of(10L, NamespaceRole.ADMIN), Set.of()));
+    }
+
+    @Test
+    void teamOwnerCanReviewOwnTeamSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertTrue(checker.canReview(task, userId,
+                NamespaceType.TEAM,
+                Map.of(10L, NamespaceRole.OWNER), Set.of()));
+    }
+
+    @Test
     void teamAdminCanReviewTeamSkill() {
         ReviewTask task = new ReviewTask(1L, 10L, "user-2");
         assertTrue(checker.canReview(task, "user-1",

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewPermissionCheckerTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewPermissionCheckerTest.java
@@ -26,11 +26,35 @@ class ReviewPermissionCheckerTest {
     }
 
     @Test
-    void skillAdminCannotReviewOwnSubmission() {
+    void skillAdminCannotReviewOwnSubmissionWithoutNamespaceRole() {
         String userId = "user-1";
         ReviewTask task = new ReviewTask(1L, 10L, userId);
         assertFalse(checker.canReview(task, userId,
                 NamespaceType.TEAM, Map.of(), Set.of("SKILL_ADMIN")));
+    }
+
+    @Test
+    void skillAdminNamespaceAdminCanReviewOwnSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertTrue(checker.canReview(task, userId,
+                NamespaceType.TEAM, Map.of(10L, NamespaceRole.ADMIN), Set.of("SKILL_ADMIN")));
+    }
+
+    @Test
+    void skillAdminNamespaceOwnerCanReviewOwnSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertTrue(checker.canReview(task, userId,
+                NamespaceType.TEAM, Map.of(10L, NamespaceRole.OWNER), Set.of("SKILL_ADMIN")));
+    }
+
+    @Test
+    void skillAdminNamespaceMemberCannotReviewOwnSubmission() {
+        String userId = "user-1";
+        ReviewTask task = new ReviewTask(1L, 10L, userId);
+        assertFalse(checker.canReview(task, userId,
+                NamespaceType.TEAM, Map.of(10L, NamespaceRole.MEMBER), Set.of("SKILL_ADMIN")));
     }
 
     @Test

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/ReviewServiceTest.java
@@ -484,6 +484,46 @@ class ReviewServiceTest {
         }
 
         @Test
+        void namespaceAdminCanApproveOwnSubmission() {
+            ReviewTask task = createPendingReviewTask();
+            Namespace ns = createTeamNamespace();
+            SkillVersion sv = createPendingReviewSkillVersion();
+            Skill skill = createSkill();
+
+            when(reviewTaskRepository.findById(REVIEW_TASK_ID)).thenReturn(Optional.of(task));
+            when(namespaceRepository.findById(NAMESPACE_ID)).thenReturn(Optional.of(ns));
+            when(permissionChecker.canReview(
+                    eq(task),
+                    eq(USER_ID),
+                    eq(ns.getType()),
+                    eq(Map.of(NAMESPACE_ID, NamespaceRole.ADMIN)),
+                    eq(Set.of())))
+                    .thenReturn(true);
+            when(reviewTaskRepository.updateStatusWithVersion(
+                    REVIEW_TASK_ID,
+                    ReviewTaskStatus.APPROVED,
+                    USER_ID,
+                    "self approved as namespace admin",
+                    task.getVersion()))
+                    .thenReturn(1);
+            when(skillVersionRepository.findById(SKILL_VERSION_ID)).thenReturn(Optional.of(sv));
+            when(skillRepository.findById(SKILL_ID)).thenReturn(Optional.of(skill));
+            when(skillRepository.findByNamespaceIdAndSlug(NAMESPACE_ID, "my-skill")).thenReturn(List.of(skill));
+            when(reviewTaskRepository.findById(REVIEW_TASK_ID)).thenReturn(Optional.of(task));
+
+            ReviewTask result = reviewService.approveReview(
+                    REVIEW_TASK_ID,
+                    USER_ID,
+                    "self approved as namespace admin",
+                    Map.of(NAMESPACE_ID, NamespaceRole.ADMIN),
+                    Set.of());
+
+            assertNotNull(result);
+            assertEquals(SkillVersionStatus.PUBLISHED, sv.getStatus());
+            assertEquals(USER_ID, skill.getUpdatedBy());
+        }
+
+        @Test
         void shouldThrowOnConcurrentModification() {
             ReviewTask task = createPendingReviewTask();
             Namespace ns = createTeamNamespace();
@@ -597,6 +637,43 @@ class ReviewServiceTest {
 
             ReviewTask result = reviewService.rejectReview(
                     REVIEW_TASK_ID, USER_ID, "self rejected", Map.of(), Set.of("SUPER_ADMIN"));
+
+            assertNotNull(result);
+            assertEquals(SkillVersionStatus.REJECTED, sv.getStatus());
+        }
+
+        @Test
+        void namespaceAdminCanRejectOwnSubmission() {
+            ReviewTask task = createPendingReviewTask();
+            Namespace ns = createTeamNamespace();
+            SkillVersion sv = createPendingReviewSkillVersion();
+
+            when(reviewTaskRepository.findById(REVIEW_TASK_ID)).thenReturn(Optional.of(task));
+            when(namespaceRepository.findById(NAMESPACE_ID)).thenReturn(Optional.of(ns));
+            when(permissionChecker.canReview(
+                    eq(task),
+                    eq(USER_ID),
+                    eq(ns.getType()),
+                    eq(Map.of(NAMESPACE_ID, NamespaceRole.ADMIN)),
+                    eq(Set.of())))
+                    .thenReturn(true);
+            when(reviewTaskRepository.updateStatusWithVersion(
+                    REVIEW_TASK_ID,
+                    ReviewTaskStatus.REJECTED,
+                    USER_ID,
+                    "self rejected as namespace admin",
+                    task.getVersion()))
+                    .thenReturn(1);
+            when(skillVersionRepository.findById(SKILL_VERSION_ID)).thenReturn(Optional.of(sv));
+            when(skillRepository.findById(SKILL_ID)).thenReturn(Optional.of(createSkill()));
+            when(reviewTaskRepository.findById(REVIEW_TASK_ID)).thenReturn(Optional.of(task));
+
+            ReviewTask result = reviewService.rejectReview(
+                    REVIEW_TASK_ID,
+                    USER_ID,
+                    "self rejected as namespace admin",
+                    Map.of(NAMESPACE_ID, NamespaceRole.ADMIN),
+                    Set.of());
 
             assertNotNull(result);
             assertEquals(SkillVersionStatus.REJECTED, sv.getStatus());

--- a/web/e2e/helpers/review-seed.ts
+++ b/web/e2e/helpers/review-seed.ts
@@ -1,0 +1,64 @@
+import type { Browser, Page, TestInfo } from '@playwright/test'
+import { loginWithCredentials, registerSession } from './session'
+import { E2eTestDataBuilder, type SeededReviewData } from './test-data-builder'
+
+function getOptionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim()
+  return value ? value : undefined
+}
+
+function adminCredentials() {
+  return {
+    username: getOptionalEnv('E2E_ADMIN_USERNAME') ?? getOptionalEnv('BOOTSTRAP_ADMIN_USERNAME') ?? 'admin',
+    password: getOptionalEnv('E2E_ADMIN_PASSWORD') ?? getOptionalEnv('BOOTSTRAP_ADMIN_PASSWORD') ?? 'ChangeMe!2026',
+  }
+}
+
+function matchCandidateUsername(
+  candidate: { userId: string; displayName: string; email?: string },
+  username: string,
+) {
+  return candidate.userId === username
+    || candidate.displayName === username
+    || candidate.email === `${username}@example.test`
+}
+
+export async function createNamespaceReviewData(
+  browser: Browser,
+  page: Page,
+  testInfo: TestInfo,
+): Promise<SeededReviewData & { reviewTaskId: number; cleanup: () => Promise<void> }> {
+  const credentials = await registerSession(page, testInfo, { allowMockSession: false })
+  const builder = new E2eTestDataBuilder(page, testInfo)
+  await builder.init()
+
+  const adminContext = await browser.newContext()
+  const adminPage = await adminContext.newPage()
+  const adminBuilder = new E2eTestDataBuilder(adminPage, testInfo)
+
+  await loginWithCredentials(adminPage, adminCredentials(), testInfo)
+  await adminBuilder.init()
+
+  const namespace = await adminBuilder.createNamespace('e2e-team')
+  const candidates = await adminBuilder.searchNamespaceMemberCandidates(namespace.slug, credentials.username)
+  const matchedCandidate = candidates.find((candidate) => matchCandidateUsername(candidate, credentials.username)) ?? candidates[0]
+
+  if (!matchedCandidate) {
+    throw new Error(`No namespace member candidate found for review actor ${credentials.username}`)
+  }
+
+  await adminBuilder.addNamespaceMember(namespace.slug, matchedCandidate.userId, 'ADMIN')
+  const skill = await builder.publishSkill(namespace.slug)
+  const reviewTaskId = await adminBuilder.waitForPendingReview(namespace.slug, skill.slug, skill.version)
+
+  return {
+    namespace,
+    skill,
+    reviewTaskId,
+    cleanup: async () => {
+      await builder.cleanup()
+      await adminBuilder.cleanup()
+      await adminContext.close()
+    },
+  }
+}

--- a/web/e2e/helpers/session.ts
+++ b/web/e2e/helpers/session.ts
@@ -10,6 +10,10 @@ export interface TestCredentials {
   username: string
 }
 
+interface RegisterSessionOptions {
+  allowMockSession?: boolean
+}
+
 interface SessionSnapshot {
   username: string
   cookies: Array<{
@@ -160,7 +164,7 @@ async function tryBootstrapMockSession(page: Page, worker: number): Promise<{ us
   return { username: 'local-user', password }
 }
 
-async function registerSessionOnce(page: Page, testInfo?: TestInfo) {
+async function registerSessionOnce(page: Page, testInfo?: TestInfo, options?: RegisterSessionOptions) {
   const worker = testInfo?.parallelIndex ?? 0
   const cached = cachedUserByWorker.get(worker)
   const username = usernameForWorker(testInfo)
@@ -175,9 +179,11 @@ async function registerSessionOnce(page: Page, testInfo?: TestInfo) {
     return { username: restored.username, password }
   }
 
-  const mockSession = await tryBootstrapMockSession(page, worker)
-  if (mockSession) {
-    return mockSession
+  if (options?.allowMockSession !== false) {
+    const mockSession = await tryBootstrapMockSession(page, worker)
+    if (mockSession) {
+      return mockSession
+    }
   }
 
   // Prefer the known-good cached account to avoid repeated failed-logins on a fixed username.
@@ -317,12 +323,12 @@ async function createFreshSessionOnce(page: Page, testInfo?: TestInfo) {
   throw new Error(`Failed to create fresh e2e session for worker ${worker}`)
 }
 
-export async function registerSession(page: Page, testInfo?: TestInfo) {
+export async function registerSession(page: Page, testInfo?: TestInfo, options?: RegisterSessionOptions) {
   let lastError: unknown
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
-      return await registerSessionOnce(page, testInfo)
+      return await registerSessionOnce(page, testInfo, options)
     } catch (error) {
       lastError = error
       if (attempt < 2) {

--- a/web/e2e/helpers/test-data-builder.ts
+++ b/web/e2e/helpers/test-data-builder.ts
@@ -34,6 +34,13 @@ interface ReviewTaskSummary {
   version: string
 }
 
+interface NamespaceCandidate {
+  userId: string
+  displayName: string
+  email?: string
+  status: string
+}
+
 interface ApiEnvelope<T> {
   code: number
   msg: string
@@ -44,6 +51,8 @@ interface ApiFailure extends Error {
   status?: number
   code?: number
 }
+
+const cleanupTimeoutMs = process.env.CI ? 8_000 : 5_000
 
 export interface SeedSkillOptions {
   name?: string
@@ -63,6 +72,24 @@ function asApiErrorBody(value: unknown): string {
 function uniqueSuffix(testInfo?: TestInfo): string {
   const worker = testInfo?.parallelIndex ?? 0
   return `${worker}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+async function runCleanupTaskWithTimeout(task: CleanupTask): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`cleanup task timed out after ${cleanupTimeoutMs}ms`))
+    }, cleanupTimeoutMs)
+
+    void task()
+      .then(() => {
+        clearTimeout(timeout)
+        resolve()
+      })
+      .catch((error) => {
+        clearTimeout(timeout)
+        reject(error)
+      })
+  })
 }
 
 function buildSkillPackageContent(suffix: string, options?: SeedSkillOptions) {
@@ -166,7 +193,7 @@ export class E2eTestDataBuilder {
   async cleanup(): Promise<void> {
     for (let i = this.cleanupTasks.length - 1; i >= 0; i -= 1) {
       try {
-        await this.cleanupTasks[i]()
+        await runCleanupTaskWithTimeout(this.cleanupTasks[i])
       } catch {
         // Best-effort cleanup for E2E environments.
       }
@@ -230,6 +257,32 @@ export class E2eTestDataBuilder {
     }
     this.ensuredNamespace = writable
     return writable
+  }
+
+  async ensureReviewableNamespace(): Promise<SeededNamespace> {
+    if (this.ensuredNamespace && this.ensuredNamespace.slug !== 'global') {
+      return this.ensuredNamespace
+    }
+
+    try {
+      const created = await this.createNamespace('e2e-team')
+      this.ensuredNamespace = created
+      return created
+    } catch (error) {
+      const failure = error as ApiFailure
+      if (failure.status !== 403) {
+        throw error
+      }
+    }
+
+    const namespaces = await this.listMyNamespaces()
+    const reviewableNamespace = namespaces.find((item) => item.slug !== 'global')
+    if (!reviewableNamespace) {
+      throw new Error('No TEAM namespace available for review E2E data seeding')
+    }
+
+    this.ensuredNamespace = reviewableNamespace
+    return reviewableNamespace
   }
 
   private async getMySkillInNamespace(namespaceSlug: string): Promise<SeededSkill | null> {
@@ -350,6 +403,21 @@ export class E2eTestDataBuilder {
     )
   }
 
+  async searchNamespaceMemberCandidates(slug: string, search: string): Promise<NamespaceCandidate[]> {
+    const query = new URLSearchParams({ search })
+    return parseEnvelope<NamespaceCandidate[]>(
+      await this.request.get(`/api/web/namespaces/${encodeURIComponent(slug)}/member-candidates?${query.toString()}`),
+    )
+  }
+
+  async addNamespaceMember(slug: string, userId: string, role: 'MEMBER' | 'ADMIN' | 'OWNER' = 'MEMBER'): Promise<void> {
+    await parseEnvelope<{ userId: string; role: string }>(
+      await this.request.post(`/api/web/namespaces/${encodeURIComponent(slug)}/members`, {
+        data: { userId, role },
+      }),
+    )
+  }
+
   async publishSkill(namespaceSlug: string, options?: SeedSkillOptions): Promise<SeededSkill> {
     const unique = `${this.suffix}_${Math.random().toString(36).slice(2, 6)}`
     const zipBuffer = buildSkillPackageZipBuffer(unique, options)
@@ -384,7 +452,7 @@ export class E2eTestDataBuilder {
   }
 
   async createReviewData(): Promise<SeededReviewData> {
-    const namespace = await this.ensureWritableNamespace()
+    const namespace = await this.ensureReviewableNamespace()
     const skill = await this.publishSkill(namespace.slug)
     return { namespace, skill }
   }

--- a/web/e2e/helpers/test-data-builder.ts
+++ b/web/e2e/helpers/test-data-builder.ts
@@ -10,6 +10,11 @@ export interface SeededNamespace {
   id: number
   slug: string
   displayName: string
+  status?: string
+  type?: string
+  currentUserRole?: string
+  canUnfreeze?: boolean
+  canRestore?: boolean
 }
 
 export interface SeededSkill {
@@ -234,6 +239,34 @@ export class E2eTestDataBuilder {
     )
   }
 
+  private isTeamNamespace(namespace: SeededNamespace): boolean {
+    return namespace.type === 'TEAM' || namespace.slug !== 'global'
+  }
+
+  private isActiveNamespace(namespace: SeededNamespace): boolean {
+    return namespace.status === 'ACTIVE'
+  }
+
+  private async activateNamespace(namespace: SeededNamespace): Promise<SeededNamespace | null> {
+    if (!this.isTeamNamespace(namespace)) {
+      return null
+    }
+
+    if (namespace.status === 'FROZEN' && namespace.canUnfreeze) {
+      return parseEnvelope<SeededNamespace>(
+        await this.request.post(`/api/web/namespaces/${encodeURIComponent(namespace.slug)}/unfreeze`),
+      )
+    }
+
+    if (namespace.status === 'ARCHIVED' && namespace.canRestore) {
+      return parseEnvelope<SeededNamespace>(
+        await this.request.post(`/api/web/namespaces/${encodeURIComponent(namespace.slug)}/restore`),
+      )
+    }
+
+    return null
+  }
+
   async ensureWritableNamespace(): Promise<SeededNamespace> {
     if (this.ensuredNamespace) {
       return this.ensuredNamespace
@@ -251,16 +284,38 @@ export class E2eTestDataBuilder {
     }
 
     const namespaces = await this.listMyNamespaces()
-    const writable = namespaces.find((item) => item.slug !== 'global') ?? namespaces[0]
-    if (!writable) {
-      throw new Error('No namespace available for e2e data seeding')
+    const activeTeam = namespaces.find((item) => this.isTeamNamespace(item) && this.isActiveNamespace(item))
+    if (activeTeam) {
+      this.ensuredNamespace = activeTeam
+      return activeTeam
     }
-    this.ensuredNamespace = writable
-    return writable
+
+    const activeFallback = namespaces.find((item) => this.isActiveNamespace(item))
+    if (activeFallback) {
+      this.ensuredNamespace = activeFallback
+      return activeFallback
+    }
+
+    const activatable = namespaces.find((item) =>
+      this.isTeamNamespace(item)
+      && ((item.status === 'FROZEN' && item.canUnfreeze) || (item.status === 'ARCHIVED' && item.canRestore)),
+    )
+    if (activatable) {
+      const activated = await this.activateNamespace(activatable)
+      if (activated) {
+        this.ensuredNamespace = activated
+        return activated
+      }
+    }
+
+    const summary = namespaces
+      .map((item) => `${item.slug}:${item.status ?? 'UNKNOWN'}`)
+      .join(', ')
+    throw new Error(`No active writable namespace available for e2e data seeding [${summary}]`)
   }
 
   async ensureReviewableNamespace(): Promise<SeededNamespace> {
-    if (this.ensuredNamespace && this.ensuredNamespace.slug !== 'global') {
+    if (this.ensuredNamespace && this.isTeamNamespace(this.ensuredNamespace) && this.isActiveNamespace(this.ensuredNamespace)) {
       return this.ensuredNamespace
     }
 
@@ -276,13 +331,28 @@ export class E2eTestDataBuilder {
     }
 
     const namespaces = await this.listMyNamespaces()
-    const reviewableNamespace = namespaces.find((item) => item.slug !== 'global')
-    if (!reviewableNamespace) {
-      throw new Error('No TEAM namespace available for review E2E data seeding')
+    const activeTeam = namespaces.find((item) => this.isTeamNamespace(item) && this.isActiveNamespace(item))
+    if (activeTeam) {
+      this.ensuredNamespace = activeTeam
+      return activeTeam
     }
 
-    this.ensuredNamespace = reviewableNamespace
-    return reviewableNamespace
+    const activatable = namespaces.find((item) =>
+      this.isTeamNamespace(item)
+      && ((item.status === 'FROZEN' && item.canUnfreeze) || (item.status === 'ARCHIVED' && item.canRestore)),
+    )
+    if (activatable) {
+      const activated = await this.activateNamespace(activatable)
+      if (activated) {
+        this.ensuredNamespace = activated
+        return activated
+      }
+    }
+
+    const summary = namespaces
+      .map((item) => `${item.slug}:${item.status ?? 'UNKNOWN'}`)
+      .join(', ')
+    throw new Error(`No TEAM namespace available for review E2E data seeding [${summary}]`)
   }
 
   private async getMySkillInNamespace(namespaceSlug: string): Promise<SeededSkill | null> {

--- a/web/e2e/namespace-review-detail-access.spec.ts
+++ b/web/e2e/namespace-review-detail-access.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test'
+import { setEnglishLocale } from './helpers/auth-fixtures'
+import { registerSession } from './helpers/session'
+import { E2eTestDataBuilder } from './helpers/test-data-builder'
+
+test.describe('Namespace Review Detail Access (Real API)', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await setEnglishLocale(page)
+    await registerSession(page, testInfo)
+  })
+
+  test('opens namespace review detail from the namespace review list', async ({ page }, testInfo) => {
+    const builder = new E2eTestDataBuilder(page, testInfo)
+    await builder.init()
+
+    try {
+      const seeded = await builder.createReviewData()
+
+      await page.goto(`/dashboard/namespaces/${seeded.namespace.slug}/reviews`)
+
+      await expect(page.getByRole('heading', { name: 'Namespace Reviews' })).toBeVisible()
+      await expect(page.getByText(`${seeded.namespace.slug}/${seeded.skill.slug}`)).toBeVisible()
+
+      await page.getByRole('link', { name: 'Open review' }).first().click()
+
+      await expect(page).toHaveURL(new RegExp(`/dashboard/namespaces/${seeded.namespace.slug}/reviews/\\d+$`))
+      await expect(page.getByRole('heading', { name: 'Review Detail' })).toBeVisible()
+      await expect(page.getByText(`${seeded.namespace.slug}/${seeded.skill.slug}`).first()).toBeVisible()
+    } finally {
+      await builder.cleanup()
+    }
+  })
+
+  test('redirects /dashboard/reviews to a namespace review page for namespace operators', async ({ page }, testInfo) => {
+    const builder = new E2eTestDataBuilder(page, testInfo)
+    await builder.init()
+
+    try {
+      await builder.createReviewData()
+
+      await page.goto('/dashboard/reviews')
+
+      await expect(page).toHaveURL(/\/dashboard\/namespaces\/.+\/reviews$/)
+      await expect(page.getByRole('heading', { name: 'Namespace Reviews' })).toBeVisible()
+    } finally {
+      await builder.cleanup()
+    }
+  })
+
+  test('redirects namespace review detail opened through the global detail route', async ({ page }, testInfo) => {
+    const builder = new E2eTestDataBuilder(page, testInfo)
+    await builder.init()
+
+    try {
+      const seeded = await builder.createReviewData()
+
+      await page.goto(`/dashboard/namespaces/${seeded.namespace.slug}/reviews`)
+      const reviewLink = page.getByRole('link', { name: 'Open review' }).first()
+      const reviewPath = await reviewLink.getAttribute('href')
+      const reviewId = reviewPath?.match(/\/reviews\/(\d+)$/)?.[1]
+      if (!reviewId) {
+        throw new Error(`Failed to resolve review id from href: ${reviewPath}`)
+      }
+
+      await page.goto(`/dashboard/reviews/${reviewId}`)
+
+      await expect(page).toHaveURL(new RegExp(`/dashboard/namespaces/${seeded.namespace.slug}/reviews/${reviewId}$`))
+      await expect(page.getByRole('heading', { name: 'Review Detail' })).toBeVisible()
+    } finally {
+      await builder.cleanup()
+    }
+  })
+})

--- a/web/e2e/namespace-review-detail-access.spec.ts
+++ b/web/e2e/namespace-review-detail-access.spec.ts
@@ -1,20 +1,18 @@
 import { expect, test } from '@playwright/test'
 import { setEnglishLocale } from './helpers/auth-fixtures'
-import { registerSession } from './helpers/session'
-import { E2eTestDataBuilder } from './helpers/test-data-builder'
+import { createNamespaceReviewData } from './helpers/review-seed'
 
 test.describe('Namespace Review Detail Access (Real API)', () => {
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.describe.configure({ timeout: 120_000 })
+
+  test.beforeEach(async ({ page }) => {
     await setEnglishLocale(page)
-    await registerSession(page, testInfo)
   })
 
-  test('opens namespace review detail from the namespace review list', async ({ page }, testInfo) => {
-    const builder = new E2eTestDataBuilder(page, testInfo)
-    await builder.init()
-
+  test('opens namespace review detail from the namespace review list', async ({ browser, page }, testInfo) => {
+    let seeded: Awaited<ReturnType<typeof createNamespaceReviewData>> | undefined
     try {
-      const seeded = await builder.createReviewData()
+      seeded = await createNamespaceReviewData(browser, page, testInfo)
 
       await page.goto(`/dashboard/namespaces/${seeded.namespace.slug}/reviews`)
 
@@ -27,47 +25,35 @@ test.describe('Namespace Review Detail Access (Real API)', () => {
       await expect(page.getByRole('heading', { name: 'Review Detail' })).toBeVisible()
       await expect(page.getByText(`${seeded.namespace.slug}/${seeded.skill.slug}`).first()).toBeVisible()
     } finally {
-      await builder.cleanup()
+      await seeded?.cleanup()
     }
   })
 
-  test('redirects /dashboard/reviews to a namespace review page for namespace operators', async ({ page }, testInfo) => {
-    const builder = new E2eTestDataBuilder(page, testInfo)
-    await builder.init()
-
+  test('redirects /dashboard/reviews to a namespace review page for namespace operators', async ({ browser, page }, testInfo) => {
+    let seeded: Awaited<ReturnType<typeof createNamespaceReviewData>> | undefined
     try {
-      await builder.createReviewData()
+      seeded = await createNamespaceReviewData(browser, page, testInfo)
 
       await page.goto('/dashboard/reviews')
 
       await expect(page).toHaveURL(/\/dashboard\/namespaces\/.+\/reviews$/)
       await expect(page.getByRole('heading', { name: 'Namespace Reviews' })).toBeVisible()
     } finally {
-      await builder.cleanup()
+      await seeded?.cleanup()
     }
   })
 
-  test('redirects namespace review detail opened through the global detail route', async ({ page }, testInfo) => {
-    const builder = new E2eTestDataBuilder(page, testInfo)
-    await builder.init()
-
+  test('redirects namespace review detail opened through the global detail route', async ({ browser, page }, testInfo) => {
+    let seeded: Awaited<ReturnType<typeof createNamespaceReviewData>> | undefined
     try {
-      const seeded = await builder.createReviewData()
+      seeded = await createNamespaceReviewData(browser, page, testInfo)
 
-      await page.goto(`/dashboard/namespaces/${seeded.namespace.slug}/reviews`)
-      const reviewLink = page.getByRole('link', { name: 'Open review' }).first()
-      const reviewPath = await reviewLink.getAttribute('href')
-      const reviewId = reviewPath?.match(/\/reviews\/(\d+)$/)?.[1]
-      if (!reviewId) {
-        throw new Error(`Failed to resolve review id from href: ${reviewPath}`)
-      }
+      await page.goto(`/dashboard/reviews/${seeded.reviewTaskId}`)
 
-      await page.goto(`/dashboard/reviews/${reviewId}`)
-
-      await expect(page).toHaveURL(new RegExp(`/dashboard/namespaces/${seeded.namespace.slug}/reviews/${reviewId}$`))
+      await expect(page).toHaveURL(new RegExp(`/dashboard/namespaces/${seeded.namespace.slug}/reviews/${seeded.reviewTaskId}$`))
       await expect(page.getByRole('heading', { name: 'Review Detail' })).toBeVisible()
     } finally {
-      await builder.cleanup()
+      await seeded?.cleanup()
     }
   })
 })

--- a/web/e2e/namespace-reviews-data.spec.ts
+++ b/web/e2e/namespace-reviews-data.spec.ts
@@ -1,26 +1,24 @@
 import { expect, test } from '@playwright/test'
 import { setEnglishLocale } from './helpers/auth-fixtures'
-import { registerSession } from './helpers/session'
-import { E2eTestDataBuilder } from './helpers/test-data-builder'
+import { createNamespaceReviewData } from './helpers/review-seed'
 
 test.describe('Namespace Reviews Data (Real API)', () => {
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.describe.configure({ timeout: 120_000 })
+
+  test.beforeEach(async ({ page }) => {
     await setEnglishLocale(page)
-    await registerSession(page, testInfo)
   })
 
-  test('opens namespace reviews page with seeded review data context', async ({ page }, testInfo) => {
-    const builder = new E2eTestDataBuilder(page, testInfo)
-    await builder.init()
-
+  test('opens namespace reviews page with seeded review data context', async ({ browser, page }, testInfo) => {
+    let seeded: Awaited<ReturnType<typeof createNamespaceReviewData>> | undefined
     try {
-      const seeded = await builder.createReviewData()
+      seeded = await createNamespaceReviewData(browser, page, testInfo)
       await page.goto(`/dashboard/namespaces/${seeded.namespace.slug}/reviews`)
 
       await expect(page.getByRole('heading', { name: 'Namespace Reviews' })).toBeVisible()
       await expect(page.getByText(`Review tasks for ${seeded.namespace.displayName}`)).toBeVisible()
     } finally {
-      await builder.cleanup()
+      await seeded?.cleanup()
     }
   })
 })

--- a/web/e2e/publish-flow-ui.spec.ts
+++ b/web/e2e/publish-flow-ui.spec.ts
@@ -40,8 +40,8 @@ test.describe('Publish Flow UI (Real API)', () => {
       await expect(confirmButton).toBeEnabled()
       await confirmButton.click()
 
-      await expect(page).toHaveURL(/\/dashboard\/skills$/, { timeout: 90_000 })
-      await expect(page.getByRole('heading', { name: 'My Skills' })).toBeVisible({ timeout: 90_000 })
+      const toastTitle = page.getByText(/Published Successfully|Submitted for Review/)
+      await expect(toastTitle).toBeVisible({ timeout: 90_000 })
     } finally {
       await builder.cleanup()
     }

--- a/web/e2e/publish-flow-ui.spec.ts
+++ b/web/e2e/publish-flow-ui.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import path from 'node:path'
 import { setEnglishLocale } from './helpers/auth-fixtures'
 import { registerSession } from './helpers/session'
 import { E2eTestDataBuilder } from './helpers/test-data-builder'
@@ -20,11 +21,27 @@ test.describe('Publish Flow UI (Real API)', () => {
       await page.goto('/dashboard/publish')
       await expect(page.getByRole('heading', { name: 'Publish Skill' })).toBeVisible()
 
-      await page.locator('#namespace').click()
-      await page.getByText(new RegExp(`\\(@${namespace.slug}\\)`)).first().click()
+      const namespaceTrigger = page.locator('#namespace')
+      await expect(namespaceTrigger).toBeVisible()
+      await namespaceTrigger.click()
+      const namespaceOption = page.getByRole('option', {
+        name: new RegExp(`\\(@${namespace.slug}\\)`),
+      }).first()
+      await expect(namespaceOption).toBeVisible()
+      await namespaceOption.evaluate((element: HTMLElement) => {
+        element.scrollIntoView({ block: 'center' })
+        element.click()
+      })
+      await expect(namespaceTrigger).toContainText(`@${namespace.slug}`)
 
       await page.locator('input[type="file"]').setInputFiles(packagePath)
-      await page.getByRole('button', { name: 'Confirm Publish' }).click()
+      await expect(page.getByText(path.basename(packagePath))).toBeVisible()
+      const confirmButton = page.getByRole('button', { name: 'Confirm Publish' })
+      await expect(confirmButton).toBeEnabled()
+      await Promise.all([
+        page.waitForURL('**/dashboard/skills'),
+        confirmButton.click(),
+      ])
 
       await expect(page).toHaveURL('/dashboard/skills')
       await expect(page.getByRole('heading', { name: 'My Skills' })).toBeVisible()

--- a/web/e2e/publish-flow-ui.spec.ts
+++ b/web/e2e/publish-flow-ui.spec.ts
@@ -6,6 +6,7 @@ import { E2eTestDataBuilder } from './helpers/test-data-builder'
 
 interface PublishEnvelope {
   code: number
+  msg?: string
   data: {
     namespace: string
     slug: string
@@ -51,14 +52,14 @@ test.describe('Publish Flow UI (Real API)', () => {
       const publishResponsePromise = page.waitForResponse(
         (response) =>
           response.request().method() === 'POST'
-          && response.url().includes(`/api/web/skills/${encodeURIComponent(namespace.slug)}/publish`)
-          && response.status() === 200,
+          && response.url().includes(`/api/web/skills/${encodeURIComponent(namespace.slug)}/publish`),
         { timeout: 90_000 },
       )
       await confirmButton.click()
       const publishResponse = await publishResponsePromise
       const publishBody = await publishResponse.json() as PublishEnvelope
 
+      expect(publishResponse.status(), `publish failed: ${publishBody.msg ?? 'unknown error'}`).toBe(200)
       expect(publishBody.code).toBe(0)
       expect(publishBody.data.namespace).toBe(namespace.slug)
 

--- a/web/e2e/publish-flow-ui.spec.ts
+++ b/web/e2e/publish-flow-ui.spec.ts
@@ -4,6 +4,15 @@ import { setEnglishLocale } from './helpers/auth-fixtures'
 import { registerSession } from './helpers/session'
 import { E2eTestDataBuilder } from './helpers/test-data-builder'
 
+interface PublishEnvelope {
+  code: number
+  data: {
+    namespace: string
+    slug: string
+    version: string
+  }
+}
+
 test.describe('Publish Flow UI (Real API)', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     await setEnglishLocale(page)
@@ -16,7 +25,8 @@ test.describe('Publish Flow UI (Real API)', () => {
 
     try {
       const namespace = await builder.ensureWritableNamespace()
-      const packagePath = builder.createSkillPackageFile()
+      const skillName = `publish-ui-${Date.now().toString(36)}`
+      const packagePath = builder.createSkillPackageFile({ name: skillName })
 
       await page.goto('/dashboard/publish')
       await expect(page.getByRole('heading', { name: 'Publish Skill' })).toBeVisible()
@@ -38,10 +48,25 @@ test.describe('Publish Flow UI (Real API)', () => {
       await expect(page.getByText(path.basename(packagePath))).toBeVisible()
       const confirmButton = page.getByRole('button', { name: 'Confirm Publish' })
       await expect(confirmButton).toBeEnabled()
+      const publishResponsePromise = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST'
+          && response.url().includes(`/api/web/skills/${encodeURIComponent(namespace.slug)}/publish`)
+          && response.status() === 200,
+        { timeout: 90_000 },
+      )
       await confirmButton.click()
+      const publishResponse = await publishResponsePromise
+      const publishBody = await publishResponse.json() as PublishEnvelope
 
-      const toastTitle = page.getByText(/Published Successfully|Submitted for Review/)
-      await expect(toastTitle).toBeVisible({ timeout: 90_000 })
+      expect(publishBody.code).toBe(0)
+      expect(publishBody.data.namespace).toBe(namespace.slug)
+
+      await page.goto('/dashboard/skills')
+      await expect(page.getByRole('heading', { name: 'My Skills' })).toBeVisible({ timeout: 30_000 })
+      await expect(page.getByRole('heading', { name: skillName, exact: true })).toBeVisible({ timeout: 30_000 })
+      await expect(page.getByText(`@${publishBody.data.namespace}`).first()).toBeVisible()
+      await expect(page.getByText(`v${publishBody.data.version}`).first()).toBeVisible()
     } finally {
       await builder.cleanup()
     }

--- a/web/e2e/publish-flow-ui.spec.ts
+++ b/web/e2e/publish-flow-ui.spec.ts
@@ -38,13 +38,10 @@ test.describe('Publish Flow UI (Real API)', () => {
       await expect(page.getByText(path.basename(packagePath))).toBeVisible()
       const confirmButton = page.getByRole('button', { name: 'Confirm Publish' })
       await expect(confirmButton).toBeEnabled()
-      await Promise.all([
-        page.waitForURL('**/dashboard/skills'),
-        confirmButton.click(),
-      ])
+      await confirmButton.click()
 
-      await expect(page).toHaveURL('/dashboard/skills')
-      await expect(page.getByRole('heading', { name: 'My Skills' })).toBeVisible()
+      await expect(page).toHaveURL(/\/dashboard\/skills$/, { timeout: 90_000 })
+      await expect(page.getByRole('heading', { name: 'My Skills' })).toBeVisible({ timeout: 90_000 })
     } finally {
       await builder.cleanup()
     }

--- a/web/e2e/search-card-interaction.spec.ts
+++ b/web/e2e/search-card-interaction.spec.ts
@@ -30,38 +30,61 @@ async function waitForCards(page: Page) {
 
   const keyword = basicSeed?.keyword
   const encodedKeyword = keyword ? encodeURIComponent(keyword) : null
+  let reloaded = false
 
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    await page.waitForLoadState('networkidle')
+  const waitForMatchingResponse = async () => {
+    if (!encodedKeyword) {
+      return
+    }
+
+    await page.waitForResponse(async (response) => {
+      if (!response.url().includes('/api/web/skills?') || !response.url().includes(`q=${encodedKeyword}`)) {
+        return false
+      }
+      if (response.status() !== 200) {
+        return false
+      }
+
+      try {
+        const payload = await response.json() as { data?: { items?: Array<unknown> } }
+        return Array.isArray(payload.data?.items) && payload.data.items.length > 0
+      } catch {
+        return false
+      }
+    }, { timeout: 15_000 }).catch(() => null)
+  }
+
+  const waitForCardCount = async () => {
+    await expect.poll(
+      async () => cards.count(),
+      {
+        timeout: 20_000,
+        intervals: [250, 500, 1_000, 2_000],
+      },
+    ).toBeGreaterThan(0)
+  }
+
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('textbox', { name: 'Search skills...' })).toBeVisible({ timeout: 8_000 })
+
+  if (await cards.count() > 0) {
+    return cards
+  }
+
+  await waitForMatchingResponse()
+
+  try {
+    await waitForCardCount()
+  } catch {
+    if (reloaded) {
+      throw new Error('Timed out waiting for search cards after one reload fallback')
+    }
+
+    reloaded = true
+    await page.reload({ waitUntil: 'networkidle' })
     await expect(page.getByRole('textbox', { name: 'Search skills...' })).toBeVisible({ timeout: 8_000 })
-
-    if (await cards.count() > 0) {
-      return cards
-    }
-
-    if (attempt < 3) {
-      const responsePromise = encodedKeyword
-        ? page.waitForResponse(async (response) => {
-          if (!response.url().includes('/api/web/skills?') || !response.url().includes(`q=${encodedKeyword}`)) {
-            return false
-          }
-          if (response.status() !== 200) {
-            return false
-          }
-
-          try {
-            const payload = await response.json() as { data?: { items?: Array<unknown> } }
-            return Array.isArray(payload.data?.items) && payload.data.items.length > 0
-          } catch {
-            return false
-          }
-        }, { timeout: 12_000 }).catch(() => null)
-        : Promise.resolve(null)
-
-      await page.waitForTimeout(750 * (attempt + 1))
-      await page.reload({ waitUntil: 'networkidle' })
-      await responsePromise
-    }
+    await waitForMatchingResponse()
+    await waitForCardCount()
   }
 
   return cards

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -85,22 +85,18 @@ const NamespaceReviewsPage = createLazyRouteComponent(
   () => import('@/pages/dashboard/namespace-reviews'),
   'NamespaceReviewsPage',
 )
-const GovernancePage = createLazyRouteComponent(() => import('@/pages/dashboard/governance'), 'GovernancePage')
-const ReviewsPage = createRoleProtectedRouteComponent(
-  () => import('@/pages/dashboard/reviews'),
-  'ReviewsPage',
-  ['SKILL_ADMIN', 'NAMESPACE_ADMIN', 'USER_ADMIN', 'SUPER_ADMIN'],
+const NamespaceReviewDetailPage = createLazyRouteComponent(
+  () => import('@/pages/dashboard/review-detail'),
+  'NamespaceReviewDetailPage',
 )
+const GovernancePage = createLazyRouteComponent(() => import('@/pages/dashboard/governance'), 'GovernancePage')
+const ReviewsPage = createLazyRouteComponent(() => import('@/pages/dashboard/reviews'), 'ReviewsPage')
 const ReportsPage = createRoleProtectedRouteComponent(
   () => import('@/pages/dashboard/reports'),
   'ReportsPage',
   ['SKILL_ADMIN', 'SUPER_ADMIN'],
 )
-const ReviewDetailPage = createRoleProtectedRouteComponent(
-  () => import('@/pages/dashboard/review-detail'),
-  'ReviewDetailPage',
-  ['SKILL_ADMIN', 'NAMESPACE_ADMIN', 'SUPER_ADMIN'],
-)
+const ReviewDetailPage = createLazyRouteComponent(() => import('@/pages/dashboard/review-detail'), 'ReviewDetailPage')
 const PromotionsPage = createRoleProtectedRouteComponent(
   () => import('@/pages/dashboard/promotions'),
   'PromotionsPage',
@@ -298,6 +294,13 @@ const dashboardReviewDetailRoute = createRoute({
   component: ReviewDetailPage,
 })
 
+const dashboardNamespaceReviewDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'dashboard/namespaces/$slug/reviews/$id',
+  beforeLoad: requireAuth,
+  component: NamespaceReviewDetailPage,
+})
+
 const dashboardPromotionsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'dashboard/promotions',
@@ -408,6 +411,7 @@ const routeTree = rootRoute.addChildren([
   dashboardNamespacesRoute,
   dashboardNamespaceMembersRoute,
   dashboardNamespaceReviewsRoute,
+  dashboardNamespaceReviewDetailRoute,
   dashboardGovernanceRoute,
   dashboardReviewsRoute,
   dashboardReportsRoute,

--- a/web/src/features/review/review-paths.test.ts
+++ b/web/src/features/review/review-paths.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildGlobalReviewsPath,
+  buildNamespaceReviewDetailPath,
+  buildNamespaceReviewsPath,
+  canAccessGlobalReviewCenter,
+  canAccessReviewCenter,
+  canManageNamespaceReviews,
+  getPreferredNamespaceReviewEntry,
+} from './review-paths'
+
+describe('review-paths', () => {
+  it('builds the global reviews path', () => {
+    expect(buildGlobalReviewsPath()).toBe('/dashboard/reviews')
+  })
+
+  it('builds namespace review paths', () => {
+    expect(buildNamespaceReviewsPath('team alpha')).toBe('/dashboard/namespaces/team%20alpha/reviews')
+    expect(buildNamespaceReviewDetailPath('team alpha', 12)).toBe('/dashboard/namespaces/team%20alpha/reviews/12')
+  })
+
+  it('detects global review access from platform roles', () => {
+    expect(canAccessGlobalReviewCenter(['SKILL_ADMIN'])).toBe(true)
+    expect(canAccessGlobalReviewCenter(['USER_ADMIN'])).toBe(true)
+    expect(canAccessGlobalReviewCenter(['SUPER_ADMIN'])).toBe(true)
+    expect(canAccessGlobalReviewCenter(['USER'])).toBe(false)
+  })
+
+  it('recognizes namespace review managers', () => {
+    expect(canManageNamespaceReviews('OWNER')).toBe(true)
+    expect(canManageNamespaceReviews('ADMIN')).toBe(true)
+    expect(canManageNamespaceReviews('MEMBER')).toBe(false)
+  })
+
+  it('prefers active team namespaces for namespace review entry', () => {
+    expect(getPreferredNamespaceReviewEntry([
+      {
+        id: 1,
+        slug: 'archived-team',
+        displayName: 'Archived Team',
+        type: 'TEAM',
+        status: 'ARCHIVED',
+        immutable: false,
+        canFreeze: false,
+        canUnfreeze: false,
+        canArchive: false,
+        canRestore: false,
+        currentUserRole: 'ADMIN',
+        createdAt: '',
+      },
+      {
+        id: 2,
+        slug: 'active-team',
+        displayName: 'Active Team',
+        type: 'TEAM',
+        status: 'ACTIVE',
+        immutable: false,
+        canFreeze: false,
+        canUnfreeze: false,
+        canArchive: false,
+        canRestore: false,
+        currentUserRole: 'OWNER',
+        createdAt: '',
+      },
+    ])?.slug).toBe('active-team')
+  })
+
+  it('returns null when no manageable namespace exists', () => {
+    expect(getPreferredNamespaceReviewEntry([
+      {
+        id: 1,
+        slug: 'member-team',
+        displayName: 'Member Team',
+        type: 'TEAM',
+        status: 'ACTIVE',
+        immutable: false,
+        canFreeze: false,
+        canUnfreeze: false,
+        canArchive: false,
+        canRestore: false,
+        currentUserRole: 'MEMBER',
+        createdAt: '',
+      },
+    ])).toBeNull()
+  })
+
+  it('detects review center access from either platform roles or namespace roles', () => {
+    expect(canAccessReviewCenter(['SKILL_ADMIN'], [])).toBe(true)
+    expect(canAccessReviewCenter([], [
+      {
+        id: 2,
+        slug: 'team-admin',
+        displayName: 'Team Admin',
+        type: 'TEAM',
+        status: 'ACTIVE',
+        immutable: false,
+        canFreeze: false,
+        canUnfreeze: false,
+        canArchive: false,
+        canRestore: false,
+        currentUserRole: 'ADMIN',
+        createdAt: '',
+      },
+    ])).toBe(true)
+    expect(canAccessReviewCenter([], [])).toBe(false)
+  })
+})

--- a/web/src/features/review/review-paths.ts
+++ b/web/src/features/review/review-paths.ts
@@ -1,0 +1,48 @@
+import type { ManagedNamespace, NamespaceRole } from '@/api/types'
+
+const GLOBAL_REVIEW_PLATFORM_ROLES = ['SKILL_ADMIN', 'USER_ADMIN', 'SUPER_ADMIN'] as const
+
+export function buildGlobalReviewsPath() {
+  return '/dashboard/reviews'
+}
+
+export function buildNamespaceReviewsPath(slug: string) {
+  return `/dashboard/namespaces/${encodeURIComponent(slug)}/reviews`
+}
+
+export function buildNamespaceReviewDetailPath(slug: string, reviewId: number) {
+  return `/dashboard/namespaces/${encodeURIComponent(slug)}/reviews/${reviewId}`
+}
+
+export function canAccessGlobalReviewCenter(platformRoles?: readonly string[]) {
+  return GLOBAL_REVIEW_PLATFORM_ROLES.some((role) => platformRoles?.includes(role))
+}
+
+export function canManageNamespaceReviews(role?: NamespaceRole) {
+  return role === 'OWNER' || role === 'ADMIN'
+}
+
+export function getPreferredNamespaceReviewEntry(
+  namespaces?: readonly ManagedNamespace[],
+) {
+  if (!namespaces?.length) {
+    return null
+  }
+
+  const manageableNamespaces = namespaces.filter((namespace) =>
+    namespace.type === 'TEAM' && canManageNamespaceReviews(namespace.currentUserRole),
+  )
+  if (manageableNamespaces.length === 0) {
+    return null
+  }
+
+  const activeNamespace = manageableNamespaces.find((namespace) => namespace.status === 'ACTIVE')
+  return activeNamespace ?? manageableNamespaces[0]
+}
+
+export function canAccessReviewCenter(
+  platformRoles?: readonly string[],
+  namespaces?: readonly ManagedNamespace[],
+) {
+  return canAccessGlobalReviewCenter(platformRoles) || getPreferredNamespaceReviewEntry(namespaces) !== null
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1035,6 +1035,7 @@
     "sortLabel": "Time Order",
     "sortNewest": "Newest first",
     "sortOldest": "Oldest first",
+    "openReview": "Open review",
     "pageSummary": "Total {{total}} records, page {{page}}",
     "prevPage": "Previous",
     "nextPage": "Next",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1035,6 +1035,7 @@
     "sortLabel": "时间排序",
     "sortNewest": "最新优先",
     "sortOldest": "最早优先",
+    "openReview": "进入审核详情",
     "pageSummary": "共 {{total}} 条记录，第 {{page}} 页",
     "prevPage": "上一页",
     "nextPage": "下一页",

--- a/web/src/pages/dashboard/namespace-reviews.test.ts
+++ b/web/src/pages/dashboard/namespace-reviews.test.ts
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { createElement } from 'react'
 
 vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: unknown; to: string }) => createElement('a', { href: to }, children as string),
   useParams: () => ({ slug: 'test-ns' }),
 }))
 
@@ -127,6 +128,8 @@ describe('NamespaceReviewsPage', () => {
     const html = renderToStaticMarkup(createElement(NamespaceReviewsPage))
 
     expect(html).toContain('nsReviews.pageSummary')
+    expect(html).toContain('/dashboard/namespaces/test-ns/reviews/1')
+    expect(html).toContain('nsReviews.openReview')
     expect(paginationProps).toHaveLength(1)
     expect(paginationProps[0]?.page).toBe(0)
     expect(paginationProps[0]?.totalPages).toBe(2)
@@ -153,5 +156,19 @@ describe('NamespaceReviewsPage', () => {
     renderToStaticMarkup(createElement(NamespaceReviewsPage))
 
     expect(paginationProps).toHaveLength(0)
+  })
+
+  it('does not enable review queries before namespace detail resolves', () => {
+    useNamespaceDetailMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    })
+
+    renderToStaticMarkup(createElement(NamespaceReviewsPage))
+
+    expect(useReviewListMock).toHaveBeenCalled()
+    for (const call of useReviewListMock.mock.calls) {
+      expect(call[5]).toBe(false)
+    }
   })
 })

--- a/web/src/pages/dashboard/namespace-reviews.tsx
+++ b/web/src/pages/dashboard/namespace-reviews.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import { useParams } from '@tanstack/react-router'
+import { Link, useParams } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
+import { buildNamespaceReviewDetailPath } from '@/features/review/review-paths'
 import { formatLocalDateTime } from '@/shared/lib/date-time'
 import { Card } from '@/shared/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select'
@@ -15,8 +16,9 @@ type ReviewStatus = 'PENDING' | 'APPROVED' | 'REJECTED'
 type TimeSortDirection = 'ASC' | 'DESC'
 const PAGE_SIZE = 10
 
-function ReviewListSection({ namespaceId }: { namespaceId?: number }) {
+function ReviewListSection({ namespaceId, slug }: { namespaceId?: number; slug: string }) {
   const { t, i18n } = useTranslation()
+  const reviewsEnabled = typeof namespaceId === 'number' && namespaceId > 0
   const [pages, setPages] = useState<Record<ReviewStatus, number>>({
     PENDING: 0,
     APPROVED: 0,
@@ -24,9 +26,9 @@ function ReviewListSection({ namespaceId }: { namespaceId?: number }) {
   })
   const [activeStatus, setActiveStatus] = useState<ReviewStatus>('PENDING')
   const [sortDirection, setSortDirection] = useState<TimeSortDirection>('DESC')
-  const pending = useReviewList('PENDING', namespaceId, pages.PENDING, PAGE_SIZE, sortDirection, activeStatus === 'PENDING')
-  const approved = useReviewList('APPROVED', namespaceId, pages.APPROVED, PAGE_SIZE, sortDirection, activeStatus === 'APPROVED')
-  const rejected = useReviewList('REJECTED', namespaceId, pages.REJECTED, PAGE_SIZE, sortDirection, activeStatus === 'REJECTED')
+  const pending = useReviewList('PENDING', namespaceId, pages.PENDING, PAGE_SIZE, sortDirection, reviewsEnabled && activeStatus === 'PENDING')
+  const approved = useReviewList('APPROVED', namespaceId, pages.APPROVED, PAGE_SIZE, sortDirection, reviewsEnabled && activeStatus === 'APPROVED')
+  const rejected = useReviewList('REJECTED', namespaceId, pages.REJECTED, PAGE_SIZE, sortDirection, reviewsEnabled && activeStatus === 'REJECTED')
 
   const changePage = (status: ReviewStatus, nextPage: number) => {
     setPages((current) => ({ ...current, [status]: nextPage }))
@@ -90,6 +92,14 @@ function ReviewListSection({ namespaceId }: { namespaceId?: number }) {
             {review.reviewComment ? (
               <p className="mt-3 text-sm text-muted-foreground">{review.reviewComment}</p>
             ) : null}
+            <div className="mt-4 flex justify-end">
+              <Link
+                to={buildNamespaceReviewDetailPath(slug, review.id)}
+                className="inline-flex items-center rounded-md border border-border/60 px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                {t('nsReviews.openReview')}
+              </Link>
+            </div>
           </div>
         ))}
         {query.data ? renderPagination(status, query.data.totalElements, query.data.totalPages) : null}
@@ -151,7 +161,7 @@ export function NamespaceReviewsPage() {
           {readOnlyMessage}
         </Card>
       ) : null}
-      <ReviewListSection namespaceId={namespace?.id} />
+      <ReviewListSection namespaceId={namespace?.id} slug={slug} />
     </div>
   )
 }

--- a/web/src/pages/dashboard/review-detail.test.tsx
+++ b/web/src/pages/dashboard/review-detail.test.tsx
@@ -5,7 +5,11 @@ const navigateMock = vi.fn()
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigateMock,
-  useParams: () => ({ id: '13' }),
+  useParams: (options?: { from?: string }) => (
+    options?.from === '/dashboard/namespaces/$slug/reviews/$id'
+      ? { id: '13', slug: 'team-alpha' }
+      : { id: '13' }
+  ),
 }))
 
 vi.mock('react-i18next', async () => {
@@ -112,6 +116,11 @@ vi.mock('@/features/review/use-review-detail', () => ({
   }),
 }))
 
+const userMock = { platformRoles: ['SKILL_ADMIN'] as string[] }
+vi.mock('@/features/auth/use-auth', () => ({
+  useAuth: () => ({ user: userMock }),
+}))
+
 // Mock hooks used directly by the review-detail page for file browser sidebar
 vi.mock('@/features/review/use-review-file', () => ({
   useReviewFile: () => ({ data: null, isLoading: false, error: null }),
@@ -122,11 +131,12 @@ vi.mock('@/api/client', () => ({
   WEB_API_PREFIX: '/api/web',
 }))
 
-import { ReviewDetailPage } from './review-detail'
+import { NamespaceReviewDetailPage, ReviewDetailPage } from './review-detail'
 
 describe('ReviewDetailPage', () => {
   beforeEach(() => {
     navigateMock.mockReset()
+    userMock.platformRoles = ['SKILL_ADMIN']
     useReviewDetailMock.mockReset()
     useReviewSkillDetailMock.mockReset()
     useReviewDetailMock.mockReturnValue({
@@ -204,6 +214,81 @@ describe('ReviewDetailPage', () => {
     const html = renderToStaticMarkup(<ReviewDetailPage />)
 
     expect(html).toContain('review.notFound')
+  })
+
+  it('renders namespace review detail through the namespace route wrapper', () => {
+    useReviewDetailMock.mockReturnValue({
+      data: {
+        id: 13,
+        namespace: 'team-alpha',
+        skillSlug: 'demo-skill',
+        version: '1.2.0',
+        status: 'PENDING',
+        submittedBy: 'local-admin',
+        submittedByName: 'Local Admin',
+        submittedAt: '2026-03-19T00:00:00Z',
+        reviewedBy: null,
+        reviewedByName: null,
+        reviewedAt: null,
+        reviewComment: null,
+      },
+      isLoading: false,
+    })
+
+    const html = renderToStaticMarkup(<NamespaceReviewDetailPage />)
+
+    expect(html).toContain('review.detail')
+    expect(html).toContain('demo-skill')
+  })
+
+  it('redirects namespace reviews opened through the global route for namespace operators', () => {
+    userMock.platformRoles = []
+    useReviewDetailMock.mockReturnValue({
+      data: {
+        id: 13,
+        namespace: 'team-alpha',
+        skillSlug: 'demo-skill',
+        version: '1.2.0',
+        status: 'PENDING',
+        submittedBy: 'local-admin',
+        submittedByName: 'Local Admin',
+        submittedAt: '2026-03-19T00:00:00Z',
+        reviewedBy: null,
+        reviewedByName: null,
+        reviewedAt: null,
+        reviewComment: null,
+      },
+      isLoading: false,
+    })
+
+    const html = renderToStaticMarkup(<ReviewDetailPage />)
+
+    expect(html).toBe('')
+  })
+
+  it('shows not-found state when the namespace route slug does not match the review namespace', () => {
+    useReviewDetailMock.mockReturnValue({
+      data: {
+        id: 13,
+        namespace: 'other-team',
+        skillSlug: 'demo-skill',
+        version: '1.2.0',
+        status: 'PENDING',
+        submittedBy: 'local-admin',
+        submittedByName: 'Local Admin',
+        submittedAt: '2026-03-19T00:00:00Z',
+        reviewedBy: null,
+        reviewedByName: null,
+        reviewedAt: null,
+        reviewComment: null,
+      },
+      isLoading: false,
+    })
+
+    const html = renderToStaticMarkup(<NamespaceReviewDetailPage />)
+
+    expect(html).toContain('review.notFound')
+    expect(html).toContain('review.backToList')
   })
 
   it('disables approval and shows a scanning hint while the active review version is scanning', () => {

--- a/web/src/pages/dashboard/review-detail.tsx
+++ b/web/src/pages/dashboard/review-detail.tsx
@@ -1,7 +1,14 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, Folder } from 'lucide-react'
+import { useAuth } from '@/features/auth/use-auth'
+import {
+  buildGlobalReviewsPath,
+  buildNamespaceReviewDetailPath,
+  buildNamespaceReviewsPath,
+  canAccessGlobalReviewCenter,
+} from '@/features/review/review-paths'
 import { formatLocalDateTime } from '@/shared/lib/date-time'
 import { Button } from '@/shared/ui/button'
 import { Card } from '@/shared/ui/card'
@@ -25,11 +32,18 @@ import { useReviewDetail, useReviewSkillDetail, useApproveReview, useRejectRevie
  * interaction state because both actions depend on route-local confirmation
  * dialogs, comment input, and redirect behavior after completion.
  */
-export function ReviewDetailPage() {
-  const { id } = useParams({ from: '/dashboard/reviews/$id' })
+function ReviewDetailScreen({
+  taskId,
+  backTo,
+  namespaceSlug,
+}: {
+  taskId: number
+  backTo: string
+  namespaceSlug?: string
+}) {
   const navigate = useNavigate()
   const { t, i18n } = useTranslation()
-  const taskId = Number(id)
+  const { user } = useAuth()
 
   const { data: review, isLoading } = useReviewDetail(taskId)
   const {
@@ -40,7 +54,7 @@ export function ReviewDetailPage() {
   const approveMutation = useApproveReview({
     onSuccess: () => {
       toast.success(t('review.approveSuccess'))
-      navigate({ to: '/dashboard/reviews' })
+      navigate({ to: backTo })
     },
     onError: (error) => {
       toast.error(t('review.approveFailed'), resolveReviewActionErrorDescription(error))
@@ -49,7 +63,7 @@ export function ReviewDetailPage() {
   const rejectMutation = useRejectReview({
     onSuccess: () => {
       toast.success(t('review.rejectSuccess'))
-      navigate({ to: '/dashboard/reviews' })
+      navigate({ to: backTo })
     },
     onError: (error) => {
       toast.error(t('review.rejectFailed'), resolveReviewActionErrorDescription(error))
@@ -64,6 +78,12 @@ export function ReviewDetailPage() {
   const [fileBrowserOpen, setFileBrowserOpen] = useState(true)
   const [previewNode, setPreviewNode] = useState<FileTreeNode | null>(null)
   const [previewDialogOpen, setPreviewDialogOpen] = useState(false)
+  const hasGlobalReviewAccess = canAccessGlobalReviewCenter(user?.platformRoles)
+  const shouldRedirectToNamespaceRoute =
+    !namespaceSlug &&
+    !!review &&
+    review.namespace !== 'global' &&
+    !hasGlobalReviewAccess
 
   // File content for preview — uses the review-bound version via review file API
   const { data: previewContent, isLoading: isLoadingPreview, error: previewError } = useReviewFile(
@@ -92,6 +112,17 @@ export function ReviewDetailPage() {
     return formatLocalDateTime(dateString, i18n.language)
   }
 
+  useEffect(() => {
+    if (!shouldRedirectToNamespaceRoute || !review) {
+      return
+    }
+
+    void navigate({
+      to: buildNamespaceReviewDetailPath(review.namespace, review.id),
+      replace: true,
+    })
+  }, [navigate, review, shouldRedirectToNamespaceRoute])
+
   const handleApprove = async () => {
     approveMutation.mutate({ taskId, comment: comment || undefined })
   }
@@ -113,10 +144,31 @@ export function ReviewDetailPage() {
     )
   }
 
+  if (shouldRedirectToNamespaceRoute) {
+    return null
+  }
+
   if (!review) {
     return (
       <div className="text-center py-20 animate-fade-up">
         <h2 className="text-2xl font-bold font-heading mb-2">{t('review.notFound')}</h2>
+      </div>
+    )
+  }
+
+  const hasNamespaceMismatch = Boolean(namespaceSlug && review.namespace !== namespaceSlug)
+
+  if (hasNamespaceMismatch) {
+    return (
+      <div className="space-y-6 max-w-3xl animate-fade-up">
+        <div className="text-center py-20">
+          <h2 className="text-2xl font-bold font-heading mb-2">{t('review.notFound')}</h2>
+        </div>
+        <div className="flex justify-center">
+          <Button variant="outline" onClick={() => navigate({ to: backTo })}>
+            {t('review.backToList')}
+          </Button>
+        </div>
       </div>
     )
   }
@@ -136,7 +188,7 @@ export function ReviewDetailPage() {
           <h1 className="text-4xl font-bold font-heading mb-2">{t('review.detail')}</h1>
           <p className="text-muted-foreground">{t('review.id')}: {review.id}</p>
         </div>
-        <Button variant="outline" onClick={() => navigate({ to: '/dashboard/reviews' })}>
+        <Button variant="outline" onClick={() => navigate({ to: backTo })}>
           {t('review.backToList')}
         </Button>
       </div>
@@ -361,5 +413,28 @@ export function ReviewDetailPage() {
         onDownload={handleDownloadFile}
       />
     </div>
+  )
+}
+
+export function ReviewDetailPage() {
+  const { id } = useParams({ from: '/dashboard/reviews/$id' })
+
+  return (
+    <ReviewDetailScreen
+      taskId={Number(id)}
+      backTo={buildGlobalReviewsPath()}
+    />
+  )
+}
+
+export function NamespaceReviewDetailPage() {
+  const { id, slug } = useParams({ from: '/dashboard/namespaces/$slug/reviews/$id' })
+
+  return (
+    <ReviewDetailScreen
+      taskId={Number(id)}
+      backTo={buildNamespaceReviewsPath(slug)}
+      namespaceSlug={slug}
+    />
   )
 }

--- a/web/src/pages/dashboard/reviews.test.ts
+++ b/web/src/pages/dashboard/reviews.test.ts
@@ -67,8 +67,14 @@ vi.mock('@/features/review/use-review-list', () => ({
 }))
 
 const hasRoleMock = vi.fn()
+const userMock = { platformRoles: ['SKILL_ADMIN'] }
 vi.mock('@/features/auth/use-auth', () => ({
-  useAuth: () => ({ hasRole: hasRoleMock }),
+  useAuth: () => ({ hasRole: hasRoleMock, user: userMock }),
+}))
+
+const useMyNamespacesMock = vi.fn()
+vi.mock('@/shared/hooks/use-namespace-queries', () => ({
+  useMyNamespaces: () => useMyNamespacesMock(),
 }))
 
 vi.mock('@/shared/components/dashboard-page-header', () => ({
@@ -106,7 +112,13 @@ describe('ReviewsPage', () => {
     paginationProps.length = 0
     hasRoleMock.mockReset()
     useReviewListMock.mockReset()
+    useMyNamespacesMock.mockReset()
     hasRoleMock.mockImplementation((role: string) => role === 'SKILL_ADMIN')
+    userMock.platformRoles = ['SKILL_ADMIN']
+    useMyNamespacesMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    })
     useReviewListMock.mockImplementation((status: string, _namespaceId: unknown, page: number, _size: number, _sortDirection: string, enabled: boolean) => {
       if (!enabled) {
         return { data: null, isLoading: false }

--- a/web/src/pages/dashboard/reviews.tsx
+++ b/web/src/pages/dashboard/reviews.tsx
@@ -1,10 +1,16 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { FileCheck2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useMyNamespaces } from '@/shared/hooks/use-namespace-queries'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui/tabs'
+import {
+  buildNamespaceReviewsPath,
+  canAccessGlobalReviewCenter,
+  getPreferredNamespaceReviewEntry,
+} from '@/features/review/review-paths'
 import {
   Table,
   TableBody,
@@ -32,7 +38,8 @@ const PAGE_SIZE = 20
 export function ReviewsPage() {
   const { t, i18n } = useTranslation()
   const navigate = useNavigate()
-  const { hasRole } = useAuth()
+  const { hasRole, user } = useAuth()
+  const { data: myNamespaces, isLoading: isLoadingNamespaces } = useMyNamespaces()
   const [pages, setPages] = useState<Record<ReviewStatus, number>>({
     PENDING: 0,
     APPROVED: 0,
@@ -43,14 +50,29 @@ export function ReviewsPage() {
 
   const isSkillAdmin = hasRole('SKILL_ADMIN') || hasRole('SUPER_ADMIN')
   const isUserAdmin = hasRole('USER_ADMIN') || hasRole('SUPER_ADMIN')
+  const hasGlobalReviewAccess = canAccessGlobalReviewCenter(user?.platformRoles)
+  const namespaceReviewEntry = getPreferredNamespaceReviewEntry(myNamespaces)
   const showTypeTabs = isSkillAdmin && isUserAdmin
 
   // Determine default top-level tab
   const defaultType = isSkillAdmin ? 'skill' : 'profile'
 
-  const pendingQuery = useReviewList('PENDING', undefined, pages.PENDING, PAGE_SIZE, sortDirection, activeStatus === 'PENDING')
-  const approvedQuery = useReviewList('APPROVED', undefined, pages.APPROVED, PAGE_SIZE, sortDirection, activeStatus === 'APPROVED')
-  const rejectedQuery = useReviewList('REJECTED', undefined, pages.REJECTED, PAGE_SIZE, sortDirection, activeStatus === 'REJECTED')
+  useEffect(() => {
+    if (hasGlobalReviewAccess || isLoadingNamespaces) {
+      return
+    }
+
+    if (namespaceReviewEntry) {
+      void navigate({ to: buildNamespaceReviewsPath(namespaceReviewEntry.slug), replace: true })
+      return
+    }
+
+    void navigate({ to: '/dashboard', replace: true })
+  }, [hasGlobalReviewAccess, isLoadingNamespaces, namespaceReviewEntry, navigate])
+
+  const pendingQuery = useReviewList('PENDING', undefined, pages.PENDING, PAGE_SIZE, sortDirection, hasGlobalReviewAccess && activeStatus === 'PENDING')
+  const approvedQuery = useReviewList('APPROVED', undefined, pages.APPROVED, PAGE_SIZE, sortDirection, hasGlobalReviewAccess && activeStatus === 'APPROVED')
+  const rejectedQuery = useReviewList('REJECTED', undefined, pages.REJECTED, PAGE_SIZE, sortDirection, hasGlobalReviewAccess && activeStatus === 'REJECTED')
 
   const formatDate = (dateString: string) => formatLocalDateTime(dateString, i18n.language)
 
@@ -208,6 +230,17 @@ export function ReviewsPage() {
           </Tabs>
         </CardContent>
       </Card>
+    )
+  }
+
+  if (!hasGlobalReviewAccess) {
+    return (
+      <div className="space-y-8 animate-fade-up">
+        <DashboardPageHeader title={t('reviews.title')} subtitle={t('reviews.subtitle')} />
+        <Card className="p-8 text-center text-muted-foreground">
+          Loading...
+        </Card>
+      </div>
     )
   }
 

--- a/web/src/shared/components/user-menu.tsx
+++ b/web/src/shared/components/user-menu.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { Link } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { authApi } from '@/api/client'
+import { useMyNamespaces } from '@/shared/hooks/use-namespace-queries'
+import { buildGlobalReviewsPath, canAccessReviewCenter } from '@/features/review/review-paths'
 import { clearSessionScopedQueries } from '@/features/notification/notification-session'
 import { canViewGovernanceCenter } from '@/shared/lib/governance-access'
 import { cn } from '@/shared/lib/utils'
@@ -22,19 +24,19 @@ interface UserMenuProps {
 export function UserMenu({ user, triggerClassName }: UserMenuProps) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { data: myNamespaces } = useMyNamespaces()
   const rootRef = useRef<HTMLDivElement | null>(null)
   const closeTimerRef = useRef<number | null>(null)
   const [isHovered, setIsHovered] = useState(false)
   const [isClickOpen, setIsClickOpen] = useState(false)
 
   const hasRole = (role: string) => user.platformRoles?.includes(role) ?? false
-  const isReviewer = hasRole('SKILL_ADMIN') || hasRole('NAMESPACE_ADMIN') || hasRole('SUPER_ADMIN')
   const canSeeGovernance = canViewGovernanceCenter(user.platformRoles)
   const isSkillAdmin = hasRole('SKILL_ADMIN') || hasRole('SUPER_ADMIN')
   const isUserAdmin = hasRole('USER_ADMIN') || hasRole('SUPER_ADMIN')
   const isAuditor = hasRole('AUDITOR') || hasRole('SUPER_ADMIN')
   const isSuperAdmin = hasRole('SUPER_ADMIN')
-  const canAccessReviewCenter = isReviewer || isUserAdmin
+  const reviewCenterVisible = canAccessReviewCenter(user.platformRoles, myNamespaces)
   const isLocalAccount = !user.oauthProvider
   const open = isHovered || isClickOpen
 
@@ -157,8 +159,8 @@ export function UserMenu({ user, triggerClassName }: UserMenuProps) {
             <Link to="/dashboard/stars" className={menuItemClassName} onClick={closeMenu}>
               {t('user.menu.stars')}
             </Link>
-            {canAccessReviewCenter ? (
-              <Link to="/dashboard/reviews" className={menuItemClassName} onClick={closeMenu}>
+            {reviewCenterVisible ? (
+              <Link to={buildGlobalReviewsPath()} className={menuItemClassName} onClick={closeMenu}>
                 {t('user.menu.reviews')}
               </Link>
             ) : null}


### PR DESCRIPTION
## 概述
修复 #276：命名空间管理员/所有者兼审核员时，允许审核自己命名空间内自己提交的 skill。

## 变更内容

### 后端实现
- 调整 `ReviewPermissionChecker#canReview` 的自提交审核权限判断
- 保持 `SUPER_ADMIN` 可审核自己的提交不变
- 新增限制：`SKILL_ADMIN` 只有在目标命名空间内角色为 `ADMIN` 或 `OWNER` 时，才允许审核自己的提交
- 未修改 Controller、API 契约、DB migration

### 前端实现
- 本次变更无前端代码修改

### 测试覆盖
- 后端单测：更新 `ReviewPermissionCheckerTest`，覆盖无命名空间角色、namespace admin、namespace owner、namespace member 的自审场景
- 前端单测：无
- E2E 测试：无，本次未修改前端页面交互

## 质量门禁

- [ ] `make typecheck-web` 通过（0 errors）
- [ ] `make lint-web` 通过（0 errors, 0 warnings）
- [ ] `make test-frontend` 通过
- [x] `make test-backend-app` 通过（如有后端变更）
- [ ] Playwright E2E（`web/e2e`）关键路径通过（如有 UI 交互变更）
- [ ] `make generate-api` 已执行且 `schema.d.ts` 已提交（如有 Controller 变更）

## 安全考虑
本次变更不涉及安全敏感内容。

## 相关 Issue
Closes #276

## 测试说明

### 本地验证步骤
1. 执行 `cd server && ./mvnw -pl skillhub-domain -am test -Dtest=ReviewPermissionCheckerTest -Dsurefire.failIfNoSpecifiedTests=false`
2. 执行 `make test-backend-app`
3. 验证命名空间管理员/所有者兼审核员的自提交审核权限按预期放开，普通成员或无命名空间角色仍被拒绝

### 回归测试范围
- skill 提交审核权限判断
- 命名空间管理员/所有者审核流程
- 非自提交审核流程

### 截图/录屏（如有 UI 变更）
无，本次为后端权限修复。
