### PR TITLE
fix(web): restore compatibility with Chromium 83 (Debian 10)

### DIFF
--- a/web/.browserslistrc
+++ b/web/.browserslistrc
@@ -1,0 +1,4 @@
+Chrome >= 83
+Edge >= 83
+Firefox >= 78
+Safari >= 14

--- a/web/src/bootstrap.ts
+++ b/web/src/bootstrap.ts
@@ -4,6 +4,7 @@
  * Deployments inject `/runtime-config.js` at startup, and this file guarantees the app sees either
  * that config or a safe fallback object before importing the main entry.
  */
+import './legacy-polyfills'
 async function loadRuntimeConfig() {
   await new Promise<void>((resolve, reject) => {
     const script = document.createElement('script')
@@ -16,14 +17,16 @@ async function loadRuntimeConfig() {
 }
 
 function ensureRuntimeConfigFallback() {
-  window.__SKILLHUB_RUNTIME_CONFIG__ ??= {
-    apiBaseUrl: '',
-    appBaseUrl: '',
-    authDirectEnabled: 'false',
-    authDirectProvider: '',
-    authSessionBootstrapEnabled: 'false',
-    authSessionBootstrapProvider: '',
-    authSessionBootstrapAuto: 'false',
+  if (!window.__SKILLHUB_RUNTIME_CONFIG__) {
+    window.__SKILLHUB_RUNTIME_CONFIG__ = {
+      apiBaseUrl: '',
+      appBaseUrl: '',
+      authDirectEnabled: 'false',
+      authDirectProvider: '',
+      authSessionBootstrapEnabled: 'false',
+      authSessionBootstrapProvider: '',
+      authSessionBootstrapAuto: 'false',
+    }
   }
 }
 

--- a/web/src/legacy-polyfills.ts
+++ b/web/src/legacy-polyfills.ts
@@ -1,0 +1,78 @@
+/**
+ * Polyfills for older browsers (e.g. Chromium 83 on Debian 10) that lack a few
+ * ES2021+ runtime methods used by bundled dependencies. esbuild only transpiles
+ * syntax, not runtime APIs, so we patch the prototypes here before any other
+ * module runs.
+ *
+ * TypeScript's lib target is ES2020, so the methods we patch are referenced via
+ * string keys / loose casts to avoid compile-time type errors.
+ */
+
+type AnyStringReplacer = (substring: string, ...args: unknown[]) => string
+
+const StringProto = String.prototype as unknown as Record<string, unknown>
+const ArrayProto = Array.prototype as unknown as Record<string, unknown>
+const ObjectCtor = Object as unknown as Record<string, unknown>
+
+if (typeof StringProto.replaceAll !== 'function') {
+  Object.defineProperty(String.prototype, 'replaceAll', {
+    configurable: true,
+    writable: true,
+    value: function replaceAll(
+      this: string,
+      search: string | RegExp,
+      replacement: string | AnyStringReplacer,
+    ): string {
+      if (search instanceof RegExp) {
+        if (!search.flags.includes('g')) {
+          throw new TypeError('String.prototype.replaceAll called with a non-global RegExp argument')
+        }
+        return this.replace(search, replacement as string)
+      }
+      const needle = String(search)
+      if (needle === '') {
+        return this.replace(new RegExp('', 'g'), replacement as string)
+      }
+      const escaped = needle.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
+      return this.replace(new RegExp(escaped, 'g'), replacement as string)
+    },
+  })
+}
+
+if (typeof ArrayProto.at !== 'function') {
+  Object.defineProperty(Array.prototype, 'at', {
+    configurable: true,
+    writable: true,
+    value: function at(this: unknown[], index: number) {
+      const len = this.length
+      const i = Math.trunc(index) || 0
+      const resolved = i < 0 ? len + i : i
+      if (resolved < 0 || resolved >= len) return undefined
+      return this[resolved]
+    },
+  })
+}
+
+if (typeof StringProto.at !== 'function') {
+  Object.defineProperty(String.prototype, 'at', {
+    configurable: true,
+    writable: true,
+    value: function at(this: string, index: number) {
+      const len = this.length
+      const i = Math.trunc(index) || 0
+      const resolved = i < 0 ? len + i : i
+      if (resolved < 0 || resolved >= len) return undefined
+      return this.charAt(resolved)
+    },
+  })
+}
+
+if (typeof ObjectCtor.hasOwn !== 'function') {
+  Object.defineProperty(Object, 'hasOwn', {
+    configurable: true,
+    writable: true,
+    value: function hasOwn(target: object, property: PropertyKey) {
+      return Object.prototype.hasOwnProperty.call(target, property)
+    },
+  })
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,9 +15,6 @@ export default defineConfig({
     target: LEGACY_BROWSER_TARGETS,
     cssTarget: LEGACY_BROWSER_TARGETS,
   },
-  esbuild: {
-    target: LEGACY_BROWSER_TARGETS,
-  },
   optimizeDeps: {
     esbuildOptions: {
       target: LEGACY_BROWSER_TARGETS,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,11 +2,25 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+const LEGACY_BROWSER_TARGETS = ['chrome83', 'edge83', 'firefox78', 'safari14']
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    target: LEGACY_BROWSER_TARGETS,
+    cssTarget: LEGACY_BROWSER_TARGETS,
+  },
+  esbuild: {
+    target: LEGACY_BROWSER_TARGETS,
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: LEGACY_BROWSER_TARGETS,
     },
   },
   test: {


### PR DESCRIPTION
## 背景

客户反馈在 Chromium 83.0.4103.116（Debian 10.10）上打开 **发布技能** 页时，命名空间和可见性的下拉菜单点击无响应。

## 根因

- Vite 6 默认 `build.target = 'modules'`，实际对应 `chrome87+`，高于客户浏览器版本。
- 产物里存在 Chrome 83 不支持的语法/API：
  - `??=` 逻辑空值赋值（Chrome 85+）—— 源码里 `bootstrap.ts` 有一处。
  - `String.prototype.replaceAll`（Chrome 85+）、`Array/String.prototype.at`（Chrome 92+）、`Object.hasOwn`（Chrome 93+）—— 由依赖（如 tanstack router）带入。
- esbuild 只转译语法、不 polyfill runtime API，所以目标降级后仍需手动补 polyfill。
- lazy chunk 解析失败 → 路由组件未挂载 → Radix Select 不响应点击。

## 改动

| 文件 | 说明 |
| --- | --- |
| `web/vite.config.ts` | 显式把 `build.target` / `build.cssTarget` / `esbuild.target` / `optimizeDeps.esbuildOptions.target` 设为 `['chrome83','edge83','firefox78','safari14']` |
| `web/.browserslistrc` | 让 autoprefixer 对齐同一基线 |
| `web/src/bootstrap.ts` | 去掉 `??=`；最顶部 `import './legacy-polyfills'`，保证 polyfill 先于其他 chunk |
| `web/src/legacy-polyfills.ts` | 新增。补齐 `String.prototype.replaceAll`、`Array/String.prototype.at`、`Object.hasOwn` |

## 验证

- `pnpm build` 通过（tsc + vite 均无错）。
- 产物扫描：`??=` / `||=` / `&&=` / `.at(-N)` 字面量均 0 次。
- `replaceAll` / `hasOwn` 在依赖 chunk 中仍存在，polyfill 已在入口 chunk 最前面注入。
