### PR TITLE
feat(dashboard): add Update button to My Skills with publish prefill

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
@@ -8,6 +8,7 @@ public record SkillSummaryResponse(
         String slug,
         String displayName,
         String summary,
+        String visibility,
         String status,
         Long downloadCount,
         Integer starCount,

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
@@ -67,6 +67,7 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
                 skill.getSlug(),
                 skill.getDisplayName(),
                 skill.getSummary(),
+                skill.getVisibility().name(),
                 skill.getStatus().name(),
                 skill.getDownloadCount(),
                 skill.getStarCount(),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
@@ -198,6 +198,7 @@ public class SkillSearchAppService {
                 skill.getSlug(),
                 skill.getDisplayName(),
                 skill.getSummary(),
+                skill.getVisibility().name(),
                 skill.getStatus().name(),
                 skill.getDownloadCount(),
                 skill.getStarCount(),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -102,6 +102,7 @@ class ClawHubCompatControllerTest {
                                 "my-skill",
                                 "My Skill",
                                 "test summary",
+                                "PUBLIC",
                                 "ACTIVE",
                                 10L,
                                 5,

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
@@ -43,6 +43,7 @@ class ClawHubRegistryFacadeTest {
                                 "time-skill",
                                 "Time Skill",
                                 "summary",
+                                "PUBLIC",
                                 "ACTIVE",
                                 12L,
                                 3,

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
@@ -63,6 +63,7 @@ class MeControllerTest {
                                 "copilot",
                                 "Copilot",
                                 "Assist with code review",
+                                "PUBLIC",
                                 "ACTIVE",
                                 12L,
                                 3,

--- a/web/e2e/my-skills-update-prefill.spec.ts
+++ b/web/e2e/my-skills-update-prefill.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test'
+import { setEnglishLocale } from './helpers/auth-fixtures'
+import { registerSession } from './helpers/session'
+import { E2eTestDataBuilder } from './helpers/test-data-builder'
+
+test.describe('My Skills Update Prefill (Real API)', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await setEnglishLocale(page)
+    await registerSession(page, testInfo)
+  })
+
+  test('opens publish page with namespace and visibility prefilled from my skills card', async ({ page }, testInfo) => {
+    const builder = new E2eTestDataBuilder(page, testInfo)
+    await builder.init()
+
+    try {
+      const namespace = await builder.ensureWritableNamespace()
+      const skillName = `update-ui-${Date.now().toString(36)}`
+      await builder.publishSkill(namespace.slug, { name: skillName })
+
+      await page.goto('/dashboard/skills')
+      await expect(page.getByRole('heading', { name: 'My Skills' })).toBeVisible()
+
+      const skillCard = page.locator('.group').filter({
+        has: page.getByRole('heading', { name: skillName, exact: true }),
+      }).first()
+      await expect(skillCard).toBeVisible()
+      await skillCard.getByRole('button', { name: 'Update' }).click()
+
+      await expect(page).toHaveURL(/\/dashboard\/publish/)
+
+      const currentUrl = new URL(page.url())
+      expect(currentUrl.searchParams.get('namespace')).toBe(namespace.slug)
+      expect(currentUrl.searchParams.get('visibility')).toBe('PUBLIC')
+      await expect(page.locator('#namespace')).toContainText(`@${namespace.slug}`)
+      await expect(page.locator('#visibility')).toContainText('Public')
+    } finally {
+      await builder.cleanup()
+    }
+  })
+
+  test('falls back to public visibility when publish search params are invalid', async ({ page }, testInfo) => {
+    const builder = new E2eTestDataBuilder(page, testInfo)
+    await builder.init()
+
+    try {
+      const namespace = await builder.ensureWritableNamespace()
+
+      await page.goto(`/dashboard/publish?namespace=${encodeURIComponent(namespace.slug)}&visibility=internal`)
+      await expect(page.getByRole('heading', { name: 'Publish Skill' })).toBeVisible()
+      await expect(page.locator('#namespace')).toContainText(`@${namespace.slug}`)
+      await expect(page.locator('#visibility')).toContainText('Public')
+    } finally {
+      await builder.cleanup()
+    }
+  })
+})

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -468,6 +468,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/skills/{namespace}/{slug}/submit-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["submitForReview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/web/skills/{namespace}/{slug}/submit-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["submitForReview_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/skills/{namespace}/{slug}/reports": {
         parameters: {
             query?: never;
@@ -494,6 +526,38 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["submitReport_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/web/skills/{namespace}/{slug}/confirm-publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["confirmPublish"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/skills/{namespace}/{slug}/confirm-publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["confirmPublish_1"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3239,6 +3303,10 @@ export interface components {
             targetVersion: string;
             confirmWarnings?: boolean;
         };
+        SubmitReviewRequest: {
+            version: string;
+            targetVisibility: string;
+        };
         SkillReportSubmitRequest: {
             reason?: string;
             details?: string;
@@ -3256,6 +3324,9 @@ export interface components {
             /** Format: int64 */
             reportId?: number;
             status?: string;
+        };
+        ConfirmPublishRequest: {
+            version: string;
         };
         AdminSkillActionRequest: {
             reason?: string;
@@ -3648,6 +3719,7 @@ export interface components {
             slug?: string;
             displayName?: string;
             summary?: string;
+            visibility?: string;
             status?: string;
             /** Format: int64 */
             downloadCount?: number;
@@ -5569,6 +5641,60 @@ export interface operations {
             };
         };
     };
+    submitForReview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubmitReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
+    submitForReview_1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubmitReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
     submitReport: {
         parameters: {
             query?: never;
@@ -5619,6 +5745,60 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["ApiResponseSkillReportMutationResponse"];
+                };
+            };
+        };
+    };
+    confirmPublish: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmPublishRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
+                };
+            };
+        };
+    };
+    confirmPublish_1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmPublishRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseSkillLifecycleMutationResponse"];
                 };
             };
         };

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -145,6 +145,7 @@ export interface SkillSummary {
   slug: string
   displayName: string
   summary?: string
+  visibility?: string
   status?: string
   downloadCount: number
   starCount: number

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -248,6 +248,10 @@ const dashboardPublishRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'dashboard/publish',
   beforeLoad: requireAuth,
+  validateSearch: (search: Record<string, unknown>): { namespace?: string; visibility?: string } => ({
+    namespace: typeof search.namespace === 'string' && search.namespace ? search.namespace : undefined,
+    visibility: typeof search.visibility === 'string' && search.visibility ? search.visibility : undefined,
+  }),
   component: PublishPage,
 })
 

