### PR TITLE
fix(search): harden portal search query parsing

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillSearchController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillSearchController.java
@@ -6,10 +6,13 @@ import com.iflytek.skillhub.dto.ApiResponse;
 import com.iflytek.skillhub.dto.ApiResponseFactory;
 import com.iflytek.skillhub.ratelimit.RateLimit;
 import com.iflytek.skillhub.service.SkillSearchAppService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Portal search endpoint that adapts HTTP query parameters to the search
@@ -18,6 +21,10 @@ import java.util.Map;
 @RestController
 @RequestMapping({"/api/web/skills"})
 public class SkillSearchController extends BaseApiController {
+    private static final Pattern NON_NEGATIVE_INTEGER = Pattern.compile("\\d+");
+    private static final String DEFAULT_SORT = "newest";
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
 
     private final SkillSearchAppService skillSearchAppService;
 
@@ -33,23 +40,53 @@ public class SkillSearchController extends BaseApiController {
             @RequestParam(required = false) String q,
             @RequestParam(required = false) String namespace,
             @RequestParam(name = "label", required = false) java.util.List<String> labels,
-            @RequestParam(defaultValue = "newest") String sort,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size,
+            @Parameter(schema = @Schema(defaultValue = DEFAULT_SORT))
+            @RequestParam(required = false) String sort,
+            @Parameter(schema = @Schema(type = "integer", defaultValue = "0", minimum = "0"))
+            @RequestParam(required = false) String page,
+            @Parameter(schema = @Schema(type = "integer", defaultValue = "20", minimum = "1"))
+            @RequestParam(required = false) String size,
             @RequestAttribute(value = "userId", required = false) String userId,
             @RequestAttribute(value = "userNsRoles", required = false) Map<Long, NamespaceRole> userNsRoles) {
 
         SkillSearchAppService.SearchResponse response = skillSearchAppService.search(
                 q,
                 namespace,
-                sort,
-                page,
-                size,
+                normalizeSort(sort),
+                parseNonNegativeInt(page, DEFAULT_PAGE),
+                parsePositiveInt(size, DEFAULT_SIZE),
                 labels,
                 userId,
                 userNsRoles
         );
 
         return ok("response.success.read", response);
+    }
+
+    private String normalizeSort(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return DEFAULT_SORT;
+        }
+        return sort.trim();
+    }
+
+    private int parseNonNegativeInt(String rawValue, int defaultValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return defaultValue;
+        }
+        String normalized = rawValue.trim();
+        if (!NON_NEGATIVE_INTEGER.matcher(normalized).matches()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(normalized);
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    private int parsePositiveInt(String rawValue, int defaultValue) {
+        int parsed = parseNonNegativeInt(rawValue, defaultValue);
+        return parsed > 0 ? parsed : defaultValue;
     }
 }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/SkillSearchControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/SkillSearchControllerTest.java
@@ -100,4 +100,47 @@ class SkillSearchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.items").isArray());
     }
