### PR TITLE
fix(search): restore clawhub namespace-only access

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubRegistrySecurityConfig.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubRegistrySecurityConfig.java
@@ -1,11 +1,13 @@
 package com.iflytek.skillhub.compat;
 
+import com.iflytek.skillhub.auth.token.ApiTokenAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 
@@ -37,7 +39,9 @@ public class ClawHubRegistrySecurityConfig {
 
     @Bean
     @Order(1)
-    public SecurityFilterChain clawHubRegistryFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain clawHubRegistryFilterChain(
+            HttpSecurity http,
+            ApiTokenAuthenticationFilter apiTokenAuthenticationFilter) throws Exception {
         http
                 .securityMatcher(
                         "/api/v1/search",
@@ -46,7 +50,8 @@ public class ClawHubRegistrySecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .requestCache(cache -> cache.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(apiTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/AuthContextFilter.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/AuthContextFilter.java
@@ -16,7 +16,9 @@ import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +30,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * Projects the authenticated principal into request attributes consumed by the controller layer.
  */
 @Component
+@Order(SecurityProperties.DEFAULT_FILTER_ORDER + 1)
 public class AuthContextFilter extends OncePerRequestFilter {
 
     private final NamespaceMemberRepository namespaceMemberRepository;

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -2,15 +2,22 @@ package com.iflytek.skillhub.compat;
 
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.auth.device.DeviceAuthService;
+import com.iflytek.skillhub.auth.entity.ApiToken;
+import com.iflytek.skillhub.auth.repository.UserRoleBindingRepository;
+import com.iflytek.skillhub.auth.token.ApiTokenService;
 import com.iflytek.skillhub.domain.audit.AuditLogService;
 import com.iflytek.skillhub.domain.namespace.Namespace;
+import com.iflytek.skillhub.domain.namespace.NamespaceMember;
 import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
+import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVersionStatus;
 import com.iflytek.skillhub.domain.skill.service.SkillQueryService;
 import com.iflytek.skillhub.domain.skill.service.SkillPublishService;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
+import com.iflytek.skillhub.domain.user.UserAccount;
+import com.iflytek.skillhub.domain.user.UserAccountRepository;
 import com.iflytek.skillhub.dto.SkillLifecycleVersionResponse;
 import com.iflytek.skillhub.dto.SkillSummaryResponse;
 import com.iflytek.skillhub.service.SkillSearchAppService;
@@ -39,6 +46,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -66,6 +74,15 @@ class ClawHubCompatControllerTest {
 
     @MockBean
     private SkillQueryService skillQueryService;
+
+    @MockBean
+    private ApiTokenService apiTokenService;
+
+    @MockBean
+    private UserAccountRepository userAccountRepository;
+
+    @MockBean
+    private UserRoleBindingRepository userRoleBindingRepository;
 
     @MockBean
     private CompatSkillLookupService compatSkillLookupService;
@@ -109,6 +126,56 @@ class ClawHubCompatControllerTest {
                 .andExpect(jsonPath("$.results[0].slug").value("my-skill"))
                 .andExpect(jsonPath("$.results[0].summary").value("test summary"))
                 .andExpect(jsonPath("$.results[0].version").value("1.2.0"));
+    }
+
+    @Test
+    void search_withBearerToken_shouldProjectNamespaceRolesIntoRequestContext() throws Exception {
+        ApiToken token = new ApiToken("user-7", "cli", "sk_test", "hash", "[]");
+        UserAccount user = new UserAccount("user-7", "Alice", "alice@example.com", null);
+        var nsRoles = java.util.Map.of(9L, NamespaceRole.MEMBER);
+
+        when(apiTokenService.validateToken("raw-token")).thenReturn(Optional.of(token));
+        when(userAccountRepository.findById("user-7")).thenReturn(Optional.of(user));
+        when(userRoleBindingRepository.findByUserId("user-7")).thenReturn(List.of());
+        when(namespaceMemberRepository.findByUserId("user-7"))
+                .thenReturn(List.of(new NamespaceMember(9L, "user-7", NamespaceRole.MEMBER)));
+        when(skillSearchAppService.search("token-search", null, "relevance", 0, 20, "user-7", nsRoles))
+                .thenReturn(new SkillSearchAppService.SearchResponse(List.of(), 0, 0, 20));
+
+        mockMvc.perform(get("/api/v1/search")
+                        .param("q", "token-search")
+                        .header("Authorization", "Bearer raw-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results").isArray());
+
+        verify(skillSearchAppService).search("token-search", null, "relevance", 0, 20, "user-7", nsRoles);
+        verify(apiTokenService).touchLastUsed(same(token));
+    }
+
+    @Test
+    void downloadQuery_withBearerToken_shouldProjectNamespaceRolesIntoRequestContext() throws Exception {
+        ApiToken token = new ApiToken("user-7", "cli", "sk_test", "hash", "[]");
+        UserAccount user = new UserAccount("user-7", "Alice", "alice@example.com", null);
+        var nsRoles = java.util.Map.of(9L, NamespaceRole.MEMBER);
+
+        when(apiTokenService.validateToken("raw-token")).thenReturn(Optional.of(token));
+        when(userAccountRepository.findById("user-7")).thenReturn(Optional.of(user));
+        when(userRoleBindingRepository.findByUserId("user-7")).thenReturn(List.of());
+        when(namespaceMemberRepository.findByUserId("user-7"))
+                .thenReturn(List.of(new NamespaceMember(9L, "user-7", NamespaceRole.MEMBER)));
+        when(compatSkillLookupService.findByLegacySlug("private-skill"))
+                .thenReturn(legacyCompatContext("team-ai", "private-skill"));
+        when(compatSkillLookupService.canAccess(any(), eq("user-7"), eq(nsRoles))).thenReturn(true);
+
+        mockMvc.perform(get("/api/v1/download")
+                        .param("slug", "private-skill")
+                        .param("version", "latest")
+                        .header("Authorization", "Bearer raw-token"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "/api/v1/skills/team-ai/private-skill/download"));
+
+        verify(compatSkillLookupService).canAccess(any(), eq("user-7"), eq(nsRoles));
+        verify(apiTokenService).touchLastUsed(same(token));
     }
 
     @Test

--- a/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
+++ b/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
@@ -102,10 +102,6 @@ public class PostgresFullTextQueryService implements SearchQueryService {
         Set<Long> memberNamespaceIds = query.visibilityScope().memberNamespaceIds().isEmpty()
                 ? Set.of(-1L)
                 : query.visibilityScope().memberNamespaceIds();
-        Set<Long> adminNamespaceIds = query.visibilityScope().adminNamespaceIds().isEmpty()
-                ? Set.of(-1L)
-                : query.visibilityScope().adminNamespaceIds();
-
         StringBuilder sql = new StringBuilder();
         sql.append("SELECT d.skill_id ");
         sql.append("FROM skill_search_document d ");
@@ -190,7 +186,6 @@ public class PostgresFullTextQueryService implements SearchQueryService {
 
         if (query.visibilityScope().userId() != null) {
             nativeQuery.setParameter("memberNamespaceIds", memberNamespaceIds);
-            nativeQuery.setParameter("adminNamespaceIds", adminNamespaceIds);
         }
 
         if (query.namespaceId() != null) {
@@ -235,7 +230,6 @@ public class PostgresFullTextQueryService implements SearchQueryService {
 
         if (query.visibilityScope().userId() != null) {
             countQuery.setParameter("memberNamespaceIds", memberNamespaceIds);
-            countQuery.setParameter("adminNamespaceIds", adminNamespaceIds);
         }
 
         if (query.namespaceId() != null) {

--- a/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryServiceTest.java
+++ b/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryServiceTest.java
@@ -393,6 +393,34 @@ class PostgresFullTextQueryServiceTest {
     }
 
     @Test
+    void authenticatedQueriesShouldNotBindUnusedAdminNamespaceIdsParameter() {
+        EntityManager entityManager = mock(EntityManager.class);
+        Query nativeQuery = mock(Query.class);
+        Query countQuery = mock(Query.class);
+        when(entityManager.createNativeQuery(anyString()))
+                .thenReturn(nativeQuery)
+                .thenReturn(countQuery);
+        when(nativeQuery.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(nativeQuery);
+        when(countQuery.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(countQuery);
+        when(nativeQuery.getResultList()).thenReturn(List.of());
+        when(countQuery.getSingleResult()).thenReturn(0L);
+
+        PostgresFullTextQueryService service = new PostgresFullTextQueryService(entityManager);
+
+        service.search(new SearchQuery(
+                "issue331",
+                null,
+                new SearchVisibilityScope("user-1", Set.of(7L), Set.of(9L)),
+                "relevance",
+                0,
+                20
+        ));
+
+        verify(nativeQuery, never()).setParameter("adminNamespaceIds", Set.of(9L));
+        verify(countQuery, never()).setParameter("adminNamespaceIds", Set.of(9L));
+    }
+
+    @Test
     void platformWideAccessShouldNotBypassVisibilityInPortalSearch() {
         EntityManager entityManager = mock(EntityManager.class);
         Query nativeQuery = mock(Query.class);


### PR DESCRIPTION
## 概述
修复命名空间可见技能在 ClawHub 兼容链路下的搜索与安装访问问题，恢复 bearer token 请求在兼容搜索/下载路径上的正确用户上下文投影，并消除认证态搜索误报 `400 Invalid request` 的问题。

## 变更内容

### 后端实现
- 调整 `ClawHubRegistrySecurityConfig`，将 API Token 鉴权接入 ClawHub 兼容路由，确保 bearer token 调用兼容搜索/下载接口时能够建立正确的认证上下文。
- 调整 `AuthContextFilter` 的执行时序，确保其在 Spring Security 完成认证后再读取并投影用户上下文，避免兼容链路下上下文缺失。
- 修复 `PostgresFullTextQueryService` 中认证态搜索的 native query 参数绑定问题，移除未在 SQL 中使用的 `adminNamespaceIds` 绑定，避免搜索接口在认证请求下抛出 `IllegalArgumentException` 并被包装为 `400 Invalid request`。
- 本次变更未涉及 DB migration。
- 本次变更未修改 Controller API 契约。

### 前端实现
- 本次变更不涉及 `web/src/**/*.ts(x)` 前端页面或交互逻辑修改。
- 本次变更不涉及路由、状态管理或 UI/UX 改动。

### 测试覆盖
- 后端单测：补充 `PostgresFullTextQueryServiceTest`，覆盖认证态搜索参数绑定回归场景。
- 后端单测：补充 `ClawHubCompatControllerTest`，覆盖 bearer token 下兼容搜索/下载链路的回归场景。
- 前端单测：无。
- E2E 测试：无新增 Playwright 用例；本次无前端交互变更。

## 质量门禁
- [ ] `make typecheck-web` 通过（本次未执行；无前端源码变更）
- [ ] `make lint-web` 通过（本次未执行；无前端源码变更）
- [ ] `make test-frontend` 通过（本次未执行；无前端源码变更）
- [x] `make test-backend-app` 通过
- [ ] Playwright E2E（`web/e2e`）关键路径通过（N/A，本次无 UI 交互变更）
- [ ] `make generate-api` 已执行且 `schema.d.ts` 已提交（N/A，本次未修改 Controller）

## 安全考虑
- 本次变更涉及鉴权/授权链路修复：确保 bearer token 访问兼容搜索与下载接口时能够按调用者身份正确执行可见性判断。
- 本次变更不引入新的对外暴露接口。
- 本次变更不涉及敏感数据存储格式调整。
- 本次变更不涉及额外的输入面扩张，主要修复认证态搜索请求在后端查询层的异常处理问题。

## 相关 Issue
Closes #331

## 测试说明

### 本地验证步骤
1. 启动完整本地环境：`make dev-all`
2. 执行后端回归测试：
   - `cd server && JDK_JAVA_OPTIONS="-XX:+EnableDynamicAgentLoading" ./mvnw -pl skillhub-search -am test -Dtest=PostgresFullTextQueryServiceTest -Dsurefire.failIfNoSpecifiedTests=false`
   - `cd server && JDK_JAVA_OPTIONS="-XX:+EnableDynamicAgentLoading" ./mvnw -pl skillhub-app -am test -Dtest=ClawHubCompatControllerTest,AuthContextFilterTest -Dsurefire.failIfNoSpecifiedTests=false`
   - `make test-backend-app`
3. 运行本地 ClawHub smoke test，针对命名空间可见 skill 验证 `login / whoami / search / install` 流程。
4. 预期结果：bearer token 请求可正常命中兼容搜索与下载接口；认证态搜索不再返回 `400 Invalid request`；命名空间可见 skill 可被正确搜索和安装。

### 回归测试范围
- ClawHub 兼容搜索接口
- ClawHub 兼容下载/安装接口
- `AuthContextFilter` 认证上下文投影
- PostgreSQL 搜索查询参数绑定与认证态可见性过滤

### 截图/录屏（如有 UI 变更）
本次变更无 UI 变更。