--- a/web/src/features/publish/publish-prefill.test.ts
+++ b/web/src/features/publish/publish-prefill.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePublishPrefill } from './publish-prefill'
+
+describe('normalizePublishPrefill', () => {
+  it('keeps namespace and normalizes visibility for valid route search params', () => {
+    expect(normalizePublishPrefill({
+      namespace: 'team-ai',
+      visibility: 'private',
+    })).toEqual({
+      namespace: 'team-ai',
+      visibility: 'PRIVATE',
+    })
+  })
+
+  it('falls back to PUBLIC when visibility is missing or invalid', () => {
+    expect(normalizePublishPrefill({
+      namespace: 'team-ai',
+      visibility: 'internal',
+    })).toEqual({
+      namespace: 'team-ai',
+      visibility: 'PUBLIC',
+    })
+  })
+
+  it('trims namespace input from search params', () => {
+    expect(normalizePublishPrefill({
+      namespace: '  team-ml  ',
+    })).toEqual({
+      namespace: 'team-ml',
+      visibility: 'PUBLIC',
+    })
+  })
+})

--- a/web/src/features/publish/publish-prefill.ts
+++ b/web/src/features/publish/publish-prefill.ts
@@ -1,0 +1,23 @@
+const VALID_VISIBILITIES = new Set(['PUBLIC', 'NAMESPACE_ONLY', 'PRIVATE'])
+
+interface PublishPrefillSearch {
+  namespace?: string
+  visibility?: string
+}
+
+export interface PublishPrefillState {
+  namespace: string
+  visibility: string
+}
+
+export function normalizePublishPrefill(search: PublishPrefillSearch): PublishPrefillState {
+  const namespace = typeof search.namespace === 'string' ? search.namespace.trim() : ''
+  const normalizedVisibility = typeof search.visibility === 'string'
+    ? search.visibility.trim().toUpperCase()
+    : ''
+
+  return {
+    namespace,
+    visibility: VALID_VISIBILITIES.has(normalizedVisibility) ? normalizedVisibility : 'PUBLIC',
+  }
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -340,6 +340,7 @@
       "HIDDEN": "Hidden"
     },
     "publishNew": "Publish New Skill",
+    "update": "Update",
     "archive": "Archive",
     "unarchive": "Restore",
     "statusArchived": "Archived",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -340,6 +340,7 @@
       "HIDDEN": "已隐藏"
     },
     "publishNew": "发布新技能",
+    "update": "更新",
     "archive": "归档",
     "unarchive": "恢复",
     "statusArchived": "已归档",

