### PR TITLE
fix(cli): respect configured npm registry

### DIFF
--- a/cli/src/clients/npm-registry-client.ts
+++ b/cli/src/clients/npm-registry-client.ts
@@ -1,32 +1,85 @@
 import { EXIT, CLI_PACKAGE_NAME } from '../shared/constants'
 import { CliError } from '../shared/errors'
 
+const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org'
+
+function readEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const exactValue = env[name]?.trim()
+  if (exactValue) {
+    return exactValue
+  }
+
+  const lowerName = name.toLowerCase()
+  for (const [key, value] of Object.entries(env)) {
+    const normalizedValue = value?.trim()
+    if (key.toLowerCase() === lowerName && normalizedValue) {
+      return normalizedValue
+    }
+  }
+  return undefined
+}
+
+function resolveRegistry(env: NodeJS.ProcessEnv): string {
+  return readEnv(env, 'SKILLHUB_NPM_REGISTRY')
+    ?? readEnv(env, 'npm_config_registry')
+    ?? readEnv(env, 'NPM_CONFIG_REGISTRY')
+    ?? DEFAULT_NPM_REGISTRY
+}
+
+function buildLatestUrl(registry: string, packageName: string): string {
+  try {
+    const base = registry.endsWith('/') ? registry : `${registry}/`
+    return new URL(`${encodeURIComponent(packageName)}/latest`, base).toString()
+  } catch {
+    throw new CliError('invalid npm registry URL', EXIT.usage, {
+      registry,
+      next: 'check npm registry configuration and retry'
+    })
+  }
+}
+
 export class NpmRegistryClient {
   constructor(
     private readonly fetchImpl: typeof fetch = fetch,
-    private readonly timeoutMs = 10_000
+    private readonly timeoutMs = 10_000,
+    private readonly env: NodeJS.ProcessEnv = process.env
   ) {}
 
   async latestVersion(packageName = CLI_PACKAGE_NAME): Promise<string> {
+    const registry = resolveRegistry(this.env)
+    const url = buildLatestUrl(registry, packageName)
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), this.timeoutMs)
     try {
       let response: Response
       try {
-        response = await this.fetchImpl(`https://registry.npmjs.org/${packageName}/latest`, {
+        response = await this.fetchImpl(url, {
           signal: controller.signal
         })
-      } catch {
+      } catch (error) {
+        const isTimeout = error instanceof Error && error.name === 'AbortError'
         throw new CliError('npm registry unreachable', EXIT.network, {
-          next: 'check network connectivity and retry'
+          registry,
+          cause: error instanceof Error ? error.message : String(error),
+          next: isTimeout
+            ? 'check npm registry connectivity or proxy settings and retry'
+            : 'check npm registry/proxy configuration and retry'
         })
       }
       if (!response.ok) {
-        throw new CliError(`npm registry returned ${response.status}`, EXIT.network)
+        throw new CliError(`npm registry returned ${response.status}`, EXIT.network, { registry })
       }
-      const body = await response.json()
-      if (typeof body.version !== 'string') {
-        throw new CliError('npm registry response missing version', EXIT.network)
+      let body: unknown
+      try {
+        body = await response.json()
+      } catch (error) {
+        throw new CliError('npm registry response invalid', EXIT.network, {
+          registry,
+          cause: error instanceof Error ? error.message : String(error)
+        })
+      }
+      if (typeof body !== 'object' || body === null || !('version' in body) || typeof body.version !== 'string') {
+        throw new CliError('npm registry response missing version', EXIT.network, { registry })
       }
       return body.version
     } finally {

--- a/cli/test/unit/clients/npm-registry-client.test.ts
+++ b/cli/test/unit/clients/npm-registry-client.test.ts
@@ -2,15 +2,154 @@ import { describe, expect, test } from 'bun:test'
 import { NpmRegistryClient } from '../../../src/clients/npm-registry-client'
 
 describe('NpmRegistryClient', () => {
+  test('uses npm_config_registry when checking the latest version', async () => {
+    let requestedUrl = ''
+    const successfulFetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = String(input)
+      return Response.json({ version: '1.2.3' })
+    }) as typeof fetch
+    const client = new NpmRegistryClient(successfulFetch, 10_000, {
+      npm_config_registry: 'https://registry.npmmirror.com'
+    })
+
+    await expect(client.latestVersion()).resolves.toBe('1.2.3')
+    expect(requestedUrl).toBe('https://registry.npmmirror.com/%40astron-team%2Fskillhub/latest')
+  })
+
+  test('uses SkillHub registry override before npm registry env vars', async () => {
+    let requestedUrl = ''
+    const successfulFetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = String(input)
+      return Response.json({ version: '1.2.3' })
+    }) as typeof fetch
+    const client = new NpmRegistryClient(successfulFetch, 10_000, {
+      SKILLHUB_NPM_REGISTRY: 'https://skillhub-registry.example.test/npm/',
+      npm_config_registry: 'https://lower-priority.example.test',
+      NPM_CONFIG_REGISTRY: 'https://lowest-priority.example.test'
+    })
+
+    await expect(client.latestVersion()).resolves.toBe('1.2.3')
+    expect(requestedUrl).toBe('https://skillhub-registry.example.test/npm/%40astron-team%2Fskillhub/latest')
+  })
+
+  test('resolves registry env names case-insensitively for Windows compatibility', async () => {
+    let requestedUrl = ''
+    const successfulFetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = String(input)
+      return Response.json({ version: '1.2.3' })
+    }) as typeof fetch
+    const client = new NpmRegistryClient(successfulFetch, 10_000, {
+      skillhub_npm_registry: 'https://windows-env.example.test'
+    })
+
+    await expect(client.latestVersion()).resolves.toBe('1.2.3')
+    expect(requestedUrl).toBe('https://windows-env.example.test/%40astron-team%2Fskillhub/latest')
+  })
+
+  test('ignores empty registry env values before falling back', async () => {
+    let requestedUrl = ''
+    const successfulFetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = String(input)
+      return Response.json({ version: '1.2.3' })
+    }) as typeof fetch
+    const client = new NpmRegistryClient(successfulFetch, 10_000, {
+      SKILLHUB_NPM_REGISTRY: '   ',
+      npm_config_registry: '',
+      NPM_CONFIG_REGISTRY: 'https://registry.example.test'
+    })
+
+    await expect(client.latestVersion()).resolves.toBe('1.2.3')
+    expect(requestedUrl).toBe('https://registry.example.test/%40astron-team%2Fskillhub/latest')
+  })
+
+  test('uses the default npm registry when no registry is configured', async () => {
+    let requestedUrl = ''
+    const successfulFetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = String(input)
+      return Response.json({ version: '1.2.3' })
+    }) as typeof fetch
+    const client = new NpmRegistryClient(successfulFetch, 10_000, {})
+
+    await expect(client.latestVersion()).resolves.toBe('1.2.3')
+    expect(requestedUrl).toBe('https://registry.npmjs.org/%40astron-team%2Fskillhub/latest')
+  })
+
   test('classifies network failures as CLI errors', async () => {
     const failingFetch = (async () => {
       throw new TypeError('fetch failed')
     }) as unknown as typeof fetch
-    const client = new NpmRegistryClient(failingFetch)
+    const client = new NpmRegistryClient(failingFetch, 10_000, {
+      NPM_CONFIG_REGISTRY: 'https://registry.example.test'
+    })
 
     await expect(client.latestVersion()).rejects.toMatchObject({
       message: 'npm registry unreachable',
-      exitCode: 3
+      exitCode: 3,
+      details: {
+        registry: 'https://registry.example.test',
+        cause: 'fetch failed',
+        next: 'check npm registry/proxy configuration and retry'
+      }
+    })
+  })
+
+  test('reports registry context for non-2xx responses', async () => {
+    const failingFetch = (async () => new Response('{}', { status: 503 })) as unknown as typeof fetch
+    const client = new NpmRegistryClient(failingFetch, 10_000, {
+      SKILLHUB_NPM_REGISTRY: 'https://registry.example.test'
+    })
+
+    await expect(client.latestVersion()).rejects.toMatchObject({
+      message: 'npm registry returned 503',
+      exitCode: 3,
+      details: {
+        registry: 'https://registry.example.test'
+      }
+    })
+  })
+
+  test('rejects registry responses without a version', async () => {
+    const failingFetch = (async () => Response.json({ name: '@astron-team/skillhub' })) as unknown as typeof fetch
+    const client = new NpmRegistryClient(failingFetch, 10_000, {
+      npm_config_registry: 'https://registry.example.test'
+    })
+
+    await expect(client.latestVersion()).rejects.toMatchObject({
+      message: 'npm registry response missing version',
+      exitCode: 3,
+      details: {
+        registry: 'https://registry.example.test'
+      }
+    })
+  })
+
+  test('rejects invalid JSON registry responses', async () => {
+    const failingFetch = (async () => new Response('<html>not json</html>')) as unknown as typeof fetch
+    const client = new NpmRegistryClient(failingFetch, 10_000, {
+      npm_config_registry: 'https://registry.example.test'
+    })
+
+    await expect(client.latestVersion()).rejects.toMatchObject({
+      message: 'npm registry response invalid',
+      exitCode: 3,
+      details: {
+        registry: 'https://registry.example.test'
+      }
+    })
+  })
+
+  test('rejects invalid registry configuration', async () => {
+    const client = new NpmRegistryClient(fetch, 10_000, {
+      npm_config_registry: 'https://['
+    })
+
+    await expect(client.latestVersion()).rejects.toMatchObject({
+      message: 'invalid npm registry URL',
+      exitCode: 5,
+      details: {
+        registry: 'https://[',
+        next: 'check npm registry configuration and retry'
+      }
     })
   })
 })


