### PR TITLE
fix : 修复登陆失败，事务失效问题

### DIFF
--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/local/LocalAuthFailedService.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/local/LocalAuthFailedService.java
@@ -1,0 +1,56 @@
+package com.iflytek.skillhub.auth.local;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Handles failed login attempts for local credentials.
+ * @author zhaieryuan
+ */
+@Service
+public class LocalAuthFailedService {
+
+    private static final int MAX_FAILED_ATTEMPTS = 5;
+    private static final Duration LOCK_DURATION = Duration.ofMinutes(15);
+
+    private final Clock clock;
+
+    private final LocalCredentialRepository credentialRepository;
+
+    public LocalAuthFailedService(Clock clock,
+                                  LocalCredentialRepository credentialRepository
+    ){
+        this.clock = clock;
+        this.credentialRepository = credentialRepository;
+    }
+
+
+
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+    public void handleFailedLogin(@Nonnull Long credentialId) {
+
+        LocalCredential credential = credentialRepository.findById(credentialId)
+                .orElseThrow(() -> new EntityNotFoundException("Invalid credential id"));
+
+        int failedAttempts = credential.getFailedAttempts() + 1;
+        Instant lockedUntil = credential.getLockedUntil();
+
+        if (failedAttempts >= MAX_FAILED_ATTEMPTS && lockedUntil == null) {
+            lockedUntil = currentTime().plus(LOCK_DURATION);
+        }
+
+        credentialRepository.updateFailedAttemptsAndLockedUntil(credentialId, failedAttempts, lockedUntil);
+    }
+
+    private Instant currentTime() {
+        return Instant.now(clock);
+    }
+}

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/local/LocalAuthService.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/local/LocalAuthService.java
@@ -45,13 +45,16 @@ public class LocalAuthService {
     private final PasswordEncoder passwordEncoder;
     private final Clock clock;
 
+    private final LocalAuthFailedService localAuthFailedService;
+
     public LocalAuthService(LocalCredentialRepository credentialRepository,
                             UserAccountRepository userAccountRepository,
                             UserRoleBindingRepository userRoleBindingRepository,
                             GlobalNamespaceMembershipService globalNamespaceMembershipService,
                             PasswordPolicyValidator passwordPolicyValidator,
                             PasswordEncoder passwordEncoder,
-                            Clock clock) {
+                            Clock clock,
+                            LocalAuthFailedService localAuthFailedService) {
         this.credentialRepository = credentialRepository;
         this.userAccountRepository = userAccountRepository;
         this.userRoleBindingRepository = userRoleBindingRepository;
@@ -59,6 +62,7 @@ public class LocalAuthService {
         this.passwordPolicyValidator = passwordPolicyValidator;
         this.passwordEncoder = passwordEncoder;
         this.clock = clock;
+        this.localAuthFailedService = localAuthFailedService;
     }
 
     /**
@@ -126,7 +130,7 @@ public class LocalAuthService {
         ensureNotLocked(credential);
 
         if (!passwordEncoder.matches(password, credential.getPasswordHash())) {
-            handleFailedLogin(credential);
+            localAuthFailedService.handleFailedLogin(credential.getId());
             throw invalidCredentials();
         }
 

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/local/LocalCredentialRepository.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/local/LocalCredentialRepository.java
@@ -1,7 +1,10 @@
 package com.iflytek.skillhub.auth.local;
 
+import java.time.Instant;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -15,4 +18,20 @@ public interface LocalCredentialRepository extends JpaRepository<LocalCredential
     Optional<LocalCredential> findByUserId(String userId);
 
     boolean existsByUsernameIgnoreCase(String username);
+
+    /**
+     * 更新本地凭证的失败尝试次数和锁定截止时间。
+     *
+     * @param id             凭证ID
+     * @param failedAttempts 失败尝试次数
+     * @param lockedUntil    锁定截止时间，如果为null表示不锁定
+     */
+    @Modifying
+    @Query("UPDATE LocalCredential c SET c.failedAttempts = :failedAttempts, c.lockedUntil = :lockedUntil WHERE c.id = :id")
+    void updateFailedAttemptsAndLockedUntil(
+            Long id,
+            int failedAttempts,
+            Instant lockedUntil
+    );
+
 }

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/local/LocalAuthServiceTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/local/LocalAuthServiceTest.java
@@ -51,6 +51,9 @@ class LocalAuthServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private LocalAuthFailedService localAuthFailedService;
+
     private LocalAuthService service;
 
     @BeforeEach
@@ -62,7 +65,8 @@ class LocalAuthServiceTest {
             globalNamespaceMembershipService,
             new PasswordPolicyValidator(),
             passwordEncoder,
-            CLOCK
+            CLOCK,
+            localAuthFailedService
         );
     }
 
