### PR TITLE
fix(deploy): isolate PostgreSQL data from volume root

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Verify Kubernetes PostgreSQL data-directory compatibility
+        run: bash scripts/tests/k8s-postgres-storage-test.sh
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -233,6 +233,12 @@ skillhub-storage-s3-secret-key: your-secret-key
 | postgres-data-0 | 10Gi | PostgreSQL 数据（with-infra only） |
 | redis-data-0 | 5Gi | Redis 数据（with-infra only） |
 
+#### PostgreSQL 数据目录兼容性
+
+`with-infra` 会在启动时检查 PostgreSQL PVC 根目录：如果已存在 `PG_VERSION`，继续使用根目录中的旧集群；否则在 `pgdata/` 子目录初始化新集群，避免新 ext4 卷中的 `lost+found` 阻止 `initdb`。升级现有部署不需要移动数据库文件。
+
+回滚到不包含该检测逻辑的旧清单时，如果集群位于 `pgdata/`，必须保留当前启动命令，或显式设置 `PGDATA=/var/lib/postgresql/data/pgdata`。不要把正在运行的数据库目录手动移动到 PVC 根目录。
+
 ## 镜像说明
 
 | 组件 | 镜像 |

--- a/deploy/k8s/overlays/with-infra/postgres-statefulset.yaml
+++ b/deploy/k8s/overlays/with-infra/postgres-statefulset.yaml
@@ -18,6 +18,19 @@ spec:
       containers:
         - name: postgres
           image: postgres:16-alpine
+          # Legacy installations store PostgreSQL directly at the PVC root.
+          # Fresh ext4 volumes may contain lost+found, so initialize new clusters
+          # in a child directory without hiding an existing root-level cluster.
+          command:
+            - sh
+            - -ec
+            - |
+              if [ -f /var/lib/postgresql/data/PG_VERSION ]; then
+                export PGDATA=/var/lib/postgresql/data
+              else
+                export PGDATA=/var/lib/postgresql/data/pgdata
+              fi
+              exec docker-entrypoint.sh postgres
           ports:
             - containerPort: 5432
               name: postgres
@@ -37,7 +50,6 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
-              subPath: pgdata
           readinessProbe:
             exec:
               command:

--- a/deploy/k8s/overlays/with-infra/postgres-statefulset.yaml
+++ b/deploy/k8s/overlays/with-infra/postgres-statefulset.yaml
@@ -37,6 +37,7 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
+              subPath: pgdata
           readinessProbe:
             exec:
               command:

--- a/docs/skillhub/en/guide/kubernetes.md
+++ b/docs/skillhub/en/guide/kubernetes.md
@@ -212,6 +212,12 @@ skillhub-storage-s3-secret-key: your-secret-key
   value: us-east-1
 ```
 
+### PostgreSQL data-directory compatibility
+
+The `with-infra` overlay checks the PostgreSQL PVC root at startup. If `PG_VERSION` already exists there, the legacy root-level cluster remains in use. Otherwise, a new cluster is initialized under `pgdata/`, avoiding the `lost+found` directory that can block `initdb` on a fresh ext4 volume. Existing installations do not need to move their database files during upgrade.
+
+When rolling back to an older manifest without this detection, keep the current startup command or set `PGDATA=/var/lib/postgresql/data/pgdata` explicitly if the cluster lives under `pgdata/`. Do not move an active database directory back to the PVC root by hand.
+
 ### Image Reference
 
 | Component | Image |

--- a/docs/skillhub/guide/kubernetes.md
+++ b/docs/skillhub/guide/kubernetes.md
@@ -212,6 +212,12 @@ skillhub-storage-s3-secret-key: your-secret-key
   value: cn-shanghai
 ```
 
+### PostgreSQL 数据目录兼容性
+
+`with-infra` 会在启动时检查 PostgreSQL PVC 根目录：如果已存在 `PG_VERSION`，继续使用根目录中的旧集群；否则在 `pgdata/` 子目录初始化新集群，避免新 ext4 卷中的 `lost+found` 阻止 `initdb`。升级现有部署不需要移动数据库文件。
+
+回滚到不包含该检测逻辑的旧清单时，如果集群位于 `pgdata/`，必须保留当前启动命令，或显式设置 `PGDATA=/var/lib/postgresql/data/pgdata`。不要把正在运行的数据库目录手动移动到 PVC 根目录。
+
 ### 镜像说明
 
 | 组件 | 镜像 |