### PR DESCRIPTION
## 概述
修复 CLI update 检查固定访问 npmjs，导致镜像源、代理或企业 registry 环境误报 npm registry unreachable 的问题。

## 变更内容

### 后端实现
- 本次变更不涉及后端实现。
- 无 DB migration 变更。
- 无 API 契约变更。

### 前端实现
- 本次变更不涉及前端页面或 web/src 代码。

### CLI 实现
- `NpmRegistryClient` 版本检测支持 registry 配置优先级：`SKILLHUB_NPM_REGISTRY` -> `npm_config_registry` -> `NPM_CONFIG_REGISTRY` -> 默认 `https://registry.npmjs.org`。
- scoped package latest URL 使用 `new URL` 构建，支持 registry 带 path 和 trailing slash。
- registry 网络错误、HTTP 非 2xx、缺少 version、无效 JSON、非法 registry URL 均带稳定 `CliError` 上下文。

### 测试覆盖
- 后端单测：不适用。
- 前端单测：不适用。
- CLI 单测：补充 `cli/test/unit/clients/npm-registry-client.test.ts`，覆盖 registry 优先级、默认 registry、path/trailing slash、网络失败、非 2xx、缺少 version、无效 JSON、非法 URL。
- E2E 测试：不适用；无 `web/src` 变更。

