### PR TITLE
Add support for .cjs and .mjs JavaScript extensions

### DIFF
--- a/docs/07-skill-protocol.md
+++ b/docs/07-skill-protocol.md
@@ -67,7 +67,7 @@ my-skill/
 
 校验规则：
 - 根目录必须包含 `SKILL.md`
-- 文件类型白名单：`.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.js`, `.ts`, `.py`, `.sh`, `.png`, `.jpg`, `.svg`
+- 文件类型白名单：`.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.js`, `.cjs`, `.mjs`, `.ts`, `.py`, `.sh`, `.png`, `.jpg`, `.svg`
 - 单文件大小限制：1MB（可配置）
 - 总包大小限制：10MB（可配置）
 - 文件数量限制：100 个（可配置）

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/support/SkillPackageArchiveExtractor.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/support/SkillPackageArchiveExtractor.java
@@ -136,7 +136,7 @@ public class SkillPackageArchiveExtractor {
         if (lower.endsWith(".css")) return "text/css";
         if (lower.endsWith(".csv")) return "text/csv";
         if (lower.endsWith(".xml")) return "application/xml";
-        if (lower.endsWith(".js")) return "text/javascript";
+        if (lower.endsWith(".js") || lower.endsWith(".cjs") || lower.endsWith(".mjs")) return "text/javascript";
         if (lower.endsWith(".ts")) return "text/typescript";
         if (lower.endsWith(".sh") || lower.endsWith(".bash") || lower.endsWith(".zsh")) return "text/x-shellscript";
         if (lower.endsWith(".png")) return "image/png";

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
@@ -25,7 +25,7 @@ public final class SkillPackagePolicy {
             // Configuration and schemas
             ".toml", ".xml", ".xsd", ".xsl", ".dtd", ".ini", ".cfg", ".env",
             // Scripts and source code
-            ".js", ".ts", ".py", ".sh", ".rb", ".go", ".rs", ".java", ".kt",
+            ".js", ".cjs", ".mjs", ".ts", ".py", ".sh", ".rb", ".go", ".rs", ".java", ".kt",
             ".lua", ".sql", ".r", ".bat", ".ps1", ".zsh", ".bash",
             // Images
             ".png", ".jpg", ".jpeg", ".svg", ".gif", ".webp", ".ico",
@@ -126,7 +126,8 @@ public final class SkillPackagePolicy {
     private static boolean isTextExtension(String path) {
         return path.endsWith(".md") || path.endsWith(".txt")
                 || path.endsWith(".json") || path.endsWith(".yaml") || path.endsWith(".yml")
-                || path.endsWith(".js") || path.endsWith(".ts") || path.endsWith(".py") || path.endsWith(".sh")
+                || path.endsWith(".js") || path.endsWith(".cjs") || path.endsWith(".mjs")
+                || path.endsWith(".ts") || path.endsWith(".py") || path.endsWith(".sh")
                 || path.endsWith(".html") || path.endsWith(".css") || path.endsWith(".csv")
                 || path.endsWith(".toml") || path.endsWith(".xml") || path.endsWith(".xsd")
                 || path.endsWith(".xsl") || path.endsWith(".dtd") || path.endsWith(".ini")

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
@@ -309,6 +309,30 @@ class SkillPackageValidatorTest {
         assertTrue(result.passed());
     }
 
+    @Test
+    void acceptsCjsFile() {
+        byte[] cjsContent = "module.exports = {};".getBytes();
+        List<PackageEntry> entries = List.of(
+                skillMdEntry(),
+                new PackageEntry("index.cjs", cjsContent, cjsContent.length, "text/javascript")
+        );
+        ValidationResult result = validator.validate(entries);
+        assertTrue(result.passed());
+        assertTrue(result.errors().isEmpty());
+    }
+
+    @Test
+    void acceptsMjsFile() {
+        byte[] mjsContent = "export default {};".getBytes();
+        List<PackageEntry> entries = List.of(
+                skillMdEntry(),
+                new PackageEntry("index.mjs", mjsContent, mjsContent.length, "text/javascript")
+        );
+        ValidationResult result = validator.validate(entries);
+        assertTrue(result.passed());
+        assertTrue(result.errors().isEmpty());
+    }
+
     private PackageEntry skillMdEntry() {
         String skillMdContent = """
             ---


### PR DESCRIPTION
## Summary

.cjs and .mjs are standard Node.js module formats but weren't in the whitelist, so packages with these files were getting rejected. Added them to the file type whitelist, MIME type detection, and validation policy so they're properly recognized.

## Validation

- [x] Backend tests passed
- [x] Frontend typecheck/build passed
- [x] OpenAPI SDK regenerated or checked when API contracts changed
- [x] Smoke test run when relevant

Commands run:

```bash
mvn test
```

## Risk

User-facing impact: Packages with .cjs/.mjs files will now upload successfully instead of being rejected.

Deployment or migration impact: None, just expanding the accepted file types.

Rollback approach: Revert the whitelist additions if needed.

## Notes

Related issue: Fixes #282

Follow-up work: None

Docs or operator runbooks updated when behavior changed: Updated docs/07-skill-protocol.md