+
+    @Test
+    void searchShouldFallbackToDefaultsForBlankQueryParams() throws Exception {
+        when(skillSearchAppService.search(
+                eq(null),
+                eq(null),
+                eq("newest"),
+                eq(0),
+                eq(20),
+                eq(null),
+                any(),
+                any()))
+                .thenReturn(new SkillSearchAppService.SearchResponse(List.of(), 0, 0, 20));
+
+        mockMvc.perform(get("/api/web/skills")
+                        .param("sort", " ")
+                        .param("page", "")
+                        .param("size", " "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(20));
+    }
+
+    @Test
+    void searchShouldFallbackToDefaultsForInvalidPagination() throws Exception {
+        when(skillSearchAppService.search(
+                eq(null),
+                eq(null),
+                eq("newest"),
+                eq(0),
+                eq(20),
+                eq(null),
+                any(),
+                any()))
+                .thenReturn(new SkillSearchAppService.SearchResponse(List.of(), 0, 0, 20));
+
+        mockMvc.perform(get("/api/web/skills")
+                        .param("page", "NaN")
+                        .param("size", "-12"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(20));
+    }
 }

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -468,6 +468,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/skills/{namespace}/{slug}/submit-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["submitForReview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/web/skills/{namespace}/{slug}/submit-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["submitForReview_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/skills/{namespace}/{slug}/reports": {
         parameters: {
             query?: never;
@@ -494,6 +526,38 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["submitReport_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/web/skills/{namespace}/{slug}/confirm-publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["confirmPublish"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/skills/{namespace}/{slug}/confirm-publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["confirmPublish_1"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3239,6 +3303,10 @@ export interface components {
             targetVersion: string;
             confirmWarnings?: boolean;
         };
+        SubmitReviewRequest: {
+            version: string;
+            targetVisibility: string;
+        };
         SkillReportSubmitRequest: {
             reason?: string;
             details?: string;
@@ -3256,6 +3324,9 @@ export interface components {
             /** Format: int64 */
             reportId?: number;
             status?: string;
+        };
+        ConfirmPublishRequest: {
+            version: string;
         };
         AdminSkillActionRequest: {
             reason?: string;
@@ -5569,6 +5640,60 @@ export interface operations {
             };
         };
     };
+    submitForReview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubmitReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
+    submitForReview_1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubmitReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
     submitReport: {
         parameters: {
             query?: never;
@@ -5619,6 +5744,60 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["ApiResponseSkillReportMutationResponse"];
+                };
+            };
+        };
+    };
+    confirmPublish: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmPublishRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
+    confirmPublish_1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmPublishRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
                 };
             };
         };


### PR DESCRIPTION
## 概述
修复搜索页首屏进入时 `/api/web/skills` 因异常 query 参数绑定直接返回 400 的问题，并补齐对应的后端回归测试与 OpenAPI 同步。

## 变更内容

### 后端实现
- 将 `SkillSearchController` 的 `sort`、`page`、`size` 改为显式兜底解析，避免空白值、非法值和溢出值在进入业务层前被 Spring 参数绑定直接打成 400。
- 保持搜索接口默认行为不变：`sort` 默认 `newest`，`page` 默认 `0`，`size` 默认 `20`。
- 为上述 query 参数补充 OpenAPI `@Schema` 元数据，维持生成契约中的整数默认值与约束表达。
- 无 DB migration 变更。
- API 契约层变更：执行了 `api-drift` 检查，并提交了生成后的 `web/src/api/generated/schema.d.ts`。

### 前端实现
- 本次无前端源码改动。
- 无状态管理和 UI/UX 变更。

### 测试覆盖
- 后端单测：扩展 `SkillSearchControllerTest`
  - 覆盖空白 `sort/page/size` 时回落默认值
  - 覆盖非法分页参数（如 `page=NaN`、`size=-12`）时回落默认值
- 前端单测：无源码改动，执行现有前端单测回归
- E2E 测试：本次无 `web/src/**/*.ts(x)` 变更，按工作流无需新增/执行 Playwright E2E

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] `make test-frontend` 通过
- [x] `make test-backend-app` 通过
- [x] Playwright E2E（`web/e2e`）关键路径通过（本次无前端页面交互变更，N/A）
- [x] `make generate-api` / `./scripts/check-openapi-generated.sh` 已执行，`schema.d.ts` 已同步提交

## 安全考虑

- 本次变更不涉及鉴权/授权逻辑调整。
- 主要安全收益是增强搜索入口对异常输入的容错，避免因非法 query 参数触发不必要的 400。
- 未引入硬编码敏感信息。
- 输入仍通过既有查询链路处理，不新增 SQL 拼接或 XSS 风险面。

## 相关 Issue

Closes #330

## 测试说明

### 本地验证步骤
1. 启动依赖服务与后端/前端，进入 `/search?q=&sort=newest&page=0&starredOnly=false`。
2. 观察首屏请求 `/api/web/skills?sort=newest&page=0&size=12`。
3. 预期结果：接口返回 200，搜索页正常渲染，不再出现“请求参数不合法”。
4. 额外验证：访问带异常参数的请求，例如 `/api/web/skills?page=NaN&size=-12`。
5. 预期结果：接口回落默认分页参数并返回 200。

### 回归测试范围
- Portal 搜索页首屏加载
- 搜索接口 query 参数解析与默认值回退逻辑
- OpenAPI 生成类型同步
- 前端现有类型检查、Lint 与单测回归

### 截图/录屏（如有 UI 变更）
- 本次无 UI 变更
