### PR TITLE
chore: update copyright info in LICENSE to match astron-agent

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 iFlytek Co., Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the `LICENSE` file to properly fill out the Appendix section with the exact copyright information, matching the convention established in `iflytek/astron-agent`. Specifically, replacing `Copyright [yyyy] [name of copyright owner]` with `Copyright 2025 iFlytek Co., Ltd.`.