### PR TITLE
fix(cli): push version bump to temp branch instead of main directly

### DIFF
--- a/scripts/publish-cli.sh
+++ b/scripts/publish-cli.sh
@@ -91,9 +91,11 @@ if [[ -n "$UNPUSHED_COMMITS" ]] || [[ -n "$UNPUSHED_RELEASE_TAGS" ]]; then
   echo "  1. Retry push (if the previous failure was temporary, e.g., network issue):" >&2
   if [[ -n "$UNPUSHED_RELEASE_TAGS" ]]; then
     FIRST_TAG="$(echo "$UNPUSHED_RELEASE_TAGS" | head -n1)"
-    echo "     git push origin $CURRENT_BRANCH $FIRST_TAG" >&2
+    BUMP_VER="${FIRST_TAG#cli-v}"
+    echo "     git push origin HEAD:refs/heads/cli-bump-${BUMP_VER}" >&2
+    echo "     git push origin $FIRST_TAG" >&2
   else
-    echo "     git push origin $CURRENT_BRANCH" >&2
+    echo "     git push origin HEAD:refs/heads/cli-bump-<version>" >&2
   fi
   echo "" >&2
   echo "  2. Rollback and retry release (if you want to start fresh):" >&2
@@ -163,8 +165,13 @@ git -C "$REPO_ROOT" commit -m "chore(cli): bump version to $NEW_VERSION"
 log_stage "creating tag $TAG"
 git -C "$REPO_ROOT" tag "$TAG"
 
-log_stage "pushing commit and tag to origin (atomic)"
-git -C "$REPO_ROOT" push --atomic origin "$CURRENT_BRANCH" "$TAG"
+BUMP_BRANCH="cli-bump-${NEW_VERSION}"
+log_stage "pushing version bump to branch $BUMP_BRANCH (main requires PR)"
+git -C "$REPO_ROOT" push origin "HEAD:refs/heads/$BUMP_BRANCH"
+
+log_stage "pushing tag $TAG to origin"
+git -C "$REPO_ROOT" push origin "$TAG"
 
 log_stage "release triggered — CI workflow will build and publish"
 log_stage "watch progress at: https://github.com/iflytek/skillhub/actions/workflows/release-cli.yml"
+log_stage "open a PR to merge the version bump: https://github.com/iflytek/skillhub/compare/$BUMP_BRANCH"


### PR DESCRIPTION
## 背景

执行 `make publish-cli` 时被 GitHub 分支保护规则拦截：

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote:  - Changes must be made through a pull request.
 ! [remote rejected]   main -> main (push declined due to repository rule violations)
 ! [remote rejected]   cli-v0.1.6 -> cli-v0.1.6 (atomic transaction failed)
```

`scripts/publish-cli.sh` 用 `git push --atomic origin main <tag>` 同时推送 main 和 tag。由于 main 启用了 "Require pull request before merging" 规则，main 推送被拒，原子事务一并失败，导致 tag 也推不上去。

## 修改

将 version bump commit 推送到临时分支 `cli-bump-<version>`，tag 单独推送。
- Tag 一旦上去，CI 即可触发构建发布
- bump commit 通过 PR 合入 main，符合分支保护规则
- recovery 提示同步更新

## 验证

逻辑变更，无新增测试。脚本流程：
1. bump 版本 → commit + tag（本地）
2. push HEAD 到 `cli-bump-<version>` 分支
3. push tag
4. 提示用户开 PR 合 bump commit