### PR TITLE
fix(compat): support namespace-aware clawhub publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,15 @@ npx clawhub search email
 npx clawhub install my-skill
 npx clawhub install my-namespace--my-skill
 
-# Publish a skill
-npx clawhub publish ./my-skill
+# Publish to global namespace
+npx clawhub publish ./my-skill --slug my-skill --version 1.0.0
+
+# Publish to a team namespace such as my-space
+npx clawhub publish ./my-skill --slug my-space--my-skill --version 1.0.0
 ```
+
+`my-space--my-skill` is the canonical compat slug. SkillHub parses it as
+namespace `my-space` plus skill slug `my-skill`.
 
 > 💡 **Tip**: The above commands are not only applicable to OpenClaw, but also to other CLI Coding Agents or Agent assistants by specifying the installation directory (`--dir`). For example: `npx clawhub --dir ~/.claude/skills install my-skill`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -331,9 +331,15 @@ npx clawhub search email
 npx clawhub install my-skill
 npx clawhub install my-namespace--my-skill
 
-# 发布技能
-npx clawhub publish ./my-skill
+# 发布到 global 空间
+npx clawhub publish ./my-skill --slug my-skill --version 1.0.0
+
+# 发布到如 my-space 这样的团队空间
+npx clawhub publish ./my-skill --slug my-space--my-skill --version 1.0.0
 ```
+
+其中 `my-space--my-skill` 是兼容层使用的 canonical slug，SkillHub 会将其解析为
+namespace `my-space` 和 skill slug `my-skill`。
 
 > 💡 **提示**：上述命令不仅适用于 OpenClaw，通过指定安装目录（`--dir`），也可适用于其他的 CLI Coding Agent 或 Agent 助手。例如：`npx clawhub --dir ~/.claude/skills install my-skill`
 

--- a/docs/openclaw-integration-en.md
+++ b/docs/openclaw-integration-en.md
@@ -110,14 +110,21 @@ npx clawhub list --help
 ### 5. Publish Skills
 
 ```bash
-# Publish skill (requires appropriate permissions)
+# Publish to the global namespace (requires appropriate permissions)
 npx clawhub publish ./my-skill --slug my-skill --name "My Skill" --version 1.0.0
+
+# Publish to a team namespace such as my-space
+npx clawhub publish ./my-skill --slug my-space--my-skill --name "My Skill" --version 1.0.0
 npx clawhub sync --all # Upload all skills in current folder
 
 # Help
 npx clawhub publish --help
 npx clawhub sync --help
 ```
+
+Notes:
+- `my-space--my-skill` is the canonical compatibility slug. SkillHub parses it as namespace `my-space` plus skill slug `my-skill`
+- To avoid mismatches between CLI display text and the final persisted coordinate, keep the `name` in `SKILL.md` aligned with the canonical slug suffix
 
 ## API Endpoints
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -110,14 +110,21 @@ npx clawhub list --help
 ### 5. 发布技能
 
 ```bash
-# 发布技能（需要相应权限）
+# 发布到 global 空间（需要相应权限）
 npx clawhub publish ./my-skill --slug my-skill --name "My Skill" --version 1.0.0
+
+# 发布到如 my-space 这样的团队空间
+npx clawhub publish ./my-skill --slug my-space--my-skill --name "My Skill" --version 1.0.0
 npx clawhub sync --all # 上传当前文件夹中所有的 skill
 
 # 使用帮助
 npx clawhub publish --help
 npx clawhub sync --help
 ```