## 质量门禁

- [x] `make test-cli` 通过（180/180 tests, 465 assertions）
- [x] `make typecheck-cli` 通过（0 TS errors）
- [x] `make lint-cli` 通过（0 errors, 0 warnings）
- [x] `git diff --check` 通过
- [ ] `make typecheck-web` 不适用（无 web/ 变更）
- [ ] `make lint-web` 不适用（无 web/ 变更）
- [ ] `make test-frontend` 不适用（无 web/ 变更）
- [ ] `make test-backend-app` 不适用（无 server/ 变更）
- [ ] Playwright E2E 不适用（无 web/src 变更）
- [ ] `make generate-api` 不适用（无 Controller 变更）

## 安全考虑

- 本次变更不涉及鉴权、授权、敏感数据处理或后端输入处理。
- registry URL 使用 `new URL` 构建，避免手写路径拼接造成的 URL 结构错误。
- 错误信息仅包含 registry 地址和底层异常消息，不包含 token 或凭据。

## 相关 Issue

Related to CLI update registry reachability issue.

## 测试说明

### 本地验证步骤
1. 运行 `make test-cli`，预期全部 CLI 测试通过。
2. 运行 `make typecheck-cli`，预期 TypeScript 0 errors。
3. 运行 `make lint-cli`，预期 ESLint 0 errors / 0 warnings。
4. 设置 `npm_config_registry` 或 `SKILLHUB_NPM_REGISTRY` 后执行 `skillhub update --check`，预期版本检测访问配置的 registry。

### 回归测试范围
- CLI update 版本检测。
- npm/bun 全局安装模式分支。
- CLI 错误输出上下文。

### 截图/录屏（如有 UI 变更）
无 UI 变更。