@@ -122,8 +126,7 @@ class LocalAuthServiceTest {
             .extracting("status")
             .isEqualTo(HttpStatus.UNAUTHORIZED);
 
-        assertThat(credential.getFailedAttempts()).isEqualTo(1);
-        verify(credentialRepository).save(credential);
+        verify(localAuthFailedService).handleFailedLogin(credential.getId());
     }
 
     @Test
@@ -141,7 +144,7 @@ class LocalAuthServiceTest {
             .extracting("status")
             .isEqualTo(HttpStatus.UNAUTHORIZED);
 
-        assertThat(credential.getLockedUntil()).isEqualTo(Instant.now(CLOCK).plusSeconds(15 * 60));
+        verify(localAuthFailedService).handleFailedLogin(credential.getId());
     }
 
     @Test


### PR DESCRIPTION
---
 Summary

 - 将登录失败计数逻辑从 LocalAuthService.handleFailedLogin() 内联方法抽取到独立的
 LocalAuthFailedService，使用 @Transactional(propagation = REQUIRES_NEW)
 在独立事务中执行，确保即使外层登录事务回滚，失败计数和账户锁定仍能正确持久化
 - 在 LocalCredentialRepository 中新增 updateFailedAttemptsAndLockedUntil JPQL 更新方法，避免通过 JPA
 dirty checking 依赖外层事务
 - 修复原有实现中 @Transactional 因 Spring 代理机制对同类内部方法调用不生效的问题（self-invocation
 不经过代理，导致事务注解失效）

 Validation

 - Backend tests passed
 - Frontend typecheck/build passed（本次无前端变更，无需验证）
 - OpenAPI SDK regenerated or checked when API contracts changed（本次无 API 契约变更）
 - Smoke test run when relevant

 Commands run:

 cd server && JDK_JAVA_OPTIONS="-XX:+EnableDynamicAgentLoading" ./mvnw test -pl skillhub-auth -am
 -Dtest=LocalAuthServiceTest -Dsurefire.failIfNoSpecifiedTests=false
 # Tests run: 12, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

 Risk

 - User-facing impact: 无功能变化，仅修复事务边界。登录失败计数和锁定行为与预期设计一致
 - Deployment or migration impact: 无数据库迁移，无配置变更，可直接部署
 - Rollback approach: 直接 revert 即可，无数据兼容性问题

 Notes

 - Related issue: 登录失败时 handleFailedLogin 的 @Transactional 因 Spring self-invocation
 不生效，导致失败计数未持久化
 - Follow-up work: 建议补充 LocalAuthFailedService 的独立单元测试
 - Docs or operator runbooks updated when behavior changed: 无需更新

 ---
 涉及文件

 ┌───────────────────────────────────────────────────────────────┬────────────────────────────────┐
 │                             文件                              │              变更              │
 ├───────────────────────────────────────────────────────────────┼────────────────────────────────┤
 │ server/skillhub-auth/src/main/java/.../LocalAuthFailedService │ 新增 —                         │
 │ .java                                                         │ 独立事务处理失败登录计数       │
 ├───────────────────────────────────────────────────────────────┼────────────────────────────────┤
 │                                                               │ 注入                           │
 │ server/skillhub-auth/src/main/java/.../LocalAuthService.java  │ LocalAuthFailedService，login  │
 │                                                               │ 方法中调用替代原内联方法       │
 ├───────────────────────────────────────────────────────────────┼────────────────────────────────┤
 │ server/skillhub-auth/src/main/java/.../LocalCredentialReposit │ 新增 updateFailedAttemptsAndLo │
 │ ory.java                                                      │ ckedUntil JPQL 方法            │
 ├───────────────────────────────────────────────────────────────┼────────────────────────────────┤
 │                                                               │ 适配新架构：mock LocalAuthFail │
 │ server/skillhub-auth/src/test/.../LocalAuthServiceTest.java   │ edService，断言改为 verify     │
 │                                                               │ 调用                           │
 └───────────────────────────────────────────────────────────────┴────────────────────────────────┘