--- a/web/src/pages/dashboard/my-skills.test.ts
+++ b/web/src/pages/dashboard/my-skills.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from 'vitest'
+import { createElement, type ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigateMock = vi.fn()
+const buttonRecords: Array<{ label: string; onClick?: ((event?: { stopPropagation: () => void }) => void) | undefined }> = []
+const useMySkillsMock = vi.fn()
 
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigateMock,
 }))
 
 vi.mock('react-i18next', async () => {
@@ -19,15 +25,25 @@ vi.mock('@/features/auth/use-auth', () => ({
 }))
 
 vi.mock('@/shared/ui/button', () => ({
-  Button: ({ children }: { children: unknown }) => children,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children?: ReactNode
+    onClick?: (event?: { stopPropagation: () => void }) => void
+  }) => {
+    const label = Array.isArray(children) ? children.join('') : String(children ?? '')
+    buttonRecords.push({ label, onClick })
+    return createElement('button', null, children)
+  },
 }))
 
 vi.mock('@/shared/ui/card', () => ({
-  Card: ({ children }: { children: unknown }) => children,
+  Card: ({ children }: { children: ReactNode }) => createElement('div', null, children),
 }))
 
 vi.mock('@/shared/components/empty-state', () => ({
-  EmptyState: () => null,
+  EmptyState: () => createElement('div', null, 'empty-state'),
 }))
 
 vi.mock('@/shared/components/confirm-dialog', () => ({
@@ -35,7 +51,7 @@ vi.mock('@/shared/components/confirm-dialog', () => ({
 }))
 
 vi.mock('@/shared/components/dashboard-page-header', () => ({
-  DashboardPageHeader: () => null,
+  DashboardPageHeader: ({ actions }: { actions?: ReactNode }) => createElement('div', null, actions),
 }))
 
 vi.mock('@/shared/components/pagination', () => ({
@@ -49,16 +65,13 @@ vi.mock('@/shared/hooks/use-skill-queries', () => ({
 }))
 
 vi.mock('@/shared/hooks/use-user-queries', () => ({
-  useMySkills: () => ({
-    data: { items: [], total: 0, page: 0, size: 10 },
-    isLoading: false,
-  }),
+  useMySkills: () => useMySkillsMock(),
   useSubmitPromotion: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
 vi.mock('@/shared/lib/skill-lifecycle', () => ({
-  getHeadlineVersion: () => null,
-  getPublishedVersion: () => null,
+  getHeadlineVersion: () => ({ id: 11, version: '1.0.0', status: 'PUBLISHED' }),
+  getPublishedVersion: () => ({ id: 11, version: '1.0.0', status: 'PUBLISHED' }),
   getOwnerPreviewVersion: () => null,
   hasPendingOwnerPreview: () => false,
 }))
@@ -79,7 +92,120 @@ vi.mock('@/api/client', () => ({
 
 import { MySkillsPage } from './my-skills'
 
+function findButton(label: string) {
+  const record = buttonRecords.find((item) => item.label === label)
+  if (!record) {
+    throw new Error(`Missing button: ${label}`)
+  }
+  return record
+}
+
 describe('MySkillsPage', () => {
+  beforeEach(() => {
+    navigateMock.mockReset()
+    buttonRecords.length = 0
+    useMySkillsMock.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 1,
+            displayName: 'Team Agent',
+            summary: 'summary',
+            namespace: 'team-ai',
+            slug: 'team-agent',
+            downloadCount: 42,
+            status: 'PUBLISHED',
+            visibility: 'PRIVATE',
+            canSubmitPromotion: false,
+          },
+        ],
+        total: 1,
+        page: 0,
+        size: 10,
+      },
+      isLoading: false,
+    })
+  })
+
+  it('navigates to publish page with namespace and visibility when update is clicked', () => {
+    renderToStaticMarkup(createElement(MySkillsPage))
+
+    const stopPropagation = vi.fn()
+    findButton('mySkills.update').onClick?.({ stopPropagation })
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/dashboard/publish',
+      search: {
+        namespace: 'team-ai',
+        visibility: 'PRIVATE',
+      },
+    })
+  })
+
+  it('does not render update action for archived skills', () => {
+    useMySkillsMock.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 2,
+            displayName: 'Archived Agent',
+            summary: 'summary',
+            namespace: 'team-ai',
+            slug: 'archived-agent',
+            downloadCount: 7,
+            status: 'ARCHIVED',
+            visibility: 'PUBLIC',
+            canSubmitPromotion: false,
+          },
+        ],
+        total: 1,
+        page: 0,
+        size: 10,
+      },
+      isLoading: false,
+    })
+
+    renderToStaticMarkup(createElement(MySkillsPage))
+
+    expect(buttonRecords.some((button) => button.label === 'mySkills.update')).toBe(false)
+  })
+
+  it('falls back to public visibility when the skill card data has no visibility field', () => {
+    useMySkillsMock.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 3,
+            displayName: 'Default Visibility Agent',
+            summary: 'summary',
+            namespace: 'team-ai',
+            slug: 'default-visibility-agent',
+            downloadCount: 9,
+            status: 'PUBLISHED',
+            canSubmitPromotion: false,
+          },
+        ],
+        total: 1,
+        page: 0,
+        size: 10,
+      },
+      isLoading: false,
+    })
+
+    renderToStaticMarkup(createElement(MySkillsPage))
+
+    findButton('mySkills.update').onClick?.({ stopPropagation: vi.fn() })
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/dashboard/publish',
+      search: {
+        namespace: 'team-ai',
+        visibility: 'PUBLIC',
+      },
+    })
+  })
+
   it('exports a named component function', () => {
     expect(typeof MySkillsPage).toBe('function')
   })

