### PR TITLE
fix(web): restore empty-query skill discovery

### DIFF
--- a/web/src/shared/hooks/skill-query-helpers.test.ts
+++ b/web/src/shared/hooks/skill-query-helpers.test.ts
@@ -17,16 +17,16 @@ describe('buildSkillSearchUrl', () => {
     expect(buildSkillSearchUrl({})).toBe('/api/web/skills')
   })
 
-  it('keeps an empty q parameter when the search query is an empty string', () => {
-    expect(buildSkillSearchUrl({ q: '' })).toBe('/api/web/skills?q=')
+  it('omits q when the search query is an empty string', () => {
+    expect(buildSkillSearchUrl({ q: '' })).toBe('/api/web/skills')
   })
 
-  it('normalizes whitespace-only queries to an empty q parameter', () => {
+  it('omits q when the normalized query is empty after trimming', () => {
     expect(buildSkillSearchUrl({
       q: '   ',
       sort: 'relevance',
       page: 0,
-    })).toBe('/api/web/skills?q=&sort=relevance&page=0')
+    })).toBe('/api/web/skills?sort=relevance&page=0')
   })
 })
 

--- a/web/src/shared/hooks/skill-query-helpers.ts
+++ b/web/src/shared/hooks/skill-query-helpers.ts
@@ -6,7 +6,7 @@ export function buildSkillSearchUrl(params: SearchParams) {
   const queryParams = new URLSearchParams()
   const normalizedQuery = normalizeSearchQuery(params.q ?? '')
 
-  if (params.q !== undefined) {
+  if (normalizedQuery) {
     queryParams.append('q', normalizedQuery)
   }
 


### PR DESCRIPTION
## Summary
- restore the search URL helper behavior so empty queries do not send a blank q parameter
- keep empty-query search pages aligned with the homepage discovery requests
- update regression tests for empty-query discovery behavior

## Verification
- ./node_modules/.bin/vitest run src/shared/hooks/skill-query-helpers.test.ts src/pages/search.test.tsx
- ./node_modules/.bin/vite build