### PR TITLE
Improve skill discovery cards and labels

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillPublishController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillPublishController.java
@@ -3,6 +3,7 @@ package com.iflytek.skillhub.controller.portal;
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.controller.BaseApiController;
 import com.iflytek.skillhub.controller.support.SkillPackageArchiveExtractor;
+import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.shared.exception.DomainBadRequestException;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.service.SkillPublishService;
@@ -12,12 +13,16 @@ import com.iflytek.skillhub.dto.ApiResponseFactory;
 import com.iflytek.skillhub.dto.PublishResponse;
 import com.iflytek.skillhub.metrics.SkillHubMetrics;
 import com.iflytek.skillhub.ratelimit.RateLimit;
+import com.iflytek.skillhub.service.SkillLabelAppService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Upload endpoints for skill packages.
@@ -32,15 +37,18 @@ public class SkillPublishController extends BaseApiController {
     private final SkillPublishService skillPublishService;
     private final SkillPackageArchiveExtractor skillPackageArchiveExtractor;
     private final SkillHubMetrics skillHubMetrics;
+    private final SkillLabelAppService skillLabelAppService;
 
     public SkillPublishController(SkillPublishService skillPublishService,
                                   SkillPackageArchiveExtractor skillPackageArchiveExtractor,
                                   ApiResponseFactory responseFactory,
-                                  SkillHubMetrics skillHubMetrics) {
+                                  SkillHubMetrics skillHubMetrics,
+                                  SkillLabelAppService skillLabelAppService) {
         super(responseFactory);
         this.skillPublishService = skillPublishService;
         this.skillPackageArchiveExtractor = skillPackageArchiveExtractor;
         this.skillHubMetrics = skillHubMetrics;
+        this.skillLabelAppService = skillLabelAppService;
     }
 
     /**
@@ -54,8 +62,14 @@ public class SkillPublishController extends BaseApiController {
             @RequestParam("file") MultipartFile file,
             @RequestParam("visibility") String visibility,
             @RequestParam(value = "confirmWarnings", defaultValue = "false") boolean confirmWarnings,
+            @RequestParam(value = "labels", required = false) List<String> labels,
+            @RequestParam(value = "summary", required = false) String summary,
+            @RequestParam(value = "description", required = false) String description,
+            @RequestAttribute(value = "userNsRoles", required = false) Map<Long, NamespaceRole> userNsRoles,
             @AuthenticationPrincipal PlatformPrincipal principal) throws IOException {
 
+        List<String> normalizedLabels = normalizeLabels(labels);
+        String summaryOverride = resolveSummaryOverride(summary, description);
         SkillVisibility skillVisibility = SkillVisibility.valueOf(visibility.toUpperCase());
 
         List<PackageEntry> entries;
@@ -81,8 +95,20 @@ public class SkillPublishController extends BaseApiController {
                 principal.userId(),
                 skillVisibility,
                 principal.platformRoles(),
-                confirmWarnings
+                confirmWarnings,
+                summaryOverride
         );
+
+        for (String labelSlug : normalizedLabels) {
+            skillLabelAppService.attachLabel(
+                    namespace,
+                    publishResult.slug(),
+                    labelSlug,
+                    principal.userId(),
+                    userNsRoles == null ? Map.of() : userNsRoles,
+                    null
+            );
+        }
 
         PublishResponse response = new PublishResponse(
                 publishResult.skillId(),
@@ -91,10 +117,34 @@ public class SkillPublishController extends BaseApiController {
                 publishResult.version().getVersion(),
                 publishResult.version().getStatus().name(),
                 publishResult.version().getFileCount(),
-                publishResult.version().getTotalSize()
+                publishResult.version().getTotalSize(),
+                normalizedLabels
         );
         skillHubMetrics.incrementSkillPublish(namespace, publishResult.version().getStatus().name());
 
         return ok("response.success.published", response);
+    }
+
+    private List<String> normalizeLabels(List<String> labels) {
+        if (labels == null) {
+            return Collections.emptyList();
+        }
+        return labels.stream()
+                .map(String::trim)
+                .filter(label -> !label.isBlank())
+                .collect(java.util.stream.Collectors.collectingAndThen(
+                        java.util.stream.Collectors.toCollection(LinkedHashSet::new),
+                        List::copyOf
+                ));
+    }
+
+    private String resolveSummaryOverride(String summary, String description) {
+        if (summary != null && !summary.isBlank()) {
+            return summary.trim();
+        }
+        if (description != null && !description.isBlank()) {
+            return description.trim();
+        }
+        return null;
     }
 }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/PublishResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/PublishResponse.java
@@ -1,5 +1,7 @@
 package com.iflytek.skillhub.dto;
 
+import java.util.List;
+
 public record PublishResponse(
         Long skillId,
         String namespace,
@@ -7,5 +9,6 @@ public record PublishResponse(
         String version,
         String status,
         int fileCount,
-        long totalSize
+        long totalSize,
+        List<String> labels
 ) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
@@ -2,6 +2,7 @@ package com.iflytek.skillhub.dto;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
 
 public record SkillSummaryResponse(
         Long id,
@@ -20,5 +21,6 @@ public record SkillSummaryResponse(
         SkillLifecycleVersionResponse headlineVersion,
         SkillLifecycleVersionResponse publishedVersion,
         SkillLifecycleVersionResponse ownerPreviewVersion,
-        String resolutionMode
+        String resolutionMode,
+        List<SkillLabelDto> labels
 ) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
@@ -79,7 +79,8 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
                 toLifecycleVersion(headlineVersion),
                 toLifecycleVersion(publishedVersion),
                 toLifecycleVersion(ownerPreviewVersion),
-                projection.resolutionMode().name()
+                projection.resolutionMode().name(),
+                List.of()
         );
     }
 

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillLabelAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillLabelAppService.java
@@ -77,6 +77,16 @@ public class SkillLabelAppService {
         return toDtos(skillLabelService.listSkillLabels(skillId));
     }
 
+    public Map<Long, List<SkillLabelDto>> listSkillLabelsBySkillIds(List<Long> skillIds) {
+        if (skillIds == null || skillIds.isEmpty()) {
+            return Map.of();
+        }
+        return skillIds.stream()
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toMap(Function.identity(), this::listSkillLabelsBySkillId));
+    }
+
     @Transactional
     public SkillLabelDto attachLabel(String namespaceSlug,
                                      String skillSlug,

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
@@ -8,6 +8,7 @@ import com.iflytek.skillhub.domain.namespace.NamespaceService;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillRepository;
 import com.iflytek.skillhub.domain.skill.service.SkillLifecycleProjectionService;
+import com.iflytek.skillhub.dto.SkillLabelDto;
 import com.iflytek.skillhub.dto.SkillSummaryResponse;
 import com.iflytek.skillhub.search.SearchQuery;
 import com.iflytek.skillhub.search.SearchQueryService;
@@ -37,6 +38,7 @@ public class SkillSearchAppService {
     private final NamespaceService namespaceService;
     private final SkillLifecycleProjectionService skillLifecycleProjectionService;
     private final RbacService rbacService;
+    private final SkillLabelAppService skillLabelAppService;
 
     public SkillSearchAppService(
             SearchQueryService searchQueryService,
@@ -44,13 +46,15 @@ public class SkillSearchAppService {
             NamespaceRepository namespaceRepository,
             NamespaceService namespaceService,
             SkillLifecycleProjectionService skillLifecycleProjectionService,
-            RbacService rbacService) {
+            RbacService rbacService,
+            SkillLabelAppService skillLabelAppService) {
         this.searchQueryService = searchQueryService;
         this.skillRepository = skillRepository;
         this.namespaceRepository = namespaceRepository;
         this.namespaceService = namespaceService;
         this.skillLifecycleProjectionService = skillLifecycleProjectionService;
         this.rbacService = rbacService;
+        this.skillLabelAppService = skillLabelAppService;
     }
 
     public record SearchResponse(
@@ -179,18 +183,24 @@ public class SkillSearchAppService {
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getSlug()));
         Map<Long, SkillLifecycleProjectionService.Projection> projectionsBySkillId =
                 skillLifecycleProjectionService.projectPublishedSummaries(matchedSkills);
+        Map<Long, List<SkillLabelDto>> labelsBySkillId = skillLabelAppService.listSkillLabelsBySkillIds(skillIds);
 
         return skillIds.stream()
                 .map(skillsById::get)
                 .filter(java.util.Objects::nonNull)
-                .map(skill -> toSummaryResponse(skill, namespaceSlugsById, projectionsBySkillId.get(skill.getId())))
+                .map(skill -> toSummaryResponse(
+                        skill,
+                        namespaceSlugsById,
+                        projectionsBySkillId.get(skill.getId()),
+                        labelsBySkillId.getOrDefault(skill.getId(), List.of())))
                 .toList();
     }
 
     private SkillSummaryResponse toSummaryResponse(
             Skill skill,
             Map<Long, String> namespaceSlugsById,
-            SkillLifecycleProjectionService.Projection projection) {
+            SkillLifecycleProjectionService.Projection projection,
+            List<SkillLabelDto> labels) {
         String namespaceSlug = namespaceSlugsById.get(skill.getNamespaceId());
 
         return new SkillSummaryResponse(
@@ -210,7 +220,8 @@ public class SkillSearchAppService {
                 toLifecycleVersion(projection.headlineVersion()),
                 toLifecycleVersion(projection.publishedVersion()),
                 toLifecycleVersion(projection.ownerPreviewVersion()),
-                projection.resolutionMode().name()
+                projection.resolutionMode().name(),
+                labels
         );
     }
 

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -114,7 +114,8 @@ class ClawHubCompatControllerTest {
                                 new SkillLifecycleVersionResponse(11L, "1.2.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.2.0", "PUBLISHED"),
                                 null,
-                                "PUBLISHED")),
+                                "PUBLISHED",
+                                List.of())),
                         1,
                         0,
                         20

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
@@ -55,7 +55,8 @@ class ClawHubRegistryFacadeTest {
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 null,
-                                "PUBLISHED"
+                                "PUBLISHED",
+                                List.of()
                         )),
                         1,
                         0,

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
@@ -75,7 +75,8 @@ class MeControllerTest {
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 null,
-                                "PUBLISHED"
+                                "PUBLISHED",
+                                List.of()
                         )),
                         9,
                         1,

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/SkillPublishControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/SkillPublishControllerTest.java
@@ -2,6 +2,7 @@ package com.iflytek.skillhub.controller.portal;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import com.iflytek.skillhub.domain.skill.SkillVersionStatus;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.service.SkillPublishService;
 import com.iflytek.skillhub.metrics.SkillHubMetrics;
+import com.iflytek.skillhub.service.SkillLabelAppService;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -63,6 +65,9 @@ class SkillPublishControllerTest {
     @MockBean
     private SkillHubMetrics skillHubMetrics;
 
+    @MockBean
+    private SkillLabelAppService skillLabelAppService;
+
     @Test
     void publish_recordsMetricsAfterSuccess() throws Exception {
         SkillVersion version = new SkillVersion(12L, "1.0.0", "usr_1");
@@ -77,7 +82,8 @@ class SkillPublishControllerTest {
             eq("usr_1"),
             eq(SkillVisibility.PUBLIC),
             eq(Set.of("SUPER_ADMIN")),
-            eq(false)))
+            eq(false),
+            isNull()))
             .willReturn(new SkillPublishService.PublishResult(12L, "demo-skill", version));
 
         PlatformPrincipal principal = new PlatformPrincipal(
@@ -128,7 +134,8 @@ class SkillPublishControllerTest {
             eq("usr_1"),
             eq(SkillVisibility.PUBLIC),
             eq(Set.of("SUPER_ADMIN")),
-            eq(true)))
+            eq(true),
+            isNull()))
             .willReturn(new SkillPublishService.PublishResult(12L, "demo-skill", version));
 
         PlatformPrincipal principal = new PlatformPrincipal(
@@ -184,7 +191,7 @@ class SkillPublishControllerTest {
 
         verify(skillPublishService, never()).publishFromEntries(
             eq("global"), anyList(), eq("usr_1"),
-            eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(false));
+            eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(false), isNull());
     }
 
     @Test
@@ -198,7 +205,7 @@ class SkillPublishControllerTest {
         given(skillPublishService.publishFromEntries(
             eq("global"), ArgumentMatchers.<List<PackageEntry>>any(),
             eq("usr_1"), eq(SkillVisibility.PUBLIC),
-            eq(Set.of("SUPER_ADMIN")), eq(true)))
+            eq(Set.of("SUPER_ADMIN")), eq(true), isNull()))
             .willReturn(new SkillPublishService.PublishResult(12L, "demo-skill", version));
 
         PlatformPrincipal principal = new PlatformPrincipal(
@@ -218,6 +225,61 @@ class SkillPublishControllerTest {
                 .with(csrf()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value(0));
+    }
+
+    @Test
+    void publish_acceptsLabelsAndSummaryOverride() throws Exception {
+        SkillVersion version = new SkillVersion(12L, "1.0.0", "usr_1");
+        version.setStatus(SkillVersionStatus.PENDING_REVIEW);
+        version.setFileCount(1);
+        version.setTotalSize(128L);
+        ReflectionTestUtils.setField(version, "id", 34L);
+
+        given(skillPublishService.publishFromEntries(
+            eq("global"),
+            ArgumentMatchers.<List<PackageEntry>>any(),
+            eq("usr_1"),
+            eq(SkillVisibility.PUBLIC),
+            eq(Set.of("SUPER_ADMIN")),
+            eq(false),
+            eq("Request summary")))
+            .willReturn(new SkillPublishService.PublishResult(12L, "demo-skill", version));
+
+        PlatformPrincipal principal = new PlatformPrincipal(
+            "usr_1",
+            "publisher",
+            "publisher@example.com",
+            "",
+            "local",
+            Set.of("SUPER_ADMIN")
+        );
+        var auth = new UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            List.of(new SimpleGrantedAuthority("ROLE_SUPER_ADMIN"))
+        );
+
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "skill.zip",
+            "application/zip",
+            buildZipBytes()
+        );
+
+        mockMvc.perform(multipart("/api/v1/skills/global/publish")
+                .file(file)
+                .param("visibility", "PUBLIC")
+                .param("labels", "official", " official ", "featured")
+                .param("summary", " Request summary ")
+                .param("description", "Description fallback")
+                .with(authentication(auth))
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.labels[0]").value("official"))
+            .andExpect(jsonPath("$.data.labels[1]").value("featured"));
+
+        verify(skillLabelAppService).attachLabel(eq("global"), eq("demo-skill"), eq("official"), eq("usr_1"), eq(java.util.Map.of()), isNull());
+        verify(skillLabelAppService).attachLabel(eq("global"), eq("demo-skill"), eq("featured"), eq("usr_1"), eq(java.util.Map.of()), isNull());
     }
 
     private byte[] buildZipBytes() throws Exception {

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/SkillSearchAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/SkillSearchAppServiceTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class SkillSearchAppServiceTest {
@@ -55,17 +56,22 @@ class SkillSearchAppServiceTest {
     @Mock
     private RbacService rbacService;
 
+    @Mock
+    private SkillLabelAppService skillLabelAppService;
+
     private SkillSearchAppService service;
 
     @BeforeEach
     void setUp() {
+        lenient().when(skillLabelAppService.listSkillLabelsBySkillIds(anyList())).thenReturn(Map.of());
         service = new SkillSearchAppService(
                 searchQueryService,
                 skillRepository,
                 namespaceRepository,
                 namespaceService,
                 new SkillLifecycleProjectionService(skillVersionRepository),
-                rbacService
+                rbacService,
+                skillLabelAppService
         );
     }
 

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/cli/CliSkillAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/cli/CliSkillAppServiceTest.java
@@ -58,7 +58,7 @@ class CliSkillAppServiceTest {
                         "global", Instant.now(), false,
                         new SkillLifecycleVersionResponse(1L, "1.2.0", "PUBLISHED"),
                         new SkillLifecycleVersionResponse(1L, "1.2.0", "PUBLISHED"),
-                        null, "PUBLISHED"
+                        null, "PUBLISHED", List.of()
                 )),
                 1L, 0, 20
         );

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
@@ -143,7 +143,19 @@ public class SkillPublishService {
             SkillVisibility visibility,
             java.util.Set<String> platformRoles,
             boolean confirmWarnings) {
-        return publishFromEntriesInternal(namespaceSlug, entries, publisherId, visibility, platformRoles, confirmWarnings, false, false);
+        return publishFromEntries(namespaceSlug, entries, publisherId, visibility, platformRoles, confirmWarnings, null);
+    }
+
+    @Transactional
+    public PublishResult publishFromEntries(
+            String namespaceSlug,
+            List<PackageEntry> entries,
+            String publisherId,
+            SkillVisibility visibility,
+            java.util.Set<String> platformRoles,
+            boolean confirmWarnings,
+            String summaryOverride) {
+        return publishFromEntriesInternal(namespaceSlug, entries, publisherId, visibility, platformRoles, confirmWarnings, false, false, summaryOverride);
     }
 
     /**
@@ -184,7 +196,8 @@ public class SkillPublishService {
                 Set.of(),
                 confirmWarnings,  // confirmWarnings: honour caller's choice for rerelease
                 false,  // forceAutoPublish=false: respect visibility rules
-                true
+                true,
+                null
         );
     }
 
@@ -196,7 +209,8 @@ public class SkillPublishService {
             Set<String> platformRoles,
             boolean confirmWarnings,
             boolean forceAutoPublish,
-            boolean bypassMembershipCheck) {
+            boolean bypassMembershipCheck,
+            String summaryOverride) {
 
         // 1. Find namespace by slug
         Namespace namespace = namespaceRepository.findBySlug(namespaceSlug)
@@ -411,7 +425,10 @@ public class SkillPublishService {
 
         // 12. Update skill metadata and move the published pointer for auto-publish flows
         skill.setDisplayName(metadata.name());
-        skill.setSummary(metadata.description());
+        String resolvedSummary = summaryOverride != null && !summaryOverride.isBlank()
+                ? summaryOverride.trim()
+                : metadata.description();
+        skill.setSummary(resolvedSummary);
         if (autoPublish || visibility == SkillVisibility.PRIVATE) {
             // Update latestVersionId for autoPublish or PRIVATE skill (UPLOADED status)
             skill.setLatestVersionId(version.getId());

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -167,6 +167,7 @@ export interface SkillSummary {
   ratingAvg?: number
   ratingCount: number
   namespace: string
+  labels?: LabelItem[]
   updatedAt: string
   canSubmitPromotion: boolean
   headlineVersion?: SkillLifecycleVersion
@@ -350,6 +351,7 @@ export interface PublishResult {
   status: string
   fileCount: number
   totalSize: number
+  labels?: string[]
 }
 
 export interface SkillDeleteResult {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -65,14 +65,14 @@ export function Layout() {
       <div
         className="absolute top-0 right-0 w-[600px] h-[500px] rounded-full opacity-90 pointer-events-none z-0"
         style={{
-          background: 'radial-gradient(ellipse at 70% 20%, rgba(184,94,255,0.25) 0%, rgba(106,109,255,0.15) 40%, transparent 70%)',
+          background: 'radial-gradient(ellipse at 70% 20%, rgba(22,163,74,0.20) 0%, rgba(21,128,61,0.12) 40%, transparent 70%)',
           filter: 'blur(60px)',
         }}
       />
 
       {/* Header */}
       <header className={getAppHeaderClassName(isHeaderElevated)} style={{ borderColor: 'hsl(var(--border))' }}>
