### PR TITLE
fix(docs): correct aliyun runtime command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `--public-url` parameter sets the public access URL for your SkillHub instan
 **For users in China (Aliyun mirror):**
 
 ```bash
-curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up -- --aliyun --public-url https://skillhub.your-company.com --version latest
+curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --aliyun --public-url https://skillhub.your-company.com --version latest
 ```
 
 If deployment runs into problems, clear the existing runtime home and retry.
@@ -195,7 +195,7 @@ Published images target both `linux/amd64` and `linux/arm64`.
 curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --public-url https://skillhub.your-company.com
 
 # Aliyun mirror (recommended for users in China)
-curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up -- --aliyun --public-url https://skillhub.your-company.com --version latest
+curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --aliyun --public-url https://skillhub.your-company.com --version latest
 ```
 
 **Deployment parameters:**

--- a/README_zh.md
+++ b/README_zh.md
@@ -67,7 +67,7 @@ curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- u
 **国内用户（阿里云镜像）：**
 
 ```bash
-curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up -- --aliyun --public-url https://skillhub.your-company.com --version latest
+curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --aliyun --public-url https://skillhub.your-company.com --version latest
 ```
 
 如果部署遇到问题，请清除现有的运行时目录并重试。
@@ -177,7 +177,7 @@ skillhub/
 curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --public-url https://skillhub.your-company.com
 
 # 阿里云镜像（国内推荐）
-curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up -- --aliyun --public-url https://skillhub.your-company.com --version latest
+curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- up --aliyun --public-url https://skillhub.your-company.com --version latest
 ```
 
 ### 配置参数说明


### PR DESCRIPTION
## 概述
修复 README / README_zh 中阿里云镜像部署示例命令，移除 `up` 和 `--aliyun` 之间多余的 `--`，避免用户直接复制命令时报参数错误。

## 变更内容
- 修正 README.md 中 2 处阿里云镜像 `runtime.sh` 示例命令
- 修正 README_zh.md 中 2 处阿里云镜像 `runtime.sh` 示例命令
- 未修改脚本实现，仅校正文档示例

## 测试覆盖
- 文档变更，无新增自动化测试

## 质量门禁
- [x] `rg -n --fixed-strings "up -- --aliyun" README.md README_zh.md` 返回空结果
- [x] `rg -n --fixed-strings "up --aliyun" README.md README_zh.md` 命中 4 处修正后的示例
- [x] `git diff --check` 通过

## 安全考虑
本次变更不涉及安全敏感内容

## 测试说明
### 本地验证步骤
1. 打开 README.md 和 README_zh.md 的阿里云镜像部署章节
2. 确认命令格式为 `sh -s -- up --aliyun ...`
3. 确认不存在 `up -- --aliyun` 示例

### 回归测试范围
- README 英文部署说明
- README 中文部署说明
