### PR TITLE
fix(search): harden portal query parsing

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubRegistrySecurityConfig.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/ClawHubRegistrySecurityConfig.java
@@ -1,11 +1,13 @@
 package com.iflytek.skillhub.compat;
 
+import com.iflytek.skillhub.auth.token.ApiTokenAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 
@@ -37,7 +39,9 @@ public class ClawHubRegistrySecurityConfig {
 
     @Bean
     @Order(1)
-    public SecurityFilterChain clawHubRegistryFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain clawHubRegistryFilterChain(
+            HttpSecurity http,
+            ApiTokenAuthenticationFilter apiTokenAuthenticationFilter) throws Exception {
         http
                 .securityMatcher(
                         "/api/v1/search",
@@ -46,7 +50,8 @@ public class ClawHubRegistrySecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .requestCache(cache -> cache.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(apiTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillSearchController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillSearchController.java
@@ -6,10 +6,13 @@ import com.iflytek.skillhub.dto.ApiResponse;
 import com.iflytek.skillhub.dto.ApiResponseFactory;
 import com.iflytek.skillhub.ratelimit.RateLimit;
 import com.iflytek.skillhub.service.SkillSearchAppService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Portal search endpoint that adapts HTTP query parameters to the search
@@ -18,6 +21,10 @@ import java.util.Map;
 @RestController
 @RequestMapping({"/api/web/skills"})
 public class SkillSearchController extends BaseApiController {
+    private static final Pattern NON_NEGATIVE_INTEGER = Pattern.compile("\\d+");
+    private static final String DEFAULT_SORT = "newest";
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
 
     private final SkillSearchAppService skillSearchAppService;
 
@@ -33,23 +40,53 @@ public class SkillSearchController extends BaseApiController {
             @RequestParam(required = false) String q,
             @RequestParam(required = false) String namespace,
             @RequestParam(name = "label", required = false) java.util.List<String> labels,
-            @RequestParam(defaultValue = "newest") String sort,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size,
+            @Parameter(schema = @Schema(defaultValue = DEFAULT_SORT))
+            @RequestParam(required = false) String sort,
+            @Parameter(schema = @Schema(type = "integer", defaultValue = "0", minimum = "0"))
+            @RequestParam(required = false) String page,
+            @Parameter(schema = @Schema(type = "integer", defaultValue = "20", minimum = "1"))
+            @RequestParam(required = false) String size,
             @RequestAttribute(value = "userId", required = false) String userId,
             @RequestAttribute(value = "userNsRoles", required = false) Map<Long, NamespaceRole> userNsRoles) {
 
         SkillSearchAppService.SearchResponse response = skillSearchAppService.search(
                 q,
                 namespace,
-                sort,
-                page,
-                size,
+                normalizeSort(sort),
+                parseNonNegativeInt(page, DEFAULT_PAGE),
+                parsePositiveInt(size, DEFAULT_SIZE),
                 labels,
                 userId,
                 userNsRoles
         );
 
         return ok("response.success.read", response);
+    }
+
+    private String normalizeSort(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return DEFAULT_SORT;
+        }
+        return sort.trim();
+    }
+
+    private int parseNonNegativeInt(String rawValue, int defaultValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return defaultValue;
+        }
+        String normalized = rawValue.trim();
+        if (!NON_NEGATIVE_INTEGER.matcher(normalized).matches()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(normalized);
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    private int parsePositiveInt(String rawValue, int defaultValue) {
+        int parsed = parseNonNegativeInt(rawValue, defaultValue);
+        return parsed > 0 ? parsed : defaultValue;
     }
 }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/AuthContextFilter.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/AuthContextFilter.java
@@ -16,7 +16,9 @@ import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +30,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * Projects the authenticated principal into request attributes consumed by the controller layer.
  */
 @Component
+@Order(SecurityProperties.DEFAULT_FILTER_ORDER + 1)
 public class AuthContextFilter extends OncePerRequestFilter {
 
     private final NamespaceMemberRepository namespaceMemberRepository;

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -2,15 +2,22 @@ package com.iflytek.skillhub.compat;
 
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.auth.device.DeviceAuthService;
+import com.iflytek.skillhub.auth.entity.ApiToken;
+import com.iflytek.skillhub.auth.repository.UserRoleBindingRepository;
+import com.iflytek.skillhub.auth.token.ApiTokenService;
 import com.iflytek.skillhub.domain.audit.AuditLogService;
 import com.iflytek.skillhub.domain.namespace.Namespace;
+import com.iflytek.skillhub.domain.namespace.NamespaceMember;
 import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
+import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVersionStatus;
 import com.iflytek.skillhub.domain.skill.service.SkillQueryService;
 import com.iflytek.skillhub.domain.skill.service.SkillPublishService;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
+import com.iflytek.skillhub.domain.user.UserAccount;
+import com.iflytek.skillhub.domain.user.UserAccountRepository;
 import com.iflytek.skillhub.dto.SkillLifecycleVersionResponse;
 import com.iflytek.skillhub.dto.SkillSummaryResponse;
 import com.iflytek.skillhub.service.SkillSearchAppService;
@@ -39,6 +46,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -66,6 +74,15 @@ class ClawHubCompatControllerTest {
 
     @MockBean
     private SkillQueryService skillQueryService;
+
+    @MockBean
+    private ApiTokenService apiTokenService;
+
+    @MockBean
+    private UserAccountRepository userAccountRepository;
+
+    @MockBean
+    private UserRoleBindingRepository userRoleBindingRepository;
 
     @MockBean
     private CompatSkillLookupService compatSkillLookupService;
@@ -109,6 +126,56 @@ class ClawHubCompatControllerTest {
                 .andExpect(jsonPath("$.results[0].slug").value("my-skill"))
                 .andExpect(jsonPath("$.results[0].summary").value("test summary"))
                 .andExpect(jsonPath("$.results[0].version").value("1.2.0"));
+    }
+
+    @Test
+    void search_withBearerToken_shouldProjectNamespaceRolesIntoRequestContext() throws Exception {
+        ApiToken token = new ApiToken("user-7", "cli", "sk_test", "hash", "[]");
+        UserAccount user = new UserAccount("user-7", "Alice", "alice@example.com", null);
+        var nsRoles = java.util.Map.of(9L, NamespaceRole.MEMBER);
+
+        when(apiTokenService.validateToken("raw-token")).thenReturn(Optional.of(token));
+        when(userAccountRepository.findById("user-7")).thenReturn(Optional.of(user));
+        when(userRoleBindingRepository.findByUserId("user-7")).thenReturn(List.of());
+        when(namespaceMemberRepository.findByUserId("user-7"))
+                .thenReturn(List.of(new NamespaceMember(9L, "user-7", NamespaceRole.MEMBER)));
+        when(skillSearchAppService.search("token-search", null, "relevance", 0, 20, "user-7", nsRoles))
+                .thenReturn(new SkillSearchAppService.SearchResponse(List.of(), 0, 0, 20));
+
+        mockMvc.perform(get("/api/v1/search")
+                        .param("q", "token-search")
+                        .header("Authorization", "Bearer raw-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results").isArray());
+
+        verify(skillSearchAppService).search("token-search", null, "relevance", 0, 20, "user-7", nsRoles);
+        verify(apiTokenService).touchLastUsed(same(token));
+    }
+
+    @Test
+    void downloadQuery_withBearerToken_shouldProjectNamespaceRolesIntoRequestContext() throws Exception {
+        ApiToken token = new ApiToken("user-7", "cli", "sk_test", "hash", "[]");
+        UserAccount user = new UserAccount("user-7", "Alice", "alice@example.com", null);
+        var nsRoles = java.util.Map.of(9L, NamespaceRole.MEMBER);
+
+        when(apiTokenService.validateToken("raw-token")).thenReturn(Optional.of(token));
+        when(userAccountRepository.findById("user-7")).thenReturn(Optional.of(user));
+        when(userRoleBindingRepository.findByUserId("user-7")).thenReturn(List.of());
+        when(namespaceMemberRepository.findByUserId("user-7"))
+                .thenReturn(List.of(new NamespaceMember(9L, "user-7", NamespaceRole.MEMBER)));
+        when(compatSkillLookupService.findByLegacySlug("private-skill"))
+                .thenReturn(legacyCompatContext("team-ai", "private-skill"));
+        when(compatSkillLookupService.canAccess(any(), eq("user-7"), eq(nsRoles))).thenReturn(true);
+
+        mockMvc.perform(get("/api/v1/download")
+                        .param("slug", "private-skill")
+                        .param("version", "latest")
+                        .header("Authorization", "Bearer raw-token"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "/api/v1/skills/team-ai/private-skill/download"));
+
+        verify(compatSkillLookupService).canAccess(any(), eq("user-7"), eq(nsRoles));
+        verify(apiTokenService).touchLastUsed(same(token));
     }
 
     @Test

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/SkillSearchControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/SkillSearchControllerTest.java
@@ -100,4 +100,47 @@ class SkillSearchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.items").isArray());
     }
+
+    @Test
+    void searchShouldFallbackToDefaultsForBlankQueryParams() throws Exception {
+        when(skillSearchAppService.search(
+                eq(null),
+                eq(null),
+                eq("newest"),
+                eq(0),
+                eq(20),
+                eq(null),
+                any(),
+                any()))
+                .thenReturn(new SkillSearchAppService.SearchResponse(List.of(), 0, 0, 20));
+
+        mockMvc.perform(get("/api/web/skills")
+                        .param("sort", " ")
+                        .param("page", "")
+                        .param("size", " "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(20));
+    }
+
+    @Test
+    void searchShouldFallbackToDefaultsForInvalidPagination() throws Exception {
+        when(skillSearchAppService.search(
+                eq(null),
+                eq(null),
+                eq("newest"),
+                eq(0),
+                eq(20),
+                eq(null),
+                any(),
+                any()))
+                .thenReturn(new SkillSearchAppService.SearchResponse(List.of(), 0, 0, 20));
+
+        mockMvc.perform(get("/api/web/skills")
+                        .param("page", "NaN")
+                        .param("size", "-12"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(20));
+    }
 }

--- a/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
+++ b/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryService.java
@@ -102,10 +102,6 @@ public class PostgresFullTextQueryService implements SearchQueryService {
         Set<Long> memberNamespaceIds = query.visibilityScope().memberNamespaceIds().isEmpty()
                 ? Set.of(-1L)
                 : query.visibilityScope().memberNamespaceIds();
-        Set<Long> adminNamespaceIds = query.visibilityScope().adminNamespaceIds().isEmpty()
-                ? Set.of(-1L)
-                : query.visibilityScope().adminNamespaceIds();
-
         StringBuilder sql = new StringBuilder();
         sql.append("SELECT d.skill_id ");
         sql.append("FROM skill_search_document d ");
@@ -190,7 +186,6 @@ public class PostgresFullTextQueryService implements SearchQueryService {
 
         if (query.visibilityScope().userId() != null) {
             nativeQuery.setParameter("memberNamespaceIds", memberNamespaceIds);
-            nativeQuery.setParameter("adminNamespaceIds", adminNamespaceIds);
         }
 
         if (query.namespaceId() != null) {
@@ -235,7 +230,6 @@ public class PostgresFullTextQueryService implements SearchQueryService {
 
         if (query.visibilityScope().userId() != null) {
             countQuery.setParameter("memberNamespaceIds", memberNamespaceIds);
-            countQuery.setParameter("adminNamespaceIds", adminNamespaceIds);
         }
 
         if (query.namespaceId() != null) {

--- a/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryServiceTest.java
+++ b/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresFullTextQueryServiceTest.java
@@ -393,6 +393,34 @@ class PostgresFullTextQueryServiceTest {
     }
 
     @Test
+    void authenticatedQueriesShouldNotBindUnusedAdminNamespaceIdsParameter() {
+        EntityManager entityManager = mock(EntityManager.class);
+        Query nativeQuery = mock(Query.class);
+        Query countQuery = mock(Query.class);
+        when(entityManager.createNativeQuery(anyString()))
+                .thenReturn(nativeQuery)
+                .thenReturn(countQuery);
+        when(nativeQuery.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(nativeQuery);
+        when(countQuery.setParameter(anyString(), org.mockito.ArgumentMatchers.any())).thenReturn(countQuery);
+        when(nativeQuery.getResultList()).thenReturn(List.of());
+        when(countQuery.getSingleResult()).thenReturn(0L);
+
+        PostgresFullTextQueryService service = new PostgresFullTextQueryService(entityManager);
+
+        service.search(new SearchQuery(
+                "issue331",
+                null,
+                new SearchVisibilityScope("user-1", Set.of(7L), Set.of(9L)),
+                "relevance",
+                0,
+                20
+        ));
+
+        verify(nativeQuery, never()).setParameter("adminNamespaceIds", Set.of(9L));
+        verify(countQuery, never()).setParameter("adminNamespaceIds", Set.of(9L));
+    }
+
+    @Test
     void platformWideAccessShouldNotBypassVisibilityInPortalSearch() {
         EntityManager entityManager = mock(EntityManager.class);
         Query nativeQuery = mock(Query.class);

--- a/web/e2e/search-page-full.spec.ts
+++ b/web/e2e/search-page-full.spec.ts
@@ -228,6 +228,7 @@ test.describe('Search Results (Real API)', () => {
     await page.goto(searchUrl(basicSeed!.keyword))
     await page.waitForLoadState('networkidle')
     const cards = getSearchCards(page)
+    await expect(cards.first()).toBeVisible({ timeout: 10_000 })
     const visibleCount = await cards.count()
     const countText = await page.getByText(/\d+\s+skills found/i).textContent()
     const totalMatch = countText?.match(/\d+/)

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -468,6 +468,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/skills/{namespace}/{slug}/submit-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["submitForReview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/web/skills/{namespace}/{slug}/submit-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["submitForReview_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/skills/{namespace}/{slug}/reports": {
         parameters: {
             query?: never;
@@ -494,6 +526,38 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["submitReport_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/web/skills/{namespace}/{slug}/confirm-publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["confirmPublish"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/skills/{namespace}/{slug}/confirm-publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["confirmPublish_1"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3239,6 +3303,10 @@ export interface components {
             targetVersion: string;
             confirmWarnings?: boolean;
         };
+        SubmitReviewRequest: {
+            version: string;
+            targetVisibility: string;
+        };
         SkillReportSubmitRequest: {
             reason?: string;
             details?: string;
@@ -3256,6 +3324,9 @@ export interface components {
             /** Format: int64 */
             reportId?: number;
             status?: string;
+        };
+        ConfirmPublishRequest: {
+            version: string;
         };
         AdminSkillActionRequest: {
             reason?: string;
@@ -5569,6 +5640,60 @@ export interface operations {
             };
         };
     };
+    submitForReview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubmitReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
+    submitForReview_1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubmitReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
     submitReport: {
         parameters: {
             query?: never;
@@ -5619,6 +5744,60 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["ApiResponseSkillReportMutationResponse"];
+                };
+            };
+        };
+    };
+    confirmPublish: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmPublishRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
+    confirmPublish_1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmPublishRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- harden `/api/web/skills` query parsing so blank or invalid pagination/sort inputs fall back to safe defaults
- bring in the upstream search visibility fix that restores authenticated namespace-only search access and unblocks search seed indexing in E2E
- stabilize `TC_SEARCH_RESULT_008` by waiting for rendered search cards before counting them

## Testing
- `cd server && JDK_JAVA_OPTIONS="-XX:+EnableDynamicAgentLoading" ./mvnw -pl skillhub-search -am test -Dtest=PostgresFullTextQueryServiceTest -Dsurefire.failIfNoSpecifiedTests=false`
- `cd server && JDK_JAVA_OPTIONS="-XX:+EnableDynamicAgentLoading" ./mvnw -pl skillhub-app -am test -Dtest=ClawHubCompatControllerTest -Dsurefire.failIfNoSpecifiedTests=false`
- `cd web && pnpm exec playwright test e2e/public-skill-detail-anonymous.spec.ts e2e/search-card-interaction.spec.ts e2e/search-page-full.spec.ts`

## Result
- Playwright: `58 passed, 1 skipped`
- Artifacts: `web/test-results/`