+
+说明：
+- `my-space--my-skill` 是兼容层 canonical slug，SkillHub 会将其解析为 namespace `my-space` 和 skill slug `my-skill`
+- 为避免 CLI 展示与服务端最终坐标不一致，建议让 `SKILL.md` 中的 `name` 与 canonical slug 后半段保持一致
 
 ## API 端点说明
 

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatAppService.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -36,6 +37,8 @@ import org.springframework.web.multipart.MultipartFile;
  */
 @Service
 public class ClawHubCompatAppService {
+
+    private static final String GLOBAL_NAMESPACE = "global";
 
     private final CanonicalSlugMapper mapper;
     private final SkillSearchAppService skillSearchAppService;
@@ -268,7 +271,7 @@ public class ClawHubCompatAppService {
                                                String clientIp,
                                                String userAgent) throws IOException {
         MultipartPackageExtractor.ExtractedPackage extracted = multipartPackageExtractor.extract(files, payloadJson);
-        String namespace = determineNamespace(principal, extracted.payload());
+        String namespace = determineNamespace(extracted.payload());
         SkillPublishService.PublishResult result = skillPublishService.publishFromEntries(
                 namespace,
                 extracted.entries(),
@@ -371,8 +374,28 @@ public class ClawHubCompatAppService {
         );
     }
 
-    private String determineNamespace(PlatformPrincipal principal, MultipartPackageExtractor.PublishPayload payload) {
-        return "global";
+    private String determineNamespace(MultipartPackageExtractor.PublishPayload payload) {
+        if (payload == null) {
+            return GLOBAL_NAMESPACE;
+        }
+
+        if (StringUtils.hasText(payload.namespace())) {
+            return normalizeNamespace(payload.namespace());
+        }
+
+        if (StringUtils.hasText(payload.slug()) && payload.slug().contains("--")) {
+            return mapper.fromCanonical(payload.slug()).namespace();
+        }
+
+        return GLOBAL_NAMESPACE;
+    }
+
+    private String normalizeNamespace(String namespace) {
+        String trimmed = namespace.trim();
+        if (trimmed.startsWith("@")) {
+            return trimmed.substring(1);
+        }
+        return trimmed;
     }
 
     private void recordCompatPublishAudit(String userId,

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/support/MultipartPackageExtractor.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/support/MultipartPackageExtractor.java
@@ -30,6 +30,7 @@ public class MultipartPackageExtractor {
     }
 
     public record PublishPayload(
+        String namespace,
         String slug,
         String displayName,
         String version,

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -2,35 +2,46 @@ package com.iflytek.skillhub.compat;
 
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.auth.device.DeviceAuthService;
+import com.iflytek.skillhub.domain.audit.AuditLogService;
 import com.iflytek.skillhub.domain.namespace.Namespace;
 import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
+import com.iflytek.skillhub.domain.skill.SkillVersion;
+import com.iflytek.skillhub.domain.skill.SkillVersionStatus;
 import com.iflytek.skillhub.domain.skill.service.SkillQueryService;
+import com.iflytek.skillhub.domain.skill.service.SkillPublishService;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.dto.SkillLifecycleVersionResponse;
 import com.iflytek.skillhub.dto.SkillSummaryResponse;
 import com.iflytek.skillhub.service.SkillSearchAppService;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -55,6 +66,12 @@ class ClawHubCompatControllerTest {
 
     @MockBean
     private CompatSkillLookupService compatSkillLookupService;
+
+    @MockBean
+    private SkillPublishService skillPublishService;
+
+    @MockBean
+    private AuditLogService auditLogService;
 
     @Test
     void search_returns_mapped_results() throws Exception {
@@ -204,9 +221,122 @@ class ClawHubCompatControllerTest {
                 .andExpect(jsonPath("$.user.image").value("https://example.com/avatar.png"));
     }
 
+    @Test
+    void publish_skill_with_canonical_slug_routes_to_namespace_publish() throws Exception {
+        SkillVersion version = publishVersion("1.0.0", 34L);
+        given(skillPublishService.publishFromEntries(
+                eq("team-ai"),
+                anyList(),
+                eq("user-42"),
+                eq(SkillVisibility.PUBLIC),
+                eq(Set.of("SUPER_ADMIN")),
+                eq(false)))
+                .willReturn(new SkillPublishService.PublishResult(12L, "my-skill", version));
+
+        mockMvc.perform(multipart("/api/v1/skills")
+                        .file(skillMdFile())
+                        .param("payload", """
+                                {"slug":"team-ai--my-skill","displayName":"My Skill","version":"1.0.0","acceptLicenseTerms":true,"tags":["latest"]}
+                                """)
+                        .with(authentication(superAdminAuth()))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.skillId").value("12"))
+                .andExpect(jsonPath("$.versionId").value("34"));
+    }
+
+    @Test
+    void publish_skill_with_plain_slug_defaults_to_global_namespace() throws Exception {
+        SkillVersion version = publishVersion("1.0.0", 35L);
+        given(skillPublishService.publishFromEntries(
+                eq("global"),
+                anyList(),
+                eq("user-42"),
+                eq(SkillVisibility.PUBLIC),
+                eq(Set.of("SUPER_ADMIN")),
+                eq(false)))
+                .willReturn(new SkillPublishService.PublishResult(13L, "my-skill", version));
+
+        mockMvc.perform(multipart("/api/v1/skills")
+                        .file(skillMdFile())
+                        .param("payload", """
+                                {"slug":"my-skill","displayName":"My Skill","version":"1.0.0","acceptLicenseTerms":true,"tags":["latest"]}
+                                """)
+                        .with(authentication(superAdminAuth()))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.skillId").value("13"))
+                .andExpect(jsonPath("$.versionId").value("35"));
+    }
+
+    @Test
+    void publish_skill_with_payload_namespace_uses_explicit_namespace() throws Exception {
+        SkillVersion version = publishVersion("1.0.0", 36L);
+        given(skillPublishService.publishFromEntries(
+                eq("team-explicit"),
+                anyList(),
+                eq("user-42"),
+                eq(SkillVisibility.PUBLIC),
+                eq(Set.of("SUPER_ADMIN")),
+                eq(false)))
+                .willReturn(new SkillPublishService.PublishResult(14L, "my-skill", version));
+
+        mockMvc.perform(multipart("/api/v1/skills")
+                        .file(skillMdFile())
+                        .param("payload", """
+                                {"namespace":"@team-explicit","slug":"my-skill","displayName":"My Skill","version":"1.0.0","acceptLicenseTerms":true,"tags":["latest"]}
+                                """)
+                        .with(authentication(superAdminAuth()))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.skillId").value("14"))
+                .andExpect(jsonPath("$.versionId").value("36"));
+    }
+
     private CompatSkillLookupService.CompatSkillContext legacyCompatContext(String namespaceSlug, String skillSlug) {
         Namespace namespace = new Namespace(namespaceSlug, namespaceSlug, "tester");
         Skill skill = new Skill(1L, skillSlug, "tester", SkillVisibility.PUBLIC);
         return new CompatSkillLookupService.CompatSkillContext(namespace, skill, Optional.empty());
+    }
+
+    private MockMultipartFile skillMdFile() {
+        return new MockMultipartFile(
+                "files",
+                "SKILL.md",
+                "text/markdown",
+                """
+                ---
+                name: my-skill
+                description: Demo skill
+                version: 1.0.0
+                ---
+                """.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private SkillVersion publishVersion(String versionValue, long versionId) {
+        SkillVersion version = new SkillVersion(12L, versionValue, "user-42");
+        version.setStatus(SkillVersionStatus.PENDING_REVIEW);
+        ReflectionTestUtils.setField(version, "id", versionId);
+        return version;
+    }
+
+    private UsernamePasswordAuthenticationToken superAdminAuth() {
+        PlatformPrincipal principal = new PlatformPrincipal(
+                "user-42",
+                "tester",
+                "tester@example.com",
+                "https://example.com/avatar.png",
+                "github",
+                Set.of("SUPER_ADMIN")
+        );
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER_ADMIN"))
+        );
     }
 }


### PR DESCRIPTION
## 概述
修复 ClawHub 兼容发布默认总是落到 global 的问题，支持通过 canonical slug 将 `clawhub publish` 路由到目标 namespace，并同步更新中英文文档说明 global 与 my-space 两种发布方式。

## 变更内容

### 后端实现
- 在 compat publish 链路中新增 namespace 解析优先级：`payload.namespace` -> canonical `payload.slug`（例如 `my-space--my-skill`）-> 默认 `global`
- 保持 domain 存储模型不变，继续分别存储 namespace 和 skill slug，不放宽 `SlugValidator`
- 扩展 multipart publish payload，预留可选 `namespace` 字段供未来客户端使用

### 前端实现
- 本次变更未修改前端代码

### 测试覆盖
- 后端单测：扩展 `ClawHubCompatControllerTest`，覆盖 canonical slug 发布到 namespace、普通 slug 默认 global、显式 `payload.namespace` 优先三类场景
- 前端单测：无
- E2E 测试：无，本次无前端页面交互改动

### 文档更新
- 更新 `README.md` 与 `README_zh.md`，区分发布到 global 和发布到 my-space namespace 的命令示例
- 更新 `docs/openclaw-integration.md` 与 `docs/openclaw-integration-en.md`，说明 canonical compat slug 的发布方式

## 质量门禁
- [x] `make typecheck-web` 不适用，本次无前端改动
- [x] `make lint-web` 不适用，本次无前端改动
- [x] `make test-frontend` 不适用，本次无前端改动
- [x] `make test-backend-app` 通过
- [x] Playwright E2E 不适用，本次无 UI 交互改动
- [x] `make generate-api` 已执行；未提交 `schema.d.ts`，因为生成出的差异与本次任务无关，已回退无关漂移

## 安全考虑
- 本次变更不涉及安全敏感内容
- namespace 路由仍复用既有发布权限校验，普通用户仍需是目标 namespace 成员，`SUPER_ADMIN` 行为保持不变
- 未放宽持久化 slug 规则，`my-space--my-skill` 仅作为 compat 输入坐标解析，不进入 domain 存储模型

## 相关 Issue
Closes #261
Closes #284

## 测试说明

### 本地验证步骤
1. 启动本地环境：`make dev-all`
2. 配置 CLI：`export CLAWHUB_REGISTRY=http://localhost:8080`
3. 创建 API token 并执行 `clawhub login --token <token>`
4. 发布到 global：`clawhub publish ./my-skill --slug my-skill --version 1.0.0`
5. 发布到 namespace：`clawhub publish ./my-skill --slug my-space--my-skill --version 1.0.0`
6. 使用 `/api/v1/skills/{namespace}/{slug}` 或 `clawhub inspect` 验证最终落库坐标

### 回归测试范围
- ClawHub 兼容层发布链路
- canonical slug 解析行为
- global 默认发布行为
- 兼容层 resolve/download 既有行为未回归

### 截图/录屏（如有 UI 变更）
本次无 UI 变更