--- a/web/src/pages/dashboard/my-skills.tsx
+++ b/web/src/pages/dashboard/my-skills.tsx
@@ -61,6 +61,13 @@ export function MySkillsPage() {
     })
   }
 
+  const handleUpdateSkill = (namespace: string, visibility?: string) => {
+    navigate({
+      to: '/dashboard/publish',
+      search: { namespace, visibility: visibility || 'PUBLIC' },
+    })
+  }
+
   const resolveStatusLabel = (status?: string) => {
     if (status === 'HIDDEN') {
       return t('mySkills.statusHidden')
@@ -306,6 +313,18 @@ export function MySkillsPage() {
                         </div>
                       </div>
                       <div className="flex items-center gap-2 pl-4">
+                        {skill.status !== 'ARCHIVED' && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              handleUpdateSkill(skill.namespace, skill.visibility ?? 'PUBLIC')
+                            }}
+                          >
+                            {t('mySkills.update')}
+                          </Button>
+                        )}
                         {hasPendingPreview && ownerPreviewVersion ? (
                           <Button
                             size="sm"

--- a/web/src/pages/dashboard/publish.test.ts
+++ b/web/src/pages/dashboard/publish.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useSearchMock = vi.fn()
+const selectRecords: Array<{ value?: string }> = []
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
+  useSearch: () => useSearchMock(),
 }))
 
 vi.mock('react-i18next', async () => {
@@ -23,7 +29,10 @@ vi.mock('@/shared/ui/button', () => ({
 }))
 
 vi.mock('@/shared/ui/select', () => ({
-  Select: ({ children }: { children: unknown }) => children,
+  Select: ({ children, value }: { children: unknown; value?: string }) => {
+    selectRecords.push({ value })
+    return children
+  },
   SelectContent: ({ children }: { children: unknown }) => children,
   SelectItem: ({ children }: { children: unknown }) => children,
   SelectTrigger: ({ children }: { children: unknown }) => children,
@@ -64,6 +73,30 @@ vi.mock('@/api/client', () => ({
 import { PublishPage } from './publish'
 
 describe('PublishPage', () => {
+  beforeEach(() => {
+    selectRecords.length = 0
+    useSearchMock.mockReturnValue({
+      namespace: '  team-ai  ',
+      visibility: 'private',
+    })
+  })
+
+  it('prefills namespace and visibility from route search params', () => {
+    renderToStaticMarkup(createElement(PublishPage))
+
+    expect(selectRecords[0]?.value).toBe('team-ai')
+    expect(selectRecords[1]?.value).toBe('PRIVATE')
+  })
+
+  it('falls back to public visibility when search params are missing', () => {
+    useSearchMock.mockReturnValue({})
+
+    renderToStaticMarkup(createElement(PublishPage))
+
+    expect(selectRecords[0]?.value).toBe('__select_namespace__')
+    expect(selectRecords[1]?.value).toBe('PUBLIC')
+  })
+
   it('exports a named component function', () => {
     expect(typeof PublishPage).toBe('function')
   })

--- a/web/src/pages/dashboard/publish.tsx
+++ b/web/src/pages/dashboard/publish.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useNavigate } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { UploadZone } from '@/features/publish/upload-zone'
 import {
@@ -9,6 +9,7 @@ import {
   isPrecheckFailureMessage,
   isVersionExistsMessage,
 } from '@/features/publish/publish-error-utils'
+import { normalizePublishPrefill } from '@/features/publish/publish-prefill'
 import { Button } from '@/shared/ui/button'
 import {
   Select,
@@ -32,9 +33,11 @@ const EMPTY_NAMESPACE_VALUE = '__select_namespace__'
 export function PublishPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const search = useSearch({ from: '/dashboard/publish' })
+  const prefill = normalizePublishPrefill(search)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
-  const [namespaceSlug, setNamespaceSlug] = useState<string>('')
-  const [visibility, setVisibility] = useState<string>('PUBLIC')
+  const [namespaceSlug, setNamespaceSlug] = useState<string>(prefill.namespace)
+  const [visibility, setVisibility] = useState<string>(prefill.visibility)
   const [warningDialogOpen, setWarningDialogOpen] = useState(false)
   const [precheckWarnings, setPrecheckWarnings] = useState<string[]>([])
 
@@ -44,6 +47,11 @@ export function PublishPage() {
   const namespaceOnlyLabel = selectedNamespace?.type === 'GLOBAL'
     ? t('publish.visibilityOptions.loggedInUsersOnly')
     : t('publish.visibilityOptions.namespaceOnly')
+
+  useEffect(() => {
+    setNamespaceSlug(prefill.namespace)
+    setVisibility(prefill.visibility)
+  }, [prefill.namespace, prefill.visibility])
 
   const handleRemoveSelectedFile = () => {
     setSelectedFile(null)


### PR DESCRIPTION
## 概述

在 My Skills 页面为每个技能卡片添加「更新」按钮，点击后携带 namespace 和 visibility 参数跳转到 Publish 页面并自动预填充，减少用户重新发布时的手动操作。

## 变更内容

### 后端实现

- `SkillSummaryResponse` 新增 `visibility` 字段，使列表 API（`/api/web/me/skills`）和搜索 API 返回技能的可见性设置
- `JpaMySkillQueryRepository` 和 `SkillSearchAppService` 在构造响应时映射 `skill.getVisibility().name()`
- `schema.d.ts` 已通过 `make generate-api` 同步

### 前端实现

- `my-skills.tsx`：每个非 ARCHIVED 状态的技能卡片新增 Update 按钮，点击后导航到 `/dashboard/publish?namespace=xxx&visibility=xxx`
- `publish.tsx`：从 URL search params 读取 namespace 和 visibility 并预填充到表单
- `publish-prefill.ts`：参数规范化模块，验证 visibility 值有效性，无效时回退到 `PUBLIC`
- `router.tsx`：publish 路由新增 `validateSearch` 支持 namespace/visibility 参数
- i18n：新增 `mySkills.update` 翻译 key（中/英）

### 测试覆盖

- 后端单测：`MeControllerTest`、`ClawHubCompatControllerTest`、`ClawHubRegistryFacadeTest` 更新以适配新字段
- 前端单测：
  - `publish-prefill.test.ts`：参数规范化逻辑（有效输入、无效 visibility 回退、空值处理）
  - `my-skills.test.ts`：Update 按钮渲染和链接目标验证
  - `publish.test.ts`：表单预填充验证
- E2E 测试：`web/e2e/my-skills-update-prefill.spec.ts`
  - 成功路径：从 My Skills 点击 Update → Publish 页面 namespace 和 visibility 正确预填
  - 边界路径：无效 visibility 参数回退到 Public

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] `make test-frontend` 通过
- [x] `make test-backend-app` 通过（409 tests passed）
- [x] Playwright E2E 通过（126 passed, 1 skipped）
- [x] `make generate-api` 已执行且 `schema.d.ts` 已提交

## 安全考虑

- URL search params 通过 `normalizePublishPrefill` 验证和规范化，防止注入无效值
- visibility 仅接受白名单值（PUBLIC / NAMESPACE_ONLY / PRIVATE），其余回退为 PUBLIC
- 本次变更不涉及鉴权/授权逻辑变更

## 相关 Issue

Related to #271

## 测试说明

### 本地验证步骤

1. `make dev-all` 启动本地环境
2. 访问 http://localhost:3000/dashboard/skills（需登录）
3. 在技能卡片上可见「Update」按钮
4. 点击后跳转到 Publish 页面，namespace 和 visibility 已自动选中
5. 手动访问 `/dashboard/publish?namespace=global&visibility=invalid`，visibility 应回退为 Public

### 回归测试范围

- My Skills 页面（卡片渲染、按钮交互）
- Publish 页面（表单初始化、namespace/visibility 选择器）
- 搜索结果页（SkillSummaryResponse 新增字段不影响现有展示）
