### PR TITLE
fix(search): preserve empty-query discovery results

### DIFF
--- a/web/e2e/search-page-full.spec.ts
+++ b/web/e2e/search-page-full.spec.ts
@@ -41,7 +41,19 @@ test.describe('Search Input (Real API)', () => {
 
   // TC_SEARCH_INPUT_003 P0 - empty search shows the default discovery list
   test('TC_SEARCH_INPUT_003: empty search shows the default discovery list', async ({ page }) => {
+    const emptyQueryResponse = page.waitForResponse((response) => {
+      if (!response.url().includes('/api/web/skills?')) {
+        return false
+      }
+
+      const url = new URL(response.url())
+      return response.status() === 200
+        && url.searchParams.has('q')
+        && url.searchParams.get('q') === ''
+    })
+
     await page.goto(searchUrl(''))
+    await emptyQueryResponse
     await expect(page).toHaveURL(/\/search/)
     await expect(getSearchCards(page).first()).toBeVisible({ timeout: 10_000 })
   })

--- a/web/src/shared/hooks/skill-query-helpers.test.ts
+++ b/web/src/shared/hooks/skill-query-helpers.test.ts
@@ -16,6 +16,18 @@ describe('buildSkillSearchUrl', () => {
   it('returns the base skills endpoint when no search params are provided', () => {
     expect(buildSkillSearchUrl({})).toBe('/api/web/skills')
   })
+
+  it('keeps an empty q parameter when the search query is an empty string', () => {
+    expect(buildSkillSearchUrl({ q: '' })).toBe('/api/web/skills?q=')
+  })
+
+  it('normalizes whitespace-only queries to an empty q parameter', () => {
+    expect(buildSkillSearchUrl({
+      q: '   ',
+      sort: 'relevance',
+      page: 0,
+    })).toBe('/api/web/skills?q=&sort=relevance&page=0')
+  })
 })
 
 describe('shouldEnableNamespaceMemberCandidates', () => {

--- a/web/src/shared/hooks/skill-query-helpers.ts
+++ b/web/src/shared/hooks/skill-query-helpers.ts
@@ -6,7 +6,7 @@ export function buildSkillSearchUrl(params: SearchParams) {
   const queryParams = new URLSearchParams()
   const normalizedQuery = normalizeSearchQuery(params.q ?? '')
 
-  if (normalizedQuery) {
+  if (params.q !== undefined) {
     queryParams.append('q', normalizedQuery)
   }
 


### PR DESCRIPTION
## 概述
修复搜索页在空关键词场景下不展示技能列表的问题，确保 `/search?q=&sort=newest&page=0&starredOnly=false` 会展示默认发现列表。

## 变更内容

### 后端实现
- 本次变更未修改后端代码
- 无 DB migration 变更
- 无 API 契约变更

### 前端实现
- 调整搜索请求 URL 构造逻辑：当 `q` 已定义时始终保留 `q` 参数，即使值为空字符串
- 保持非空关键词仍按既有规则执行 trim/normalize
- 补充空字符串与全空白关键词的前端单测
- 加强搜索页 Playwright 回归用例，显式断言空搜索请求包含 `q=`

### 测试覆盖
- 前端单测：`web/src/shared/hooks/skill-query-helpers.test.ts`，覆盖空字符串和空白关键词请求构造
- E2E 测试：`web/e2e/search-page-full.spec.ts`，覆盖空关键词展示默认发现列表，并校验请求包含 `q=`
- Playwright 产物：`web/test-results/search-page-full-Search-In-6a209--the-default-discovery-list-chromium`

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] `make test-frontend` 未全量执行；已执行针对性 Vitest：`cd web && pnpm exec vitest run src/shared/hooks/skill-query-helpers.test.ts`
- [ ] `make test-backend-app` 通过（如有后端变更）
- [x] Playwright E2E（`web/e2e`）关键路径通过：`cd web && pnpm exec playwright test e2e/search-page-full.spec.ts -g "TC_SEARCH_INPUT_003: empty search shows the default discovery list"`
- [ ] `make generate-api` 已执行且 `schema.d.ts` 已提交（如有 Controller 变更）

## 安全考虑
本次变更不涉及安全敏感内容。

## 相关 Issue
Closes #344

## 测试说明

### 本地验证步骤
1. 打开 `/search?q=&sort=newest&page=0&starredOnly=false`
2. 观察页面是否展示技能卡片，而不是空白状态
3. 检查网络请求确认前端请求包含空查询参数 `q=`

### 回归测试范围
- 搜索页空关键词默认列表展示
- 搜索请求 URL 参数构造
- 搜索页回车搜索与既有非空搜索路径

### 截图/录屏（如有 UI 变更）
- Playwright 截图产物位于 `web/test-results/search-page-full-Search-In-6a209--the-default-discovery-list-chromium`
