### PR TITLE
docs: add discord server link to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/iflytek/skillhub)
 [![Docs](https://img.shields.io/badge/docs-zread.ai-4A90E2?logo=gitbook&logoColor=white)](https://zread.ai/iflytek/skillhub)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/qHYvtDNPHS)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 [![Build](https://github.com/iflytek/skillhub/actions/workflows/publish-images.yml/badge.svg)](https://github.com/iflytek/skillhub/actions/workflows/publish-images.yml)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-2496ED?logo=docker&logoColor=white)](https://ghcr.io/iflytek/skillhub)
@@ -441,6 +442,7 @@ what you'd like to change.
 
 - 💬 **Community Discussion**: [GitHub Discussions](https://github.com/iflytek/skillhub/discussions)
 - 🐛 **Bug Reports**: [Issues](https://github.com/iflytek/skillhub/issues)
+- 👾 **Discord**: [Join our Server](https://discord.gg/qHYvtDNPHS)
 - 👥 **WeChat Work Group**:
 
   ![WeChat Work Group](https://github.com/iflytek/astron-agent/raw/main/docs/imgs/WeCom_Group.png)

--- a/README_zh.md
+++ b/README_zh.md
@@ -7,6 +7,7 @@
 <div align="center">
 
 [![文档](https://img.shields.io/badge/docs-zread.ai-4A90E2?logo=gitbook&logoColor=white)](https://zread.ai/iflytek/skillhub)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/qHYvtDNPHS)
 [![许可证](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 [![构建](https://github.com/iflytek/skillhub/actions/workflows/publish-images.yml/badge.svg)](https://github.com/iflytek/skillhub/actions/workflows/publish-images.yml)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-2496ED?logo=docker&logoColor=white)](https://ghcr.io/iflytek/skillhub)
@@ -373,6 +374,7 @@ namespace `my-space` 和 skill slug `my-skill`。
 
 - 💬 **社区讨论**：[GitHub Discussions](https://github.com/iflytek/skillhub/discussions)
 - 🐛 **Bug 报告**：[Issues](https://github.com/iflytek/skillhub/issues)
+- 👾 **Discord**：[加入我们的服务器](https://discord.gg/qHYvtDNPHS)
 - 👥 **企业微信群**：
 
   ![企业微信群](https://github.com/iflytek/astron-agent/raw/main/docs/imgs/WeCom_Group.png)


### PR DESCRIPTION
This PR strictly adds the official Discord server link to the README.md and README_zh.md files.