### PR TITLE
fix(env): add gitlab oauth release example config

### DIFF
--- a/.env.release.example
+++ b/.env.release.example
@@ -56,6 +56,13 @@ DEVICE_AUTH_VERIFICATION_URI=
 OAUTH2_GITHUB_CLIENT_ID=
 OAUTH2_GITHUB_CLIENT_SECRET=
 
+# Optional: configure real GitLab OAuth before exposing the stack to other users.
+# Set OAUTH2_GITLAB_BASE_URI to your self-hosted GitLab URL when applicable.
+OAUTH2_GITLAB_CLIENT_ID=
+OAUTH2_GITLAB_CLIENT_SECRET=
+OAUTH2_GITLAB_BASE_URI=https://gitlab.com
+OAUTH2_GITLAB_DISPLAY_NAME=GitLab
+
 # SMTP configuration for password reset verification emails.
 SPRING_MAIL_HOST=
 SPRING_MAIL_PORT=587


### PR DESCRIPTION
## 概述
补齐 `.env.release.example` 中缺失的 GitLab OAuth 发布配置示例，避免部署时遗漏必要环境变量。

## 变更内容

### 后端实现
- 无后端代码变更
- 无 DB migration 变更
- 无 API 契约变更

### 前端实现
- 无前端代码变更

### 测试覆盖
- 后端单测：未涉及
- 前端单测：未涉及
- E2E 测试：未涉及

## 质量门禁

- [ ] `make typecheck-web` 通过（0 errors）
- [ ] `make lint-web` 通过（0 errors, 0 warnings）
- [ ] `make test-frontend` 通过
- [ ] `make test-backend-app` 通过（如有后端变更）
- [ ] Playwright E2E（`web/e2e`）关键路径通过（如有 UI 交互变更）
- [ ] `make generate-api` 已执行且 `schema.d.ts` 已提交（如有 Controller 变更）

说明：本次仅修改 `.env.release.example`，未涉及 `server/**/*.java`、`web/src/**/*.ts(x)` 或 Controller，因此上述代码类检查与测试不适用，已通过本地 diff 校验和变量名对齐校验确认变更正确。

## 安全考虑

- 本次变更不涉及安全敏感内容
- 新增项仅为发布配置示例占位符，不包含真实密钥

## 相关 Issue

Related to #N/A

## 测试说明

### 本地验证步骤
1. 打开 `.env.release.example`
2. 确认存在 `OAUTH2_GITLAB_CLIENT_ID`、`OAUTH2_GITLAB_CLIENT_SECRET`、`OAUTH2_GITLAB_BASE_URI`、`OAUTH2_GITLAB_DISPLAY_NAME`
3. 对照 `server/skillhub-app/src/main/resources/application.yml` 中 GitLab OAuth 配置占位符，确认变量名一致

### 回归测试范围
- 发布环境初始化配置
- GitLab OAuth 部署文档/示例配置读取

### 截图/录屏（如有 UI 变更）
无
