### PR TITLE
fix(namespace): add pagination to namespace skill list

### DIFF
--- a/web/e2e/namespace-skill-pagination.spec.ts
+++ b/web/e2e/namespace-skill-pagination.spec.ts
@@ -36,14 +36,18 @@ test.describe('Namespace Skill List Pagination (Real API)', () => {
 
     try {
       const namespace = await builder.ensureWritableNamespace()
+      await builder.publishSkill(namespace.slug)
 
-      // Publish 21 skills to trigger pagination (PAGE_SIZE = 20)
-      for (let i = 0; i < 21; i += 1) {
-        await builder.publishSkill(namespace.slug, {
-          name: `e2e-skill-${i}`,
-          description: `Test skill ${i} for pagination`,
-        })
-      }
+      // Intercept the search API to inflate `total` so the pagination component renders.
+      // This avoids publishing 21 real skills which triggers 429 rate limits in CI.
+      await page.route('**/api/web/skills?**', async (route) => {
+        const response = await route.fetch()
+        const body = await response.json()
+        if (body.data) {
+          body.data.total = 21
+        }
+        await route.fulfill({ response, json: body })
+      })
 
       await page.goto(`/space/${namespace.slug}`)
 
@@ -64,7 +68,7 @@ test.describe('Namespace Skill List Pagination (Real API)', () => {
       // Navigate to second page
       await nextButton.click()
 
-      // Second page: both buttons should be enabled (or Previous enabled, Next disabled if only 2 pages)
+      // Second page: Previous should be enabled
       await expect(previousButton).toBeEnabled()
 
       // Navigate back to first page

--- a/web/e2e/namespace-skill-pagination.spec.ts
+++ b/web/e2e/namespace-skill-pagination.spec.ts
@@ -36,17 +36,39 @@ test.describe('Namespace Skill List Pagination (Real API)', () => {
 
     try {
       const namespace = await builder.ensureWritableNamespace()
-      await builder.publishSkill(namespace.slug)
 
-      // Intercept the search API to inflate `total` so the pagination component renders.
-      // This avoids publishing 21 real skills which triggers 429 rate limits in CI.
-      await page.route('**/api/web/skills?**', async (route) => {
-        const response = await route.fetch()
-        const body = await response.json()
-        if (body.data) {
-          body.data.total = 21
-        }
-        await route.fulfill({ response, json: body })
+      // Build a fake skill list to simulate >20 skills without hitting rate limits.
+      const fakeSkill = (i: number) => ({
+        id: 90000 + i,
+        namespace: namespace.slug,
+        slug: `fake-skill-${i}`,
+        displayName: `Fake Skill ${i}`,
+        summary: `Pagination test skill ${i}`,
+        downloadCount: 0,
+        starCount: 0,
+        ratingAvg: 0,
+        ratingCount: 0,
+        versions: [{ id: 90000 + i, version: '1.0.0', status: 'PUBLISHED' }],
+      })
+
+      // Intercept the search API with a regex (glob '?' is ambiguous for literal '?').
+      // Return fully mocked responses to avoid needing real published skills.
+      await page.route(/\/api\/web\/skills\?/, async (route) => {
+        const url = new URL(route.request().url())
+        const reqPage = Number(url.searchParams.get('page') ?? '0')
+        const items = reqPage === 0
+          ? Array.from({ length: 20 }, (_, i) => fakeSkill(i))
+          : [fakeSkill(20)]
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 0,
+            msg: 'success',
+            data: { items, total: 21, page: reqPage, size: 20 },
+          }),
+        })
       })
 
       await page.goto(`/space/${namespace.slug}`)

--- a/web/e2e/namespace-skill-pagination.spec.ts
+++ b/web/e2e/namespace-skill-pagination.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+import { setEnglishLocale } from './helpers/auth-fixtures'
+import { registerSession } from './helpers/session'
+import { E2eTestDataBuilder } from './helpers/test-data-builder'
+
+test.describe('Namespace Skill List Pagination (Real API)', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await setEnglishLocale(page)
+    await registerSession(page, testInfo)
+  })
+
+  test('shows namespace page with skills and no pagination when under 20 skills', async ({ page }, testInfo) => {
+    const builder = new E2eTestDataBuilder(page, testInfo)
+    await builder.init()
+
+    try {
+      const namespace = await builder.ensureWritableNamespace()
+      await builder.publishSkill(namespace.slug)
+
+      await page.goto(`/space/${namespace.slug}`)
+
+      await expect(page.getByText(`@${namespace.slug}`).first()).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Skills', exact: true })).toBeVisible()
+
+      // Verify pagination controls do not appear when there are fewer than 20 skills
+      await expect(page.getByRole('button', { name: 'Previous' })).toHaveCount(0)
+      await expect(page.getByRole('button', { name: 'Next' })).toHaveCount(0)
+    } finally {
+      await builder.cleanup()
+    }
+  })
+
+  test('shows pagination controls when there are more than 20 skills', async ({ page }, testInfo) => {
+    const builder = new E2eTestDataBuilder(page, testInfo)
+    await builder.init()
+
+    try {
+      const namespace = await builder.ensureWritableNamespace()
+
+      // Publish 21 skills to trigger pagination (PAGE_SIZE = 20)
+      for (let i = 0; i < 21; i += 1) {
+        await builder.publishSkill(namespace.slug, {
+          name: `e2e-skill-${i}`,
+          description: `Test skill ${i} for pagination`,
+        })
+      }
+
+      await page.goto(`/space/${namespace.slug}`)
+
+      await expect(page.getByText(`@${namespace.slug}`).first()).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Skills', exact: true })).toBeVisible()
+
+      // Verify pagination controls appear
+      const previousButton = page.getByRole('button', { name: 'Previous' }).first()
+      const nextButton = page.getByRole('button', { name: 'Next' }).first()
+
+      await expect(previousButton).toBeVisible()
+      await expect(nextButton).toBeVisible()
+
+      // First page: Previous should be disabled, Next should be enabled
+      await expect(previousButton).toBeDisabled()
+      await expect(nextButton).toBeEnabled()
+
+      // Navigate to second page
+      await nextButton.click()
+
+      // Second page: both buttons should be enabled (or Previous enabled, Next disabled if only 2 pages)
+      await expect(previousButton).toBeEnabled()
+
+      // Navigate back to first page
+      await previousButton.click()
+      await expect(previousButton).toBeDisabled()
+      await expect(nextButton).toBeEnabled()
+    } finally {
+      await builder.cleanup()
+    }
+  })
+})

--- a/web/src/pages/namespace.tsx
+++ b/web/src/pages/namespace.tsx
@@ -1,11 +1,15 @@
+import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { NamespaceHeader } from '@/features/namespace/namespace-header'
 import { SkillCard } from '@/features/skill/skill-card'
 import { SkeletonList } from '@/shared/components/skeleton-loader'
 import { EmptyState } from '@/shared/components/empty-state'
+import { Pagination } from '@/shared/components/pagination'
 import { useSearchSkills } from '@/shared/hooks/use-skill-queries'
 import { useNamespaceDetail } from '@/shared/hooks/use-namespace-queries'
+
+const PAGE_SIZE = 20
 
 /**
  * Public namespace page showing namespace metadata and the skills currently discoverable inside it.
@@ -14,12 +18,21 @@ export function NamespacePage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { namespace } = useParams({ from: '/space/$namespace' })
+  const [page, setPage] = useState(0)
+
+  // Reset page when namespace changes
+  useEffect(() => {
+    setPage(0)
+  }, [namespace])
 
   const { data: namespaceData, isLoading: isLoadingNamespace } = useNamespaceDetail(namespace)
   const { data: skillsData, isLoading: isLoadingSkills } = useSearchSkills({
     namespace,
-    size: 20,
+    page,
+    size: PAGE_SIZE,
   })
+
+  const totalPages = skillsData ? Math.max(Math.ceil(skillsData.total / skillsData.size), 1) : 1
 
   const handleSkillClick = (slug: string) => {
     navigate({ to: `/space/${namespace}/${encodeURIComponent(slug)}` })
@@ -47,16 +60,22 @@ export function NamespacePage() {
         {isLoadingSkills ? (
           <SkeletonList count={6} />
         ) : skillsData && skillsData.items.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {skillsData.items.map((skill, idx) => (
-              <div key={skill.id} className={`animate-fade-up delay-${Math.min(idx + 1, 6)}`}>
-                <SkillCard
-                  skill={skill}
-                  onClick={() => handleSkillClick(skill.slug)}
-                />
-              </div>
-            ))}
-          </div>
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+              {skillsData.items.map((skill, idx) => (
+                <div key={skill.id} className={`animate-fade-up delay-${Math.min(idx + 1, 6)}`}>
+                  <SkillCard
+                    skill={skill}
+                    onClick={() => handleSkillClick(skill.slug)}
+                  />
+                </div>
+              ))}
+            </div>
+
+            {skillsData.total > PAGE_SIZE ? (
+              <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+            ) : null}
+          </>
         ) : (
           <EmptyState
             title={t('namespace.emptyTitle')}


### PR DESCRIPTION
## 概述
命名空间详情页技能列表硬编码了 20 条上限且无分页控件，导致超过 20 个技能的命名空间显示不全。本次修复添加分页支持。

## 变更内容

### 前端实现
- `web/src/pages/namespace.tsx`: 添加 `page` 状态和 `PAGE_SIZE` 常量，将分页参数传入 `useSearchSkills`，当 `total > PAGE_SIZE` 时渲染 `Pagination` 组件
- 使用 `useEffect` 在命名空间切换时重置页码，避免跨命名空间的分页状态污染

### 测试覆盖
- E2E 测试: `web/e2e/namespace-skill-pagination.spec.ts` — 覆盖无分页（< 20 skills）和有分页（> 20 skills）两条路径

## 质量门禁

- [x] `make typecheck-web` 通过 (0 errors)
- [x] `make lint-web` 通过 (0 errors, 0 warnings)
- [x] `make test-frontend` 通过 (176/176)
- [x] Playwright E2E 测试已编写

## 安全考虑
本次变更不涉及安全敏感内容。

## 相关 Issue
Closes #350

## 测试说明

### 本地验证步骤
1. `make dev-all` 启动本地环境
2. 向同一命名空间上传 > 20 个技能
3. 访问 `/space/{namespace}`，确认分页控件出现且翻页正常
4. 访问技能数 ≤ 20 的命名空间，确认无分页控件

### 回归测试范围
- 命名空间详情页技能列表展示
- 搜索页面（共用 `useSearchSkills` hook）