### PR TITLE
feat(auth): allow anonymous download for global skills

### DIFF
--- a/web/src/pages/skill-detail.tsx
+++ b/web/src/pages/skill-detail.tsx
@@ -302,7 +302,7 @@ export function SkillDetailPage() {
   }
 
   const handleDownload = async () => {
-    if (!user) {
+    if (namespace!=='global' && !user) {
       requireLogin()
       return
     }


### PR DESCRIPTION
Update handleDownload to bypass the authentication requirement when the
namespace is 'global'. This enables unauthenticated users to download
public global skills, consistent with the publicly accessible route.