### PR TITLE
fix(promotion): copy bundleReady and downloadReady when promoting skill to global

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/PromotionService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/PromotionService.java
@@ -234,6 +234,8 @@ public class PromotionService {
         newVersion.setManifestJson(sourceVersion.getManifestJson());
         newVersion.setFileCount(sourceVersion.getFileCount());
         newVersion.setTotalSize(sourceVersion.getTotalSize());
+        newVersion.setBundleReady(sourceVersion.isBundleReady());
+        newVersion.setDownloadReady(sourceVersion.isDownloadReady());
         newVersion = skillVersionRepository.save(newVersion);
 
         // Update skill's latest version

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/PromotionServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/review/PromotionServiceTest.java
@@ -91,6 +91,8 @@ class PromotionServiceTest {
         sv.setManifestJson("{\"version\":\"1.0.0\"}");
         sv.setFileCount(3);
         sv.setTotalSize(1024L);
+        sv.setBundleReady(true);
+        sv.setDownloadReady(true);
         return sv;
     }
 
@@ -466,6 +468,8 @@ class PromotionServiceTest {
             assertEquals(3, newVersion.getFileCount());
             assertEquals(1024L, newVersion.getTotalSize());
             assertEquals(Instant.now(CLOCK), newVersion.getPublishedAt());
+            assertTrue(newVersion.isBundleReady());
+            assertTrue(newVersion.isDownloadReady());
 
             // Verify files copied
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

修复了小组级技能提升到全局后下载按钮变灰、无法下载的问题。

## Root Cause

在 `PromotionService.approvePromotion` 创建全局技能版本时，复制了源版本的大部分元数据字段（changelog、metadata、manifest、fileCount、totalSize 等），但遗漏了 `bundleReady` 和 `downloadReady` 两个字段，导致它们使用默认值 `false`。

前端下载按钮的禁用逻辑（`web/src/pages/skill-detail.tsx:181`）：
\`\`\`ts
isVersionDownloadable = selectedVersionEntry?.status === 'PUBLISHED' && (selectedVersionEntry?.downloadAvailable ?? false)
\`\`\`

后端 `SkillQueryService.isDownloadAvailable`（`SkillQueryService.java:489`）最终依赖 `version.isDownloadReady()`，因此 promotion 后的版本始终判定为不可下载。

## Changes

- `PromotionService.java`: 在创建新版本时增加复制 `bundleReady` 与 `downloadReady` 字段
- `PromotionServiceTest.java`: 增加对应字段的断言，防止回归

## Testing

- 单元测试更新：`createPublishedVersion` 设置两字段为 true，`shouldApprovePromotionSuccessfully` 断言新版本继承了它们