### PR TITLE
feat(compat): add visibility parameter support to ClawHub publish API

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatAppService.java
@@ -14,6 +14,7 @@ import com.iflytek.skillhub.controller.support.MultipartPackageExtractor;
 import com.iflytek.skillhub.controller.support.ZipPackageExtractor;
 import com.iflytek.skillhub.domain.audit.AuditLogService;
 import com.iflytek.skillhub.domain.namespace.NamespaceRole;
+import com.iflytek.skillhub.domain.shared.exception.DomainBadRequestException;
 import com.iflytek.skillhub.domain.shared.exception.DomainNotFoundException;
 import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
@@ -294,11 +295,12 @@ public class ClawHubCompatAppService {
                                                String userAgent) throws IOException {
         MultipartPackageExtractor.ExtractedPackage extracted = multipartPackageExtractor.extract(files, payloadJson);
         String namespace = determineNamespace(extracted.payload());
+        SkillVisibility visibility = parseVisibility(extracted.payload().visibility());
         SkillPublishService.PublishResult result = skillPublishService.publishFromEntries(
                 namespace,
                 extracted.entries(),
                 principal.userId(),
-                SkillVisibility.PUBLIC,
+                visibility,
                 principal.platformRoles(),
                 confirmWarnings
         );
@@ -309,15 +311,17 @@ public class ClawHubCompatAppService {
 
     public ClawHubPublishResponse publish(MultipartFile file,
                                           String namespace,
+                                          String visibility,
                                           boolean confirmWarnings,
                                           PlatformPrincipal principal,
                                           String clientIp,
                                           String userAgent) throws IOException {
+        SkillVisibility parsedVisibility = parseVisibility(visibility);
         SkillPublishService.PublishResult result = skillPublishService.publishFromEntries(
                 namespace,
                 zipPackageExtractor.extract(file),
                 principal.userId(),
-                SkillVisibility.PUBLIC,
+                parsedVisibility,
                 principal.platformRoles(),
                 confirmWarnings
         );
@@ -418,6 +422,21 @@ public class ClawHubCompatAppService {
             return trimmed.substring(1);
         }
         return trimmed;
+    }
+
+    private SkillVisibility parseVisibility(String visibilityStr) {
+        if (visibilityStr == null || visibilityStr.isBlank()) {
+            return SkillVisibility.PUBLIC;
+        }
+        return switch (visibilityStr.toLowerCase()) {
+            case "public" -> SkillVisibility.PUBLIC;
+            case "namespace" -> SkillVisibility.NAMESPACE_ONLY;
+            case "private" -> SkillVisibility.PRIVATE;
+            default -> throw new DomainBadRequestException(
+                "error.skill.publish.invalid.visibility",
+                "Invalid visibility: " + visibilityStr + ". Must be 'public', 'namespace', or 'private'"
+            );
+        };
     }
 
     private void recordCompatPublishAudit(String userId,

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubCompatController.java
@@ -155,12 +155,14 @@ public class ClawHubCompatController {
     @PostMapping("/publish")
     public ClawHubPublishResponse publish(@RequestParam("file") MultipartFile file,
                                           @RequestParam("namespace") String namespace,
+                                          @RequestParam(value = "visibility", required = false) String visibility,
                                           @RequestParam(value = "confirmWarnings", defaultValue = "false") boolean confirmWarnings,
                                           @AuthenticationPrincipal PlatformPrincipal principal,
                                           HttpServletRequest request) throws IOException {
         return clawHubCompatAppService.publish(
                 file,
                 namespace,
+                visibility,
                 confirmWarnings,
                 principal,
                 request.getRemoteAddr(),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/support/MultipartPackageExtractor.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/support/MultipartPackageExtractor.java
@@ -37,7 +37,8 @@ public class MultipartPackageExtractor {
         String changelog,
         Boolean acceptLicenseTerms,
         List<String> tags,
-        ForkOf forkOf
+        ForkOf forkOf,
+        String visibility
     ) {
         public record ForkOf(String slug, String version) {}
     }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -304,6 +304,99 @@ class ClawHubCompatControllerTest {
                 .andExpect(jsonPath("$.versionId").value("36"));
     }
 
+    @Test
+    void publish_skill_with_namespace_visibility() throws Exception {
+        SkillVersion version = publishVersion("1.0.0", 37L);
+        given(skillPublishService.publishFromEntries(
+                eq("global"),
+                anyList(),
+                eq("user-42"),
+                eq(SkillVisibility.NAMESPACE_ONLY),
+                eq(Set.of("SUPER_ADMIN")),
+                eq(false)))
+                .willReturn(new SkillPublishService.PublishResult(15L, "my-skill", version));
+
+        mockMvc.perform(multipart("/api/v1/skills")
+                        .file(skillMdFile())
+                        .param("payload", """
+                                {"slug":"my-skill","displayName":"My Skill","version":"1.0.0","visibility":"namespace","acceptLicenseTerms":true,"tags":["latest"]}
+                                """)
+                        .with(authentication(superAdminAuth()))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.skillId").value("15"))
+                .andExpect(jsonPath("$.versionId").value("37"));
+    }
+
+    @Test
+    void publish_skill_with_private_visibility() throws Exception {
+        SkillVersion version = publishVersion("1.0.0", 38L);
+        given(skillPublishService.publishFromEntries(
+                eq("global"),
+                anyList(),
+                eq("user-42"),
+                eq(SkillVisibility.PRIVATE),
+                eq(Set.of("SUPER_ADMIN")),
+                eq(false)))
+                .willReturn(new SkillPublishService.PublishResult(16L, "my-skill", version));
+
+        mockMvc.perform(multipart("/api/v1/skills")
+                        .file(skillMdFile())
+                        .param("payload", """
+                                {"slug":"my-skill","displayName":"My Skill","version":"1.0.0","visibility":"private","acceptLicenseTerms":true,"tags":["latest"]}
+                                """)
+                        .with(authentication(superAdminAuth()))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.skillId").value("16"))
+                .andExpect(jsonPath("$.versionId").value("38"));
+    }
+
+    @Test
+    void publish_skill_with_invalid_visibility_returns_400() throws Exception {
+        mockMvc.perform(multipart("/api/v1/skills")
+                        .file(skillMdFile())
+                        .param("payload", """
+                                {"slug":"my-skill","displayName":"My Skill","version":"1.0.0","visibility":"invalid","acceptLicenseTerms":true,"tags":["latest"]}
+                                """)
+                        .with(authentication(superAdminAuth()))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void publish_via_post_endpoint_with_visibility_parameter() throws Exception {
+        SkillVersion version = publishVersion("1.0.0", 39L);
+        MockMultipartFile zipFile = new MockMultipartFile(
+                "file",
+                "skill.zip",
+                "application/zip",
+                "fake-zip-content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        given(skillPublishService.publishFromEntries(
+                eq("test-namespace"),
+                anyList(),
+                eq("user-42"),
+                eq(SkillVisibility.NAMESPACE_ONLY),
+                eq(Set.of("SUPER_ADMIN")),
+                eq(false)))
+                .willReturn(new SkillPublishService.PublishResult(17L, "my-skill", version));
+
+        mockMvc.perform(multipart("/api/v1/publish")
+                        .file(zipFile)
+                        .param("namespace", "test-namespace")
+                        .param("visibility", "namespace")
+                        .with(authentication(superAdminAuth()))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.skillId").value("17"))
+                .andExpect(jsonPath("$.versionId").value("39"));
+    }
+
     private CompatSkillLookupService.CompatSkillContext legacyCompatContext(String namespaceSlug, String skillSlug) {
         Namespace namespace = new Namespace(namespaceSlug, namespaceSlug, "tester");
         Skill skill = new Skill(1L, skillSlug, "tester", SkillVisibility.PUBLIC);


### PR DESCRIPTION
## Summary

Adds support for specifying skill visibility (`public`/`namespace`/`private`) when publishing via ClawHub compatibility endpoints, resolving issue #314.

- Add `visibility` field to `PublishPayload` record in multipart package extractor
- Add optional `visibility` query parameter to `POST /api/v1/publish` endpoint  
- Parse and validate visibility string with proper error handling (400 for invalid values)
- Default to `PUBLIC` for backward compatibility when visibility is not specified
- Add comprehensive test coverage for all visibility options (namespace, private, invalid)

## Changes

**Backend:**
- `MultipartPackageExtractor.java` - Added `visibility` field to `PublishPayload` record
- `ClawHubCompatAppService.java` - Added `parseVisibility()` method and updated both publish methods to use parsed visibility
- `ClawHubCompatController.java` - Added optional `visibility` parameter to `/api/v1/publish` endpoint

**Tests:**
- `ClawHubCompatControllerTest.java` - Added 4 new test cases covering namespace visibility, private visibility, invalid visibility validation, and query parameter support

## Test Plan

- [x] All existing tests pass (16 tests in ClawHubCompatControllerTest, 0 failures)
- [x] New tests verify namespace visibility publishing
- [x] New tests verify private visibility publishing  
- [x] New tests verify invalid visibility returns 400 error
- [x] New tests verify visibility parameter via query string
- [x] Backward compatibility verified (defaults to PUBLIC when not specified)
- [ ] Manual testing with `clawhub` CLI after it's updated to support `--visibility` flag

## Notes

- No database migration needed - the `visibility` column already exists in the `skill` table
- The external `clawhub` CLI tool will need to be updated separately to pass the `--visibility` flag
- Case-insensitive parsing (accepts "public", "Public", "PUBLIC", etc.)

Closes #314