--- a/scripts/tests/k8s-postgres-storage-test.sh
+++ b/scripts/tests/k8s-postgres-storage-test.sh
@@ -40,7 +40,13 @@ fi
 wait_for_postgres() {
   local container="$1"
   for _ in $(seq 1 30); do
-    if docker exec "$container" pg_isready -U skillhub -d skillhub >/dev/null 2>&1; then
+    # docker-entrypoint.sh briefly starts a temporary PostgreSQL process while
+    # initializing a fresh cluster. Wait until PID 1 is the final server so a
+    # successful readiness probe cannot race with that temporary shutdown.
+    if docker exec "$container" sh -ec \
+      'test "$(cat /proc/1/comm)" = postgres' >/dev/null 2>&1 \
+      && docker exec "$container" psql -U skillhub -d skillhub -Atqc \
+        'SELECT 1' >/dev/null 2>&1; then
       return 0
     fi
     sleep 1

--- a/scripts/tests/k8s-postgres-storage-test.sh
+++ b/scripts/tests/k8s-postgres-storage-test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$REPO_ROOT/deploy/k8s/overlays/with-infra/postgres-statefulset.yaml"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:16-alpine}"
+RUN_ID="skillhub-k8s-pgdata-$$"
+FRESH_VOLUME="${RUN_ID}-fresh"
+LEGACY_VOLUME="${RUN_ID}-legacy"
+CONTAINERS=()
+VOLUMES=("$FRESH_VOLUME" "$LEGACY_VOLUME")
+
+cleanup() {
+  for container in "${CONTAINERS[@]}"; do
+    docker stop "$container" >/dev/null 2>&1 || true
+  done
+  for volume in "${VOLUMES[@]}"; do
+    docker volume rm "$volume" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+for command in docker sed; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "required command not found: $command" >&2
+    exit 1
+  fi
+done
+
+POSTGRES_START_COMMAND="$(
+  sed -n '/^            - |$/,/^          ports:$/p' "$MANIFEST" \
+    | sed '1d;$d;s/^              //'
+)"
+if [[ -z "$POSTGRES_START_COMMAND" ]]; then
+  echo "could not extract the PostgreSQL startup command from $MANIFEST" >&2
+  exit 1
+fi
+
+wait_for_postgres() {
+  local container="$1"
+  for _ in $(seq 1 30); do
+    if docker exec "$container" pg_isready -U skillhub -d skillhub >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  docker logs "$container" >&2
+  return 1
+}
+
+start_postgres() {
+  local container="$1"
+  local volume="$2"
+  local mode="${3:-default}"
+  CONTAINERS+=("$container")
+  if [[ "$mode" == "patched" ]]; then
+    docker run --detach --rm \
+      --name "$container" \
+      --env POSTGRES_DB=skillhub \
+      --env POSTGRES_USER=skillhub \
+      --env POSTGRES_PASSWORD=storage-test \
+      --volume "$volume:/var/lib/postgresql/data" \
+      --entrypoint sh \
+      "$POSTGRES_IMAGE" \
+      -ec "$POSTGRES_START_COMMAND" >/dev/null
+  else
+    docker run --detach --rm \
+      --name "$container" \
+      --env POSTGRES_DB=skillhub \
+      --env POSTGRES_USER=skillhub \
+      --env POSTGRES_PASSWORD=storage-test \
+      --volume "$volume:/var/lib/postgresql/data" \
+      "$POSTGRES_IMAGE" >/dev/null
+  fi
+  wait_for_postgres "$container"
+}
+
+stop_postgres() {
+  docker stop "$1" >/dev/null
+}
+
+assert_marker() {
+  local container="$1"
+  local expected="$2"
+  local actual
+  actual="$(docker exec "$container" psql -U skillhub -d skillhub -Atqc \
+    'SELECT value FROM storage_upgrade_verification WHERE id = 1')"
+  [[ "$actual" == "$expected" ]]
+}
+
+docker volume create "$FRESH_VOLUME" >/dev/null
+docker run --rm \
+  --volume "$FRESH_VOLUME:/data" \
+  --entrypoint sh \
+  "$POSTGRES_IMAGE" \
+  -ec 'mkdir -p /data/lost+found'
+
+start_postgres "${RUN_ID}-fresh-1" "$FRESH_VOLUME" patched
+docker exec "${RUN_ID}-fresh-1" test -f /var/lib/postgresql/data/pgdata/PG_VERSION
+docker exec "${RUN_ID}-fresh-1" psql -U skillhub -d skillhub -v ON_ERROR_STOP=1 -qc \
+  "CREATE TABLE storage_upgrade_verification (id integer PRIMARY KEY, value text NOT NULL); \
+   INSERT INTO storage_upgrade_verification VALUES (1, 'fresh-volume');"
+stop_postgres "${RUN_ID}-fresh-1"
+
+start_postgres "${RUN_ID}-fresh-2" "$FRESH_VOLUME" patched
+assert_marker "${RUN_ID}-fresh-2" "fresh-volume"
+stop_postgres "${RUN_ID}-fresh-2"
+echo "PASS: fresh volume with lost+found initializes in pgdata and survives restart"
+
+docker volume create "$LEGACY_VOLUME" >/dev/null
+start_postgres "${RUN_ID}-legacy-1" "$LEGACY_VOLUME"
+docker exec "${RUN_ID}-legacy-1" test -f /var/lib/postgresql/data/PG_VERSION
+docker exec "${RUN_ID}-legacy-1" psql -U skillhub -d skillhub -v ON_ERROR_STOP=1 -qc \
+  "CREATE TABLE storage_upgrade_verification (id integer PRIMARY KEY, value text NOT NULL); \
+   INSERT INTO storage_upgrade_verification VALUES (1, 'legacy-root');"
+stop_postgres "${RUN_ID}-legacy-1"
+
+start_postgres "${RUN_ID}-legacy-2" "$LEGACY_VOLUME" patched
+assert_marker "${RUN_ID}-legacy-2" "legacy-root"
+stop_postgres "${RUN_ID}-legacy-2"
+echo "PASS: legacy root-level cluster remains visible after the manifest upgrade"


### PR DESCRIPTION
## Summary

- Avoid PostgreSQL `initdb` failures on fresh ext4-backed PVCs whose root contains `lost+found`.
- Preserve existing installations that store a PostgreSQL cluster directly at the PVC root.
- Select the data directory at startup: use the root when root-level `PG_VERSION` exists; otherwise initialize/use `pgdata/`.
- Document upgrade and rollback behavior in the Kubernetes operator guides.
- Run the storage-layout regression from the PR E2E workflow.

## Why

Mounting a fresh filesystem root directly as `PGDATA` can fail because `lost+found` makes the directory non-empty. An unconditional `subPath: pgdata` fixes fresh installs but hides existing root-level clusters during upgrade. Startup-time selection handles both layouts without moving live data.

## Validation

- [x] Fresh volume containing `lost+found` initializes under `pgdata/`.
- [x] Fresh-layout data survives PostgreSQL container recreation.
- [x] Existing root-level cluster remains visible after switching to the new startup command.
- [x] `kubectl kustomize deploy/k8s/overlays/with-infra` renders successfully.
- [x] Bilingual VitePress documentation build passes.
- [x] Synthetic merges with current `main` and `big-main` are clean.
- [x] PR and `big-main` CI, including the storage regression and full E2E suite, pass.
- [x] `big-main` was deployed to the shared test runtime and passed targeted storage plus runtime smoke validation.

Command for the stateful regression:

```bash
bash scripts/tests/k8s-postgres-storage-test.sh
```

## Risk

- **User-facing impact:** None in the web/API product; this only affects the `with-infra` Kubernetes PostgreSQL startup path.
- **Deployment or migration impact:** Existing PVCs with root-level `PG_VERSION` continue using the root. Fresh PVCs and PVCs already initialized under `pgdata/` use `pgdata/`. No automatic file move is performed.
- **Rollback approach:** If data lives under `pgdata/`, an older manifest must retain the new startup command or set `PGDATA=/var/lib/postgresql/data/pgdata`. Do not move a running database directory back to the PVC root. Root-layout installations can roll back without changing `PGDATA`.

## Notes

- The contributor commit is preserved. Maintainer follow-ups add the compatibility path, documentation, regression test, CI wiring, and deterministic final-server readiness wait.
- DCO remains a merge gate. Commits `a0d0738f` (xring) and `0dd600ce` (XiaoSeS) lack sign-off. The contributor must attest their own commit; the maintainer can repair only the maintainer commit after the contributor updates the branch.
- Operator documentation: `deploy/k8s/README.md`, `docs/skillhub/guide/kubernetes.md`, and `docs/skillhub/en/guide/kubernetes.md`.