-        <Link to="/" className="text-xl font-semibold tracking-tight text-brand-gradient">
+        <Link to="/" className="hover-lift text-xl font-semibold tracking-tight text-brand-gradient">
           SkillHub
         </Link>
 
@@ -87,8 +87,8 @@ export function Layout() {
                 to={item.to}
                 className={
                   active
-                    ? 'px-4 py-1.5 rounded-full bg-brand-gradient text-white shadow-sm'
-                    : 'hover:opacity-80 transition-opacity duration-150'
+                    ? 'hover-lift px-4 py-1.5 rounded-full bg-brand-gradient text-white shadow-sm'
+                    : 'hover-lift hover:opacity-80 transition-opacity duration-150'
                 }
               >
                 {item.label}
@@ -106,7 +106,7 @@ export function Layout() {
             <Link
               to="/login"
               search={{ returnTo: '' }}
-              className="hover:opacity-80 transition-opacity"
+              className="hover-lift hover:opacity-80 transition-opacity"
             >
               {t('nav.login')}
             </Link>
@@ -132,75 +132,11 @@ export function Layout() {
       </main>
 
       {/* Footer */}
-      <footer className="relative z-10 border-t rounded-t-2xl mt-auto" style={{ background: '#F1F5F9', borderColor: 'hsl(var(--border))' }}>
-        <div className="max-w-6xl mx-auto px-6 md:px-12 py-10">
-          <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-10 md:gap-12">
-            <div className="flex-shrink-0">
-              <div className="flex items-center gap-2 mb-3">
-                <div className="w-9 h-9 rounded-lg flex items-center justify-center text-white text-sm font-bold shadow-sm bg-brand-gradient">
-                  S
-                </div>
-                <span className="text-lg font-bold text-brand-gradient">SkillHub</span>
-              </div>
-              <p className="text-sm max-w-xs" style={{ color: 'hsl(var(--text-secondary))' }}>
-                {t('layout.footerDescription')}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-12 md:gap-16">
-              <div>
-                <h4 className="text-sm font-semibold mb-3" style={{ color: 'hsl(var(--foreground))' }}>
-                  {t('nav.home')}
-                </h4>
-                <ul className="space-y-2 text-sm">
-                  <li>
-                    <Link to="/" className="hover:opacity-80 transition-opacity" style={{ color: 'hsl(var(--text-secondary))' }}>
-                      {t('nav.home')}
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      to="/search"
-                      search={{ q: '', sort: 'relevance', page: 0, starredOnly: false }}
-                      className="hover:opacity-80 transition-opacity"
-                      style={{ color: 'hsl(var(--text-secondary))' }}
-                    >
-                      {t('nav.search')}
-                    </Link>
-                  </li>
-                  <li>
-                    <Link to="/dashboard" className="hover:opacity-80 transition-opacity" style={{ color: 'hsl(var(--text-secondary))' }}>
-                      {t('nav.dashboard')}
-                    </Link>
-                  </li>
-                </ul>
-              </div>
-              <div>
-                <h4 className="text-sm font-semibold mb-3" style={{ color: 'hsl(var(--foreground))' }}>
-                  {t('footer.resources')}
-                </h4>
-                <ul className="space-y-2 text-sm">
-                  <li>
-                    <a href="#" className="hover:opacity-80 transition-opacity" style={{ color: 'hsl(var(--text-secondary))' }}>
-                      {t('footer.docs')}
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" className="hover:opacity-80 transition-opacity" style={{ color: 'hsl(var(--text-secondary))' }}>
-                      {t('footer.api')}
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" className="hover:opacity-80 transition-opacity" style={{ color: 'hsl(var(--text-secondary))' }}>
-                      {t('footer.community')}
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
+      <footer className="relative z-10 border-t mt-auto" style={{ background: '#F1F5F9', borderColor: 'hsl(var(--border))' }}>
+        <div className="max-w-6xl mx-auto px-6 md:px-12 py-5">
           <div
-            className="mt-10 pt-6 border-t flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 text-xs"
-            style={{ borderColor: 'hsl(var(--border))', color: 'hsl(var(--muted-foreground))' }}
+            className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 text-xs"
+            style={{ color: 'hsl(var(--muted-foreground))' }}
           >
             <span>{t('footer.copyright')}</span>
             <div className="flex items-center gap-2">

--- a/web/src/features/skill/skill-card.tsx
+++ b/web/src/features/skill/skill-card.tsx
@@ -1,11 +1,14 @@
+import type { MouseEvent } from 'react'
 import type { SkillSummary } from '@/api/types'
 import { useAuth } from '@/features/auth/use-auth'
 import { useStar } from '@/features/social/use-star'
 import { Card } from '@/shared/ui/card'
-import { NamespaceBadge } from '@/shared/components/namespace-badge'
 import { getHeadlineVersion } from '@/shared/lib/skill-lifecycle'
 import { formatCompactCount } from '@/shared/lib/number-format'
-import { Bookmark } from 'lucide-react'
+import { useCopyToClipboard } from '@/shared/lib/clipboard'
+import { toast } from '@/shared/lib/toast'
+import { buildInstallCommand, getBaseUrl } from './install-command'
+import { Bookmark, Check, Copy } from 'lucide-react'
 
 interface SkillCardProps {
   skill: SkillSummary
@@ -13,26 +16,37 @@ interface SkillCardProps {
   highlightStarred?: boolean
 }
 
-/**
- * Reusable card for displaying one skill in lists such as landing, namespace, search, and stars.
- */
 export function SkillCard({ skill, onClick, highlightStarred = true }: SkillCardProps) {
   const { isAuthenticated } = useAuth()
   const { data: starStatus } = useStar(skill.id, highlightStarred && isAuthenticated)
   const showStarredHighlight = highlightStarred && isAuthenticated && starStatus?.starred
   const headlineVersion = getHeadlineVersion(skill)
   const isInteractive = typeof onClick === 'function'
+  const [copied, copy] = useCopyToClipboard()
+
+  const allLabels = skill.labels ?? []
+  const maxVisible = 2
+  const visibleLabels = allLabels.slice(0, maxVisible)
+  const extraCount = allLabels.length - maxVisible
+  const installCommand = buildInstallCommand(skill.namespace, skill.slug, getBaseUrl())
+
+  const handleCopy = async (event: MouseEvent) => {
+    event.stopPropagation()
+    try {
+      await copy(installCommand)
+      toast.success('Install command copied', installCommand)
+    } catch {
+      toast.error('Failed to copy install command')
+    }
+  }
 
   return (
     <Card
-      className="h-full p-5 cursor-pointer group relative overflow-hidden bg-white border shadow-sm transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2"
+      className="h-full p-5 cursor-pointer group relative overflow-hidden bg-white border shadow-sm card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2"
       style={{ borderColor: 'hsl(var(--border-card))' }}
       onClick={onClick}
       onKeyDown={(event) => {
-        if (!isInteractive) {
-          return
-        }
-
+        if (!isInteractive) return
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault()
           onClick()
@@ -42,15 +56,28 @@ export function SkillCard({ skill, onClick, highlightStarred = true }: SkillCard
       tabIndex={isInteractive ? 0 : undefined}
     >
       <div className="flex h-full flex-col">
-        <div className="flex items-start justify-between mb-3">
-          <div className="space-y-2">
-            <h3 className="font-semibold text-lg group-hover:text-primary transition-colors" style={{ color: 'hsl(var(--foreground))' }}>
-              {skill.displayName}
-            </h3>
-          </div>
-          <div className="flex items-center gap-2">
-            <NamespaceBadge type="TEAM" name={`@${skill.namespace}`} />
-          </div>
+        <div className="flex items-center justify-between gap-2 mb-3">
+          <h3 className="font-semibold text-lg group-hover:text-primary transition-colors flex-shrink min-w-0" style={{ color: 'hsl(var(--foreground))' }}>
+            {skill.displayName}
+          </h3>
+          {visibleLabels.length > 0 && (
+            <div className="flex items-center gap-1 flex-shrink-0">
+              {visibleLabels.map((label) => (
+                <span
+                  key={label.slug}
+                  className="px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap"
+                  style={{ background: '#c6ffdd', color: '#0b8a3c' }}
+                >
+                  {label.displayName}
+                </span>
+              ))}
+              {extraCount > 0 && (
+                <span className="text-xs font-medium whitespace-nowrap" style={{ color: 'hsl(var(--text-secondary))' }}>
+                  +{extraCount}
+                </span>
+              )}
+            </div>
+          )}
         </div>
 
         {skill.summary && (
@@ -59,32 +86,43 @@ export function SkillCard({ skill, onClick, highlightStarred = true }: SkillCard
           </p>
         )}
 
-        <div className="mt-auto flex items-center gap-4 text-xs text-muted-foreground">
-          {headlineVersion && (
-            <span className="px-2.5 py-1 rounded-full bg-secondary/60 font-mono">
-              v{headlineVersion.version}
-            </span>
-          )}
-          <span className="flex items-center gap-1">
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
-            </svg>
-            {formatCompactCount(skill.downloadCount)}
-          </span>
-          <span
-            className={`flex items-center gap-1 ${showStarredHighlight ? 'font-semibold text-primary' : ''}`}
-          >
-            <Bookmark className={`w-3.5 h-3.5 ${showStarredHighlight ? 'fill-current' : ''}`} />
-            {skill.starCount}
-          </span>
-          {skill.ratingAvg !== undefined && skill.ratingCount > 0 && (
+        <div className="mt-auto flex items-center text-xs text-muted-foreground">
+          <div className="flex items-center gap-4 flex-1 min-w-0">
+            {headlineVersion && (
+              <span className="px-2.5 py-1 rounded-full bg-secondary/60 font-mono">
+                v{headlineVersion.version}
+              </span>
+            )}
             <span className="flex items-center gap-1">
-              <svg className="w-3.5 h-3.5 text-primary" fill="currentColor" viewBox="0 0 20 20">
-                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
               </svg>
-              {skill.ratingAvg.toFixed(1)}
+              {formatCompactCount(skill.downloadCount)}
             </span>
-          )}
+            <span
+              className={`flex items-center gap-1 ${showStarredHighlight ? 'font-semibold text-primary' : ''}`}
+            >
+              <Bookmark className={`w-3.5 h-3.5 ${showStarredHighlight ? 'fill-current' : ''}`} />
+              {skill.starCount}
+            </span>
+            {skill.ratingAvg !== undefined && skill.ratingCount > 0 && (
+              <span className="flex items-center gap-1">
+                <svg className="w-3.5 h-3.5 text-primary" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+                {skill.ratingAvg.toFixed(1)}
+              </span>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            title={installCommand}
+            className="no-hover-lift flex-shrink-0 p-1.5 rounded-lg transition-colors hover:bg-secondary/80"
+            style={{ color: copied ? 'hsl(var(--primary))' : 'hsl(var(--muted-foreground))' }}
+          >
+            {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+          </button>
         </div>
       </div>
     </Card>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -4,50 +4,48 @@
 
 @layer base {
   :root {
-    /* SkillHub — 浅色主题 (indigo-violet brand) */
-    --background: 210 20% 98%;
-    --foreground: 220 26% 14%;
+    /* SkillHub light theme */
+    --background: 0 0% 97%;
+    --foreground: 160 20% 10%;
     --card: 0 0% 100%;
     --card-foreground: 220 26% 14%;
     --popover: 0 0% 100%;
     --popover-foreground: 220 26% 14%;
-    /* Indigo primary (#6A6DFF) */
-    --primary: 239 100% 71%;
+    --primary: 142 71% 37%;
     --primary-foreground: 0 0% 100%;
     /* Surface tones */
-    --secondary: 210 30% 96%;
+    --secondary: 138 30% 95%;
     --secondary-foreground: 220 26% 14%;
     --muted: 210 25% 95%;
     --muted-foreground: 215 14% 46%;
-    /* Violet accent (#B85EFF) */
-    --accent: 271 100% 68%;
+    --accent: 162 60% 40%;
     --accent-foreground: 0 0% 100%;
     --destructive: 0 72% 55%;
     --destructive-foreground: 0 0% 100%;
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 239 100% 71%;
+    --border: 140 20% 88%;
+    --input: 140 20% 88%;
+    --ring: 142 71% 37%;
     --radius: 0.75rem;
 
     /* Extended palette */
-    --surface-glass: 210 30% 97%;
-    --glow-primary: 239 100% 71%;
-    --glow-accent: 271 100% 68%;
+    --surface-glass: 138 30% 97%;
+    --glow-primary: 142 71% 37%;
+    --glow-accent: 162 60% 40%;
     --success: 160 60% 45%;
     --warning: 38 92% 58%;
 
     /* Brand */
-    --brand-start: #6A6DFF;
-    --brand-end: #B85EFF;
-    --brand-gradient: linear-gradient(135deg, #6A6DFF 0%, #B85EFF 100%);
+    --brand-start: #16a34a;
+    --brand-end: #15803d;
+    --brand-gradient: linear-gradient(135deg, #16a34a 0%, #15803d 100%);
 
     /* Text semantic */
-    --text-secondary: 215 19% 35%;
-    --text-muted: 215 14% 46%;
-    --text-placeholder: 213 12% 63%;
+    --text-secondary: 160 15% 35%;
+    --text-muted: 160 10% 46%;
+    --text-placeholder: 160 8% 63%;
 
     /* Border semantic */
-    --border-card: 220 26% 94%;
+    --border-card: 140 20% 94%;
   }
 
   .dark {
@@ -254,10 +252,70 @@
 }
 
 .dark .text-gradient-hero {
-  background: linear-gradient(135deg, #8183FF, #C77EFF);
+  background: linear-gradient(135deg, #4ade80, #16a34a);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+}
+
+.btn-press,
+.hover-lift {
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.btn-press:hover,
+.hover-lift:hover {
+  transform: scale(1.06);
+}
+
+.btn-press:active,
+.hover-lift:active {
+  transform: scale(0.97) translateY(1px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+button:not([disabled]):not(.no-hover-lift):not(.icon-btn),
+a[role="link"]:not(.no-hover-lift):not(.icon-btn),
+[role="button"]:not([disabled]):not(.no-hover-lift):not(.icon-btn) {
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+button:not([disabled]):not(.no-hover-lift):not(.icon-btn):hover,
+a[role="link"]:not(.no-hover-lift):not(.icon-btn):hover,
+[role="button"]:not([disabled]):not(.no-hover-lift):not(.icon-btn):hover {
+  transform: scale(1.04);
+}
+
+button:not([disabled]):not(.no-hover-lift):not(.icon-btn):active,
+a[role="link"]:not(.no-hover-lift):not(.icon-btn):active,
+[role="button"]:not([disabled]):not(.no-hover-lift):not(.icon-btn):active {
+  transform: scale(0.97);
+}
+
+button.icon-btn:not([disabled]):hover,
+[role="button"].icon-btn:not([disabled]):hover {
+  border-color: #158940;
+  box-shadow: 0 0 0 2px rgba(21, 137, 64, 0.18);
+  transform: none;
+}
+
+.label-tag {
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.label-tag:hover {
+  border-color: #158940;
+  box-shadow: 0 0 0 3px rgba(21, 137, 64, 0.2);
+  background: hsl(var(--primary) / 0.06);
+}
+
+.search-shell {
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.search-shell:focus-within {
+  border-color: #158940;
+  box-shadow: 0 0 0 4px rgba(21, 137, 64, 0.15), 0 8px 24px rgba(15, 23, 42, 0.08);
 }
 
 /* ─── Card hover lift ─── */
@@ -268,10 +326,10 @@
 }
 
 .card-hover:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 20px 40px -12px hsl(var(--primary) / 0.1),
-              0 8px 16px -8px hsl(0 0% 0% / 0.2);
-  border-color: hsl(var(--primary) / 0.3);
+  transform: translateY(-6px) scale(1.02);
+  box-shadow: 0 24px 48px -12px rgba(22, 163, 74, 0.15),
+              0 12px 24px -8px rgba(0, 0, 0, 0.12);
+  border-color: hsl(var(--primary) / 0.4);
 }
 
 /* ─── Scrollbar ─── */
@@ -323,9 +381,9 @@
   padding: 4px 10px;
   font-size: 12px;
   font-weight: 500;
-  color: #0369a1;
-  background: #e0f2fe;
-  border: 1px solid #7dd3fc;
+  color: #166534;
+  background: #dcfce7;
+  border: 1px solid #86efac;
   border-radius: 9999px;
 }
 
@@ -459,7 +517,7 @@
 
 .upload-zone:hover {
   border-color: var(--brand-start);
-  background: rgba(106, 109, 255, 0.04);
+  background: rgba(22, 163, 74, 0.04);
 }
 
 .upload-zone .upload-zone-icon {
@@ -473,7 +531,7 @@
 
 /* ─── Feature icon shadow ─── */
 .feature-icon {
-  box-shadow: 0 14px 30px rgba(106, 109, 255, 0.45);
+  box-shadow: 0 14px 30px rgba(22, 163, 74, 0.45);
 }
 
 /* ─── Hero input placeholder ─── */

--- a/web/src/pages/landing.tsx
+++ b/web/src/pages/landing.tsx
@@ -1,44 +1,40 @@
+import { useMemo, useState } from 'react'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { normalizeSearchQuery } from '@/shared/lib/search-query'
-import { PackageOpen, Terminal, Shield, Users, GitBranch, Search as SearchIcon, Settings } from 'lucide-react'
+import { Search as SearchIcon } from 'lucide-react'
 import { LandingQuickStartSection } from '@/shared/components/landing-quick-start'
 import { SkillCard } from '@/features/skill/skill-card'
 import { SkeletonList } from '@/shared/components/skeleton-loader'
 import { useSearchSkills } from '@/shared/hooks/use-skill-queries'
-import { useInView } from '@/shared/hooks/use-in-view'
-import { Button } from '@/shared/ui/button'
+import { useVisibleLabels } from '@/shared/hooks/use-label-queries'
 
-/**
- * Marketing-style landing page for unauthenticated and first-time visitors.
- *
- * The page mixes static positioning content with live skill queries so popular and latest skills
- * stay aligned with the current registry state.
- */
+const PRIMARY_FILTERS = [
+  { key: 'all', sort: 'relevance' as const, titleKey: 'landing.category.all', fallback: 'All' },
+  { key: 'downloads', sort: 'downloads' as const, titleKey: 'landing.category.downloads', fallback: 'Popular' },
+  { key: 'newest', sort: 'newest' as const, titleKey: 'landing.category.newest', fallback: 'Newest' },
+  { key: 'stars', sort: 'relevance' as const, titleKey: 'landing.category.stars', fallback: 'Featured' },
+]
+
 export function LandingPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const [primaryFilter, setPrimaryFilter] = useState('downloads')
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([])
 
-  const { data: popularSkills, isLoading: isLoadingPopular } = useSearchSkills({
-    sort: 'downloads',
-    size: 6,
-  })
+  const activePrimaryFilter = PRIMARY_FILTERS.find((item) => item.key === primaryFilter) ?? PRIMARY_FILTERS[0]
+  const selectedLabel = selectedLabels[0]
 
-  const { data: latestSkills, isLoading: isLoadingLatest } = useSearchSkills({
-    sort: 'newest',
-    size: 6,
+  const { data: visibleLabels } = useVisibleLabels()
+  const { data: skills, isLoading: isLoadingSkills } = useSearchSkills({
+    sort: activePrimaryFilter.sort,
+    size: 9,
+    label: selectedLabel || undefined,
   })
 
   const handleSkillClick = (namespace: string, slug: string) => {
     navigate({ to: `/space/${namespace}/${encodeURIComponent(slug)}` })
   }
-
-  const heroView = useInView()
-  const statsView = useInView()
-  const featuresView = useInView()
-  const quickStartView = useInView()
-  const popularView = useInView()
-  const latestView = useInView()
 
   const handleSearch = (query: string) => {
     const normalized = normalizeSearchQuery(query)
@@ -48,229 +44,140 @@ export function LandingPage() {
     })
   }
 
-  const features = [
-    {
-      icon: <Shield className="w-6 h-6 text-white" strokeWidth={2} />,
-      title: t('landing.features.secure.title'),
-      description: t('landing.features.secure.description'),
-    },
-    {
-      icon: <Users className="w-6 h-6 text-white" strokeWidth={2} />,
-      title: t('landing.features.community.title'),
-      description: t('landing.features.community.description'),
-    },
-    {
-      icon: <PackageOpen className="w-6 h-6 text-white" strokeWidth={2} />,
-      title: t('landing.features.integration.title'),
-      description: t('landing.features.integration.description'),
-    },
-    {
-      icon: <GitBranch className="w-6 h-6 text-white" strokeWidth={2} />,
-      title: t('landing.features.versionControl.title', { defaultValue: 'Version control' }),
-      description: t('landing.features.versionControl.description', { defaultValue: 'Managed release flows keep skill packages traceable and easier to review.' }),
-    },
-    {
-      icon: <Terminal className="w-6 h-6 text-white" strokeWidth={2} />,
-      title: t('landing.features.cli.title', { defaultValue: 'CLI tooling' }),
-      description: t('landing.features.cli.description', { defaultValue: 'Command-line workflows support publishing, installing, and operating skills quickly.' }),
-    },
-    {
-      icon: <Settings className="w-6 h-6 text-white" strokeWidth={2} />,
-      title: t('landing.features.governance.title', { defaultValue: 'Governance' }),
-      description: t('landing.features.governance.description', { defaultValue: 'Built-in review and permission flows help teams enforce skill quality.' }),
-    },
-  ]
-
-  const stats = [
-    { value: '1000+', label: t('landing.stats.skills', { defaultValue: 'Registry items' }) },
-    { value: '50K+', label: t('landing.stats.downloads', { defaultValue: 'Downloads' }) },
-    { value: '200+', label: t('landing.stats.teams', { defaultValue: 'Teams' }) },
-  ]
+  const quickLabels = useMemo(() => (visibleLabels ?? []).slice(0, 9), [visibleLabels])
 
   return (
-    <>
-      {/* Hero Section */}
-      <main ref={heroView.ref} className={`relative z-10 flex flex-col items-center pt-16 pb-20 px-4 md:pt-24 scroll-fade-up${heroView.inView ? ' in-view' : ''}`}>
-        <h1 className="text-5xl md:text-7xl font-bold tracking-tight text-brand-gradient mb-4">
-          SkillHub
-        </h1>
-        <h2
-          className="text-xl md:text-2xl font-semibold tracking-tight text-center mb-3"
-          style={{ color: 'hsl(var(--foreground))' }}
-        >
-          {t('landing.hero.title')}
-        </h2>
-        <p
-          className="text-base md:text-lg text-center max-w-2xl mb-10 leading-relaxed"
-          style={{ color: 'hsl(var(--text-secondary))' }}
-        >
-          {t('landing.hero.subtitle')}
-        </p>
-
-        {/* Search box */}
-        <div className="w-full max-w-2xl mb-8">
-          <div
-            className="flex items-center bg-white rounded-xl border shadow-sm px-5 py-3.5"
-            style={{ borderColor: 'hsl(var(--border))' }}
-          >
-            <SearchIcon className="w-5 h-5 flex-shrink-0 mr-3" style={{ color: 'hsl(var(--text-placeholder))' }} strokeWidth={1.5} />
-            <input
-              type="text"
-              placeholder={t('landing.hero.searchPlaceholder')}
-              className="hero-input flex-1 bg-transparent outline-none text-base"
+    <main className="relative z-10 px-4 pt-12 pb-20 md:px-8 lg:px-[60px] md:pt-20">
+      <section className="max-w-7xl mx-auto pb-20">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-20 items-stretch">
+          <div className="flex flex-col">
+            <h1 className="text-6xl md:text-7xl font-bold tracking-tight text-brand-gradient mb-4">
+              SkillHub
+            </h1>
+            <h2
+              className="text-xl md:text-2xl font-semibold tracking-tight mb-3"
               style={{ color: 'hsl(var(--foreground))' }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  handleSearch((e.target as HTMLInputElement).value)
-                }
-              }}
-            />
+            >
+              {t('landing.hero.title')}
+            </h2>
+            <p
+              className="text-base md:text-lg max-w-2xl mb-8 leading-relaxed"
+              style={{ color: 'hsl(var(--text-secondary))' }}
+            >
+              {t('landing.hero.subtitle')}
+            </p>
+
+            <div className="w-full max-w-xl mb-8">
+              <div
+                className="search-shell flex items-center bg-white rounded-xl border-2 shadow-sm px-5 py-3.5"
+                style={{ borderColor: '#158940', boxShadow: '0 8px 24px rgba(15,23,42,0.06)' }}
+              >
+                <SearchIcon className="w-5 h-5 flex-shrink-0 mr-3" style={{ color: 'hsl(var(--text-placeholder))' }} strokeWidth={1.5} />
+                <input
+                  type="text"
+                  placeholder={t('landing.hero.searchPlaceholder')}
+                  className="hero-input flex-1 bg-transparent outline-none text-base"
+                  style={{ color: 'hsl(var(--foreground))' }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleSearch((e.target as HTMLInputElement).value)
+                    }
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-4 mt-auto">
+              <Link
+                to="/search"
+                search={{ q: '', sort: 'relevance', page: 0, starredOnly: false }}
+                className="hover-lift px-8 py-3.5 rounded-xl text-base font-medium text-white bg-brand-gradient shadow-sm"
+              >
+                {t('landing.hero.exploreSkills')}
+              </Link>
+              <Link
+                to="/dashboard/publish"
+                className="hover-lift px-8 py-3.5 rounded-xl text-base font-medium border-2 bg-white"
+                style={{ borderColor: '#158940', color: 'hsl(var(--primary))' }}
+              >
+                {t('landing.hero.publishSkill')}
+              </Link>
+            </div>
+          </div>
+
+          <div className="flex justify-center lg:justify-end">
+            <LandingQuickStartSection compact />
           </div>
         </div>
+      </section>
 
-        {/* CTA buttons */}
-        <div className="flex flex-wrap justify-center gap-4 mb-14">
+      <section className="max-w-7xl mx-auto space-y-6">
+        <div className="flex items-center justify-between gap-2 flex-nowrap min-w-0">
+          <div className="flex gap-1.5 flex-nowrap min-w-0">
+            {PRIMARY_FILTERS.map((filter) => {
+              const active = filter.key === primaryFilter
+              return (
+                <button
+                  key={filter.key}
+                  type="button"
+                  onClick={() => setPrimaryFilter(filter.key)}
+                  className="hover-lift px-3 py-1.5 rounded-full text-xs sm:text-sm sm:px-4 sm:py-2 font-medium border whitespace-nowrap"
+                  style={{
+                    background: active ? 'var(--brand-gradient)' : '#ffffff',
+                    color: active ? '#ffffff' : 'hsl(var(--foreground))',
+                    borderColor: active ? 'transparent' : 'hsl(var(--border))',
+                  }}
+                >
+                  {t(filter.titleKey, { defaultValue: filter.fallback })}
+                </button>
+              )
+            })}
+          </div>
           <Link
             to="/search"
-            search={{ q: '', sort: 'relevance', page: 0, starredOnly: false }}
-            className="px-8 py-3.5 rounded-xl text-base font-medium text-white bg-brand-gradient shadow-sm hover:opacity-95 transition-opacity"
+            search={{ q: '', sort: activePrimaryFilter.sort, page: 0, starredOnly: false }}
+            className="flex-shrink-0 whitespace-nowrap text-sm hover:underline"
+            style={{ color: 'hsl(var(--primary))' }}
           >
-            {t('landing.hero.exploreSkills')}
-          </Link>
-          <Link
-            to="/dashboard/publish"
-            className="px-8 py-3.5 rounded-xl text-base font-medium border transition-colors"
-            style={{
-              background: 'hsl(var(--secondary))',
-              borderColor: 'hsl(var(--muted-foreground))',
-              color: 'hsl(var(--muted-foreground))',
-            }}
-          >
-            {t('landing.hero.publishSkill', { defaultValue: '开始构建' })}
+            {t('home.viewAll')}
           </Link>
         </div>
 
-        {/* Stats */}
-        <div ref={statsView.ref} className={`flex flex-row justify-center gap-16 md:gap-24 scroll-fade-up${statsView.inView ? ' in-view' : ''}`} style={{ transitionDelay: '0.15s' }}>
-          {stats.map((stat) => (
-            <div key={stat.label} className="flex flex-col items-center">
-              <span className="text-3xl md:text-4xl font-bold tracking-tight text-brand-gradient mb-1">
-                {stat.value}
-              </span>
-              <span className="text-sm font-normal" style={{ color: 'hsl(var(--foreground))' }}>
-                {stat.label}
-              </span>
-            </div>
-          ))}
-        </div>
-      </main>
-
-      {/* Features Section */}
-      <section ref={featuresView.ref} className={`relative z-10 w-full py-20 md:py-24 px-6 scroll-fade-up${featuresView.inView ? ' in-view' : ''}`} style={{ background: 'var(--bg-page, hsl(var(--background)))' }}>
-        <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-14">
-            <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-3" style={{ color: 'hsl(var(--foreground))' }}>
-              {t('landing.whySkillHub.title', { defaultValue: '为什么选择 SkillHub' })}
-            </h2>
-            <p className="text-base md:text-lg max-w-2xl mx-auto leading-relaxed" style={{ color: 'hsl(var(--text-secondary))' }}>
-              {t('landing.whySkillHub.subtitle', { defaultValue: '专为企业打造的私有化 Agent 技能管理平台' })}
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {features.map((feature) => (
-              <div
-                key={feature.title}
-                className="bg-white rounded-xl p-8 border shadow-sm transition-shadow hover:shadow-md"
-                style={{ borderColor: 'hsl(var(--border-card))' }}
+        <div className="flex flex-wrap gap-2">
+          {quickLabels.map((label) => {
+            const active = selectedLabels.includes(label.slug)
+            return (
+              <button
+                key={label.slug}
+                type="button"
+                onClick={() => setSelectedLabels(active ? [] : [label.slug])}
+                className="label-tag px-3 py-1.5 rounded-full text-xs font-medium border"
+                style={{
+                  background: active ? 'hsl(var(--primary))' : '#ffffff',
+                  color: active ? '#ffffff' : 'hsl(var(--text-secondary))',
+                  borderColor: active ? 'hsl(var(--primary))' : 'hsl(var(--border))',
+                }}
               >
-                <div className="feature-icon w-12 h-12 rounded-2xl flex items-center justify-center mb-6 mx-auto bg-brand-gradient">
-                  {feature.icon}
-                </div>
-                <h3 className="text-lg font-semibold text-center mb-3" style={{ color: 'hsl(var(--foreground))' }}>
-                  {feature.title}
-                </h3>
-                <p className="text-sm text-center leading-relaxed" style={{ color: 'hsl(var(--text-secondary))' }}>
-                  {feature.description}
-                </p>
-              </div>
+                {label.displayName}
+              </button>
+            )
+          })}
+        </div>
+
+        {isLoadingSkills ? (
+          <SkeletonList count={9} />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            {skills?.items.map((skill) => (
+              <SkillCard
+                key={skill.id}
+                skill={skill}
+                onClick={() => handleSkillClick(skill.namespace, skill.slug)}
+              />
             ))}
           </div>
-        </div>
+        )}
       </section>
-
-      {/* Quick Start */}
-      <div ref={quickStartView.ref} className={`scroll-fade-up${quickStartView.inView ? ' in-view' : ''}`}>
-        <LandingQuickStartSection />
-      </div>
-
-      {/* Popular Downloads Section */}
-      <section ref={popularView.ref} className={`relative z-10 w-full py-20 md:py-24 px-6 scroll-fade-up${popularView.inView ? ' in-view' : ''}`} style={{ background: 'var(--bg-page, hsl(var(--background)))' }}>
-        <div className="max-w-6xl mx-auto space-y-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-3xl font-bold tracking-tight mb-2" style={{ color: 'hsl(var(--foreground))' }}>
-                {t('home.popularTitle')}
-              </h2>
-              <p style={{ color: 'hsl(var(--text-secondary))' }}>{t('home.popularDescription')}</p>
-            </div>
-            <Button
-              variant="ghost"
-              onClick={() => navigate({ to: '/search', search: { q: '', sort: 'downloads', page: 0, starredOnly: false } })}
-            >
-              {t('home.viewAll')}
-            </Button>
-          </div>
-          {isLoadingPopular ? (
-            <SkeletonList count={6} />
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-              {popularSkills?.items.map((skill, idx) => (
-                <div key={skill.id} className={`animate-fade-up delay-${Math.min(idx + 1, 6)}`}>
-                  <SkillCard
-                    skill={skill}
-                    onClick={() => handleSkillClick(skill.namespace, skill.slug)}
-                  />
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Latest Releases Section */}
-      <section ref={latestView.ref} className={`relative z-10 w-full py-20 md:py-24 px-6 scroll-fade-up${latestView.inView ? ' in-view' : ''}`} style={{ background: 'var(--bg-page, hsl(var(--background)))' }}>
-        <div className="max-w-6xl mx-auto space-y-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-3xl font-bold tracking-tight mb-2" style={{ color: 'hsl(var(--foreground))' }}>
-                {t('home.latestTitle')}
-              </h2>
-              <p style={{ color: 'hsl(var(--text-secondary))' }}>{t('home.latestDescription')}</p>
-            </div>
-            <Button
-              variant="ghost"
-              onClick={() => navigate({ to: '/search', search: { q: '', sort: 'newest', page: 0, starredOnly: false } })}
-            >
-              {t('home.viewAll')}
-            </Button>
-          </div>
-          {isLoadingLatest ? (
-            <SkeletonList count={6} />
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-              {latestSkills?.items.map((skill, idx) => (
-                <div key={skill.id} className={`animate-fade-up delay-${Math.min(idx + 1, 6)}`}>
-                  <SkillCard
-                    skill={skill}
-                    onClick={() => handleSkillClick(skill.namespace, skill.slug)}
-                  />
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </section>
-    </>
+    </main>
   )
 }

--- a/web/src/shared/components/landing-quick-start.tsx
+++ b/web/src/shared/components/landing-quick-start.tsx
@@ -51,7 +51,7 @@ function CompactCopyButton({ text }: { text: string }) {
       onClick={handleCopy}
       aria-label={label}
       title={label}
-      className="absolute right-2.5 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-xl border bg-white transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer"
+      className="no-hover-lift absolute right-2.5 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-xl border bg-white transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 cursor-pointer"
       style={{ borderColor: 'hsl(var(--border))', color: 'hsl(var(--foreground))' }}
     >
       {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
@@ -59,7 +59,7 @@ function CompactCopyButton({ text }: { text: string }) {
   )
 }
 
-export function LandingQuickStartSection() {
+export function LandingQuickStartSection({ compact = false }: { compact?: boolean }) {
   const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState<LandingQuickStartTabId>('agent')
   const baseUrl = useMemo(() => getAppBaseUrl(), [])
@@ -86,6 +86,72 @@ export function LandingQuickStartSection() {
   ]
 
   const currentTab = tabs.find((tab) => tab.id === activeTab) ?? tabs[0]
+
+  if (compact) {
+    return (
+      <div
+        className="flex h-full w-full flex-col rounded-2xl border-2 bg-white p-6 pt-8 shadow-lg"
+        style={{ borderColor: '#158940' }}
+      >
+        <div className="mb-5">
+          <h3 className="text-2xl font-bold" style={{ color: 'hsl(var(--foreground))' }}>
+            {t('landing.quickStart.title')}
+          </h3>
+          <p className="text-sm mt-2" style={{ color: 'hsl(var(--text-secondary))' }}>
+            {t('landing.quickStart.description', { defaultValue: t('landing.quickStart.subtitle') })}
+          </p>
+        </div>
+
+        <div
+          className="mb-5 grid grid-cols-2 gap-2 rounded-xl p-1.5"
+          style={{ background: 'linear-gradient(180deg, rgba(248,250,252,0.98) 0%, rgba(241,245,249,0.92) 100%)' }}
+        >
+          {tabs.map((tab) => {
+            const isActive = tab.id === currentTab.id
+            const Icon = tab.id === 'agent' ? Bot : UserRound
+
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                aria-pressed={isActive}
+                className="flex min-h-10 items-center justify-center gap-1.5 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer"
+                style={{
+                  background: isActive ? 'rgba(255,255,255,0.96)' : 'transparent',
+                  color: isActive ? 'hsl(var(--foreground))' : 'hsl(var(--muted-foreground))',
+                  boxShadow: isActive ? '0 4px 12px rgba(15, 23, 42, 0.08)' : 'none',
+                }}
+              >
+                <Icon className="h-3.5 w-3.5" strokeWidth={1.75} />
+                <span>{tab.label}</span>
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="flex flex-1 flex-col pb-2">
+          <div className="flex flex-1 items-center justify-center py-2">
+            <p className="text-center text-sm font-medium leading-relaxed" style={{ color: 'hsl(var(--foreground))' }}>
+              {currentTab.description}
+            </p>
+          </div>
+          <div
+            className="relative rounded-xl border bg-slate-50/90 px-4 py-3.5 pr-12 shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]"
+            style={{ borderColor: 'hsl(var(--border))' }}
+          >
+            <code
+              className="line-clamp-2 break-all font-mono text-sm"
+              style={{ color: currentTab.id === 'agent' ? '#16A34A' : '#0F172A' }}
+            >
+              {currentTab.command}
+            </code>
+            <CompactCopyButton text={currentTab.command} />
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <section className="relative z-10 w-full px-6 py-14 md:py-16" style={{ background: 'var(--bg-page, hsl(var(--background)))' }}>
@@ -143,9 +209,9 @@ export function LandingQuickStartSection() {
               className="relative rounded-2xl border bg-slate-50/90 px-4 py-3 pr-14 shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]"
               style={{ borderColor: 'hsl(var(--border))' }}
             >
-              <div className="overflow-x-auto whitespace-nowrap">
+              <div>
                 <code
-                  className="font-mono text-sm md:text-base"
+                  className="font-mono text-sm md:text-base break-all"
                   style={{ color: currentTab.id === 'agent' ? '#16A34A' : '#0F172A' }}
                 >
                   {currentTab.command}

--- a/web/src/shared/hooks/use-skill-queries.ts
+++ b/web/src/shared/hooks/use-skill-queries.ts
@@ -44,12 +44,27 @@ async function getSkillDocumentation(namespace: string, slug: string, version: s
   return fetchText(`${WEB_API_PREFIX}/skills/${cleanNamespace}/${encodeURIComponent(slug)}/versions/${encodeURIComponent(version)}/file?path=${encodeURIComponent(path)}`)
 }
 
-async function publishSkill(params: { namespace: string; file: File; visibility: string; confirmWarnings?: boolean }): Promise<PublishResult> {
+async function publishSkill(params: {
+  namespace: string
+  file: File
+  visibility: string
+  confirmWarnings?: boolean
+  labels?: string[]
+  summary?: string
+  description?: string
+}): Promise<PublishResult> {
   const cleanNamespace = params.namespace.startsWith('@') ? params.namespace.slice(1) : params.namespace
   const formData = new FormData()
   formData.append('file', params.file)
   formData.append('visibility', params.visibility)
   formData.append('confirmWarnings', String(params.confirmWarnings === true))
+  params.labels?.forEach((label) => formData.append('labels', label))
+  if (params.summary) {
+    formData.append('summary', params.summary)
+  }
+  if (params.description) {
+    formData.append('description', params.description)
+  }
 
   return fetchJson<PublishResult>(`${WEB_API_PREFIX}/skills/${cleanNamespace}/publish`, {
     method: 'POST',


### PR DESCRIPTION
Expose labels in skill summaries, support label attachment during publish, and refresh the public discovery UI.

Tested: pnpm exec tsc --noEmit; pnpm run build; git diff --check; scanned staged diff and tracked config files for secrets.

## Summary

- What changed?
- Why is this needed?

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
# paste commands here
```

## Risk

- User-facing impact:
- Deployment or migration impact:
- Rollback approach:

## Notes

- Related issue:
- Follow-up work:
- Docs or operator runbooks updated when behavior changed:

Tested: pnpm exec tsc --noEmit; pnpm run build; git diff --check; scanned staged diff and tracked config files for secrets.

  ## Summary

  - Refresh the public discovery UI and skill cards.
  - Expose skill labels in skill summary responses so list pages can render labels directly.
  - Support optional `labels`, `summary`, and `description` parameters during skill publish.

  ## Validation

  - [ ] Backend tests passed
  - [x] Frontend typecheck/build passed
  - [ ] OpenAPI SDK regenerated or checked when API contracts changed
  - [ ] Smoke test run when relevant

  ```bash
  pnpm exec tsc --noEmit
  pnpm run build
  git diff --check

  Additional checks:

  - Scanned staged diff and tracked config files for secrets.
  - No config files were changed in this PR.
  - No real secrets were found in the staged diff.

  ## Risk

  - User-facing impact: Updates the public discovery page and skill card presentation.
  - Deployment or migration impact: No database migration or deployment configuration change.
  - Rollback approach: Revert this PR to restore the previous discovery UI and publish response shape.

  ## Notes

  - Related issue: N/A
  - Follow-up work: Regenerate or verify OpenAPI artifacts if required by the maintainers.
  - Docs or operator runbooks updated when behavior changed: N/A
