### PR TITLE
feat(publish): add --dry-run validation endpoint and CLI option

### DIFF
--- a/cli/src/clients/skillhub-client.ts
+++ b/cli/src/clients/skillhub-client.ts
@@ -151,8 +151,11 @@ export class SkillHubClient {
   }
 
   private async handleJsonResponse<T>(response: Response): Promise<T> {
-    if (response.status === 401 || response.status === 403) {
+    if (response.status === 401) {
       throw new CliError('authentication failed', EXIT.auth, { registry: this.registry, next: 'run `skillhub login`' })
+    }
+    if (response.status === 403) {
+      throw new CliError('access denied — token may lack required scope', EXIT.auth, { registry: this.registry, next: 'regenerate token with required scopes or run `skillhub login`' })
     }
     if (response.status === 404) {
       throw new CliError('resource not found', EXIT.generic, { registry: this.registry })

--- a/cli/src/clients/skillhub-client.ts
+++ b/cli/src/clients/skillhub-client.ts
@@ -121,9 +121,10 @@ export class SkillHubClient {
     return this.handleJsonResponse<PublishResponse>(response)
   }
 
-  async validatePublish(namespace: string, file: Blob, fileName = 'skill.zip'): Promise<DryRunResponse> {
+  async validatePublish(namespace: string, file: Blob, visibility: string, fileName = 'skill.zip'): Promise<DryRunResponse> {
     const formData = new FormData()
     formData.append('file', file, fileName)
+    formData.append('visibility', visibility)
     let response: Response
     try {
       response = await this.fetchImpl(`${this.registry}/api/cli/v1/skills/${namespace}/publish/validate`, {

--- a/cli/src/clients/skillhub-client.ts
+++ b/cli/src/clients/skillhub-client.ts
@@ -44,6 +44,14 @@ export interface PublishResponse {
   visibility: string
 }
 
+export interface DryRunResponse {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+  resolvedSlug: string | null
+  resolvedVersion: string | null
+}
+
 export class SkillHubClient {
   constructor(
     readonly registry: string,
@@ -111,6 +119,22 @@ export class SkillHubClient {
       throw new CliError('registry unreachable', EXIT.network, { registry: this.registry, next: 'check network or pass --registry' })
     }
     return this.handleJsonResponse<PublishResponse>(response)
+  }
+
+  async validatePublish(namespace: string, file: Blob, fileName = 'skill.zip'): Promise<DryRunResponse> {
+    const formData = new FormData()
+    formData.append('file', file, fileName)
+    let response: Response
+    try {
+      response = await this.fetchImpl(`${this.registry}/api/cli/v1/skills/${namespace}/publish/validate`, {
+        method: 'POST',
+        headers: this.token ? { Authorization: `Bearer ${this.token}` } : {},
+        body: formData
+      })
+    } catch {
+      throw new CliError('registry unreachable', EXIT.network, { registry: this.registry, next: 'check network or pass --registry' })
+    }
+    return this.handleJsonResponse<DryRunResponse>(response)
   }
 
   private async getJson<T>(path: string): Promise<T> {

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -61,6 +61,10 @@ export async function publishCommand(path: string, options: PublishCommandOption
     const result = await client.validatePublish(namespace, archiveBlob, archiveName)
 
     if (options.json) {
+      if (!result.valid) {
+        process.stdout.write(JSON.stringify(result) + '\n')
+        throw new CliError('validation failed', EXIT.validation)
+      }
       return JSON.stringify(result)
     }
 
@@ -87,6 +91,10 @@ export async function publishCommand(path: string, options: PublishCommandOption
       for (const warning of result.warnings) {
         lines.push(`  - ${warning}`)
       }
+    }
+    if (!result.valid) {
+      process.stdout.write(lines.join('\n') + '\n')
+      throw new CliError('validation failed', EXIT.validation)
     }
     return lines.join('\n')
   }

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -58,7 +58,7 @@ export async function publishCommand(path: string, options: PublishCommandOption
   const client = new SkillHubClient(registry, token)
 
   if (options.dryRun) {
-    const result = await client.validatePublish(namespace, archiveBlob, archiveName)
+    const result = await client.validatePublish(namespace, archiveBlob, toServerVisibility(visibility), archiveName)
 
     if (options.json) {
       if (!result.valid) {

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -14,6 +14,7 @@ export interface PublishCommandOptions {
   registry?: string
   token?: string
   json?: boolean
+  dryRun?: boolean
 }
 
 export async function publishCommand(path: string, options: PublishCommandOptions): Promise<string> {
@@ -40,7 +41,6 @@ export async function publishCommand(path: string, options: PublishCommandOption
   let archiveBlob: Blob
   let archiveName: string
   if (pathStat.isFile()) {
-    // If input is a file, check if it's already a zip
     if (await isZipFile(path)) {
       const buffer = await readFile(path)
       archiveBlob = new Blob([buffer], { type: 'application/zip' })
@@ -49,7 +49,6 @@ export async function publishCommand(path: string, options: PublishCommandOption
       throw new CliError(`file must be a zip archive: ${path}`, EXIT.filesystem, { path })
     }
   } else if (pathStat.isDirectory()) {
-    // If input is a directory, create zip from it
     archiveBlob = await createZip(path)
     archiveName = `${basename(path)}.zip`
   } else {
@@ -57,6 +56,41 @@ export async function publishCommand(path: string, options: PublishCommandOption
   }
 
   const client = new SkillHubClient(registry, token)
+
+  if (options.dryRun) {
+    const result = await client.validatePublish(namespace, archiveBlob, archiveName)
+
+    if (options.json) {
+      return JSON.stringify(result)
+    }
+
+    const lines: string[] = []
+    if (result.valid) {
+      lines.push('Validation passed')
+    } else {
+      lines.push('Validation failed')
+    }
+    if (result.resolvedSlug) {
+      lines.push(`  Slug: ${result.resolvedSlug}`)
+    }
+    if (result.resolvedVersion) {
+      lines.push(`  Version: ${result.resolvedVersion}`)
+    }
+    if (result.errors.length > 0) {
+      lines.push('Errors:')
+      for (const error of result.errors) {
+        lines.push(`  - ${error}`)
+      }
+    }
+    if (result.warnings.length > 0) {
+      lines.push('Warnings:')
+      for (const warning of result.warnings) {
+        lines.push(`  - ${warning}`)
+      }
+    }
+    return lines.join('\n')
+  }
+
   const result = await client.publish(namespace, archiveBlob, toServerVisibility(visibility), archiveName)
 
   const detailUrl = `${registry}/space/${result.namespace}/${encodeURIComponent(result.slug)}`

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -278,6 +278,7 @@ cli
   .command('publish <path>', 'Publish a local skill package')
   .option('--namespace <slug>', 'Namespace')
   .option('--visibility <v>', 'Visibility (public|namespace-only|private)')
+  .option('--dry-run', 'Validate without publishing')
   .option('--registry <url>', 'Registry URL')
   .option('--token <token>', 'API token')
   .option('--json', 'Output JSON')

--- a/cli/src/shared/constants.ts
+++ b/cli/src/shared/constants.ts
@@ -8,5 +8,6 @@ export const EXIT = {
   auth: 2,
   network: 3,
   filesystem: 4,
-  usage: 5
+  usage: 5,
+  validation: 6
 } as const

--- a/cli/test/helpers/fake-registry.ts
+++ b/cli/test/helpers/fake-registry.ts
@@ -94,6 +94,7 @@ export interface CapturedPublish {
 export interface CapturedValidate {
   namespace: string
   fileName: string
+  visibility: string
 }
 
 /** Last resolve GET: useful for verifying --version is forwarded as ?version=. */
@@ -358,11 +359,12 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
 
         return req.formData().then(form => {
           const fileField = form.get('file')
+          const visibility = (form.get('visibility') as string | null) ?? 'PUBLIC'
           let fileName = 'skill.zip'
           if (fileField instanceof File) {
             fileName = fileField.name || fileName
           }
-          state.validate = { namespace, fileName }
+          state.validate = { namespace, fileName, visibility }
 
           const dryRunData = options.dryRunResponse ?? {
             valid: true,

--- a/cli/test/helpers/fake-registry.ts
+++ b/cli/test/helpers/fake-registry.ts
@@ -22,16 +22,19 @@ export function createFakeRegistry(handlers: Record<string, FakeHandler>) {
 /**
  * Controls how a specific endpoint behaves when a failure is injected:
  *   'auth'         => 401 { code: 401, message: 'unauthorized' }
+ *   'forbidden'    => 403 { code: 403, message: 'forbidden' }
  *   'not_found'    => 404 { code: 404, message: 'not found' }
  *   'server_error' => 500 { code: 500, message: 'internal error' }
  *   'network'      => handler throws, causing fetch() to reject with a TypeError
  */
-export type FailureMode = 'auth' | 'not_found' | 'server_error' | 'network'
+export type FailureMode = 'auth' | 'forbidden' | 'not_found' | 'server_error' | 'network'
 
 function failureResponse(mode: FailureMode): Response {
   switch (mode) {
     case 'auth':
       return Response.json({ code: 401, message: 'unauthorized' }, { status: 401 })
+    case 'forbidden':
+      return Response.json({ code: 403, message: 'forbidden' }, { status: 403 })
     case 'not_found':
       return Response.json({ code: 404, message: 'not found' }, { status: 404 })
     case 'server_error':

--- a/cli/test/helpers/fake-registry.ts
+++ b/cli/test/helpers/fake-registry.ts
@@ -91,6 +91,11 @@ export interface CapturedPublish {
   visibility: string
 }
 
+export interface CapturedValidate {
+  namespace: string
+  fileName: string
+}
+
 /** Last resolve GET: useful for verifying --version is forwarded as ?version=. */
 export interface CapturedResolve {
   namespace: string
@@ -116,6 +121,8 @@ interface FakeRegistryOptions {
   searchItems?: Array<{ namespace: string; slug: string; latestVersion: string; summary: string }>
   /** Skills available for resolve / download / delete / publish. */
   skills?: FakeSkill[]
+  /** Response to return for publish/validate (dry-run) requests. */
+  dryRunResponse?: { valid: boolean; errors: string[]; warnings: string[]; resolvedSlug: string | null; resolvedVersion: string | null }
   /**
    * Per-endpoint failure injection. When set for an endpoint, that endpoint
    * ignores all other logic and returns the specified failure (or throws for
@@ -128,6 +135,7 @@ interface FakeRegistryOptions {
     download?: FailureMode
     deleteRemote?: FailureMode
     publish?: FailureMode
+    validate?: FailureMode
   }
 }
 
@@ -167,7 +175,8 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
     publish: CapturedPublish | null
     resolve: CapturedResolve | null
     delete: CapturedDelete | null
-  } = { publish: null, resolve: null, delete: null }
+    validate: CapturedValidate | null
+  } = { publish: null, resolve: null, delete: null, validate: null }
 
   // If any endpoint is configured with 'network' failure mode, we need a real
   // TCP-level failure. Start a connection-dropping server and return its URL
@@ -336,6 +345,33 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
             namespace,
             slug
           }
+        })
+      }
+
+      // Validate (dry-run): POST /api/cli/v1/skills/:namespace/publish/validate
+      const validateMatch = path.match(/^\/api\/cli\/v1\/skills\/([^/]+)\/publish\/validate$/)
+      if (validateMatch && req.method === 'POST') {
+        if (options.failures?.validate) return failureResponse(options.failures.validate)
+        const authErr = checkAuth(req)
+        if (authErr) return authErr
+        const namespace = validateMatch[1]!
+
+        return req.formData().then(form => {
+          const fileField = form.get('file')
+          let fileName = 'skill.zip'
+          if (fileField instanceof File) {
+            fileName = fileField.name || fileName
+          }
+          state.validate = { namespace, fileName }
+
+          const dryRunData = options.dryRunResponse ?? {
+            valid: true,
+            errors: [],
+            warnings: [],
+            resolvedSlug: fileName.replace(/\.zip$/, ''),
+            resolvedVersion: '1.0.0'
+          }
+          return Response.json({ code: 0, data: dryRunData })
         })
       }
 

--- a/cli/test/integration/publish-dry-run.test.ts
+++ b/cli/test/integration/publish-dry-run.test.ts
@@ -98,7 +98,7 @@ describe('publish --dry-run', () => {
       USERPROFILE: env.home
     })
 
-    expect(result.exitCode).toBe(0)
+    expect(result.exitCode).toBe(6)
     expect(result.stdout).toContain('Validation failed')
     expect(result.stdout).toContain('Missing required file: SKILL.md at root')
   })

--- a/cli/test/integration/publish-dry-run.test.ts
+++ b/cli/test/integration/publish-dry-run.test.ts
@@ -50,12 +50,12 @@ describe('publish --dry-run', () => {
     expect(registry.received.publish).toBeNull()
   })
 
-  test('--dry-run with --json returns structured response', async () => {
+  test('--dry-run with --json returns structured response on warnings (valid=false)', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({
       token: 'sk_ok',
       dryRunResponse: {
-        valid: true,
+        valid: false,
         errors: [],
         warnings: ['Disallowed file extension: data.bin'],
         resolvedSlug: 'my-skill',
@@ -70,9 +70,9 @@ describe('publish --dry-run', () => {
       USERPROFILE: env.home
     })
 
-    expect(result.exitCode).toBe(0)
+    expect(result.exitCode).toBe(6)
     const json = JSON.parse(result.stdout)
-    expect(json.valid).toBe(true)
+    expect(json.valid).toBe(false)
     expect(json.resolvedSlug).toBe('my-skill')
     expect(json.resolvedVersion).toBe('2.0.0')
     expect(json.warnings).toContain('Disallowed file extension: data.bin')

--- a/cli/test/integration/publish-dry-run.test.ts
+++ b/cli/test/integration/publish-dry-run.test.ts
@@ -131,6 +131,20 @@ describe('publish --dry-run', () => {
     expect(registry.received.validate!.namespace).toBe('myteam')
   })
 
+  test('--dry-run forwards --visibility to server', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok' })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['SKILL.md', '---\nname: test\ndescription: test\n---\n'])
+    await runCli(['publish', dir, '--dry-run', '--visibility', 'private', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(registry.received.validate!.visibility).toBe('PRIVATE')
+  })
+
   test('--dry-run requires authentication', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({ token: 'sk_ok' })

--- a/cli/test/integration/publish-dry-run.test.ts
+++ b/cli/test/integration/publish-dry-run.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { createTempHome } from '../helpers/temp-env'
+import { startFakeRegistry } from '../helpers/fake-registry'
+import { runCli } from '../helpers/run-cli'
+
+let registry: Awaited<ReturnType<typeof startFakeRegistry>> | undefined
+
+afterEach(() => {
+  registry?.stop()
+  registry = undefined
+})
+
+async function login(env: { home: string }, registryUrl: string) {
+  const result = await runCli(['login', '--registry', registryUrl, '--token', 'sk_ok'], {
+    HOME: env.home,
+    USERPROFILE: env.home
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`login failed: ${result.stderr}`)
+  }
+}
+
+async function makeTempDir(...files: Array<[string, string]>) {
+  const dir = await mkdtemp(join(tmpdir(), 'skillhub-dryrun-'))
+  for (const [name, content] of files) {
+    await writeFile(join(dir, name), content)
+  }
+  return dir
+}
+
+describe('publish --dry-run', () => {
+  test('calls validate endpoint and reports success', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok' })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['SKILL.md', '---\nname: my-skill\ndescription: A test\n---\n# Hello'])
+    const result = await runCli(['publish', dir, '--dry-run', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Validation passed')
+    expect(registry.received.validate).not.toBeNull()
+    expect(registry.received.validate!.namespace).toBe('global')
+    expect(registry.received.publish).toBeNull()
+  })
+
+  test('--dry-run with --json returns structured response', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({
+      token: 'sk_ok',
+      dryRunResponse: {
+        valid: true,
+        errors: [],
+        warnings: ['Disallowed file extension: data.bin'],
+        resolvedSlug: 'my-skill',
+        resolvedVersion: '2.0.0'
+      }
+    })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['SKILL.md', '---\nname: my-skill\ndescription: test\n---\n'])
+    const result = await runCli(['publish', dir, '--dry-run', '--json', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(result.exitCode).toBe(0)
+    const json = JSON.parse(result.stdout)
+    expect(json.valid).toBe(true)
+    expect(json.resolvedSlug).toBe('my-skill')
+    expect(json.resolvedVersion).toBe('2.0.0')
+    expect(json.warnings).toContain('Disallowed file extension: data.bin')
+  })
+
+  test('--dry-run reports validation errors', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({
+      token: 'sk_ok',
+      dryRunResponse: {
+        valid: false,
+        errors: ['Missing required file: SKILL.md at root'],
+        warnings: [],
+        resolvedSlug: null,
+        resolvedVersion: null
+      }
+    })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['README.md', '# No SKILL.md here'])
+    const result = await runCli(['publish', dir, '--dry-run', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Validation failed')
+    expect(result.stdout).toContain('Missing required file: SKILL.md at root')
+  })
+
+  test('--dry-run does not actually publish', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok' })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['SKILL.md', '---\nname: test\ndescription: test\n---\n'])
+    await runCli(['publish', dir, '--dry-run', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(registry.received.publish).toBeNull()
+  })
+
+  test('--dry-run respects --namespace', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok' })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['SKILL.md', '---\nname: test\ndescription: test\n---\n'])
+    await runCli(['publish', dir, '--dry-run', '--namespace', 'myteam', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(registry.received.validate!.namespace).toBe('myteam')
+  })
+
+  test('--dry-run requires authentication', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok' })
+
+    const dir = await makeTempDir(['SKILL.md', '---\nname: test\ndescription: test\n---\n'])
+    const result = await runCli(['publish', dir, '--dry-run', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('authentication')
+  })
+})

--- a/cli/test/integration/publish-dry-run.test.ts
+++ b/cli/test/integration/publish-dry-run.test.ts
@@ -158,4 +158,19 @@ describe('publish --dry-run', () => {
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('authentication')
   })
+
+  test('--dry-run reports scope error on 403', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok', failures: { validate: 'forbidden' } })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['SKILL.md', '---\nname: test\ndescription: test\n---\n'])
+    const result = await runCli(['publish', dir, '--dry-run', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('scope')
+  })
 })

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/cli/CliSkillController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/cli/CliSkillController.java
@@ -100,6 +100,7 @@ public class CliSkillController extends BaseApiController {
     public ApiResponse<CliDryRunResponse> validatePublish(
             @PathVariable String namespace,
             @RequestPart("file") MultipartFile file,
+            @RequestPart(value = "visibility", required = false) String visibility,
             @AuthenticationPrincipal PlatformPrincipal principal) throws IOException {
         List<PackageEntry> entries;
         try {
@@ -107,8 +108,14 @@ public class CliSkillController extends BaseApiController {
         } catch (IllegalArgumentException e) {
             throw new DomainBadRequestException("error.skill.publish.package.invalid", e.getMessage());
         }
+        SkillVisibility resolvedVisibility;
+        try {
+            resolvedVisibility = SkillVisibility.valueOf((visibility != null ? visibility : "PUBLIC").toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new DomainBadRequestException("error.skill.publish.visibility.invalid", visibility);
+        }
         var result = cliSkillAppService.validatePublish(
-                namespace, entries, principal.userId(), principal.platformRoles());
+                namespace, entries, principal.userId(), resolvedVisibility, principal.platformRoles());
         return ok("response.success.read", result);
     }
 

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/cli/CliSkillController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/cli/CliSkillController.java
@@ -95,6 +95,23 @@ public class CliSkillController extends BaseApiController {
                 namespace, slug, principal.userId(), AuditRequestContext.from(request)));
     }
 
+    @PostMapping(value = "/{namespace}/publish/validate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @RateLimit(category = "publish", authenticated = 10, anonymous = 0)
+    public ApiResponse<CliDryRunResponse> validatePublish(
+            @PathVariable String namespace,
+            @RequestPart("file") MultipartFile file,
+            @AuthenticationPrincipal PlatformPrincipal principal) throws IOException {
+        List<PackageEntry> entries;
+        try {
+            entries = archiveExtractor.extract(file);
+        } catch (IllegalArgumentException e) {
+            throw new DomainBadRequestException("error.skill.publish.package.invalid", e.getMessage());
+        }
+        var result = cliSkillAppService.validatePublish(
+                namespace, entries, principal.userId(), principal.platformRoles());
+        return ok("response.success.read", result);
+    }
+
     @PostMapping(value = "/{namespace}/publish", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @RateLimit(category = "publish", authenticated = 10, anonymous = 0)
     public ApiResponse<CliPublishResponse> publish(

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/cli/CliDryRunResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/cli/CliDryRunResponse.java
@@ -1,0 +1,11 @@
+package com.iflytek.skillhub.dto.cli;
+
+import java.util.List;
+
+public record CliDryRunResponse(
+        boolean valid,
+        List<String> errors,
+        List<String> warnings,
+        String resolvedSlug,
+        String resolvedVersion
+) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/cli/CliSkillAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/cli/CliSkillAppService.java
@@ -120,9 +120,9 @@ public class CliSkillAppService {
         );
     }
 
-    public CliDryRunResponse validatePublish(String namespace, List<PackageEntry> entries, String publisherId, Set<String> platformRoles) {
+    public CliDryRunResponse validatePublish(String namespace, List<PackageEntry> entries, String publisherId, SkillVisibility visibility, Set<String> platformRoles) {
         SkillPublishService.DryRunResult result = skillPublishService.validateOnly(
-                namespace, entries, publisherId, platformRoles);
+                namespace, entries, publisherId, visibility, platformRoles);
         return new CliDryRunResponse(
                 result.valid(),
                 result.errors(),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/cli/CliSkillAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/cli/CliSkillAppService.java
@@ -8,6 +8,7 @@ import com.iflytek.skillhub.domain.skill.service.SkillQueryService;
 import com.iflytek.skillhub.domain.skill.validation.PackageEntry;
 import com.iflytek.skillhub.dto.SkillSummaryResponse;
 import com.iflytek.skillhub.dto.cli.CliDeleteResponse;
+import com.iflytek.skillhub.dto.cli.CliDryRunResponse;
 import com.iflytek.skillhub.dto.cli.CliPublishResponse;
 import com.iflytek.skillhub.dto.cli.CliResolveResponse;
 import com.iflytek.skillhub.service.AuditRequestContext;
@@ -116,6 +117,18 @@ public class CliSkillAppService {
                 "delete",
                 result.namespace(),
                 result.slug()
+        );
+    }
+
+    public CliDryRunResponse validatePublish(String namespace, List<PackageEntry> entries, String publisherId, Set<String> platformRoles) {
+        SkillPublishService.DryRunResult result = skillPublishService.validateOnly(
+                namespace, entries, publisherId, platformRoles);
+        return new CliDryRunResponse(
+                result.valid(),
+                result.errors(),
+                result.warnings(),
+                result.resolvedSlug(),
+                result.resolvedVersion()
         );
     }
 

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliDryRunValidateTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliDryRunValidateTest.java
@@ -1,6 +1,7 @@
 package com.iflytek.skillhub.controller.cli;
 
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
+import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.dto.cli.CliDryRunResponse;
 import com.iflytek.skillhub.service.cli.CliSkillAppService;
 import org.junit.jupiter.api.Test;
@@ -41,9 +42,10 @@ class CliDryRunValidateTest {
 
     @Test
     void validatePublish_returnsValidResult() throws Exception {
-        given(cliSkillAppService.validatePublish(eq("global"), any(), eq("user-1"), eq(Set.of("USER"))))
+        given(cliSkillAppService.validatePublish(
+                eq("global"), any(), eq("user-1"), eq(SkillVisibility.PUBLIC), eq(Set.of("USER"))))
                 .willReturn(new CliDryRunResponse(
-                        true, List.of(), List.of("Disallowed file extension: data.bin"),
+                        true, List.of(), List.of(),
                         "my-skill", "1.0.0"));
 
         MockMultipartFile file = new MockMultipartFile("file", "skill.zip",
@@ -55,13 +57,13 @@ class CliDryRunValidateTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.valid").value(true))
                 .andExpect(jsonPath("$.data.resolvedSlug").value("my-skill"))
-                .andExpect(jsonPath("$.data.resolvedVersion").value("1.0.0"))
-                .andExpect(jsonPath("$.data.warnings[0]").value("Disallowed file extension: data.bin"));
+                .andExpect(jsonPath("$.data.resolvedVersion").value("1.0.0"));
     }
 
     @Test
     void validatePublish_returnsInvalidResult() throws Exception {
-        given(cliSkillAppService.validatePublish(eq("global"), any(), eq("user-1"), eq(Set.of("USER"))))
+        given(cliSkillAppService.validatePublish(
+                eq("global"), any(), eq("user-1"), eq(SkillVisibility.PUBLIC), eq(Set.of("USER"))))
                 .willReturn(new CliDryRunResponse(
                         false, List.of("Missing required file: SKILL.md at root"), List.of(),
                         null, null));
@@ -76,6 +78,36 @@ class CliDryRunValidateTest {
                 .andExpect(jsonPath("$.data.valid").value(false))
                 .andExpect(jsonPath("$.data.errors[0]").value("Missing required file: SKILL.md at root"))
                 .andExpect(jsonPath("$.data.resolvedSlug").doesNotExist());
+    }
+
+    @Test
+    void validatePublish_acceptsCustomVisibility() throws Exception {
+        given(cliSkillAppService.validatePublish(
+                eq("global"), any(), eq("user-1"), eq(SkillVisibility.PRIVATE), eq(Set.of("USER"))))
+                .willReturn(new CliDryRunResponse(
+                        true, List.of(), List.of(), "my-skill", "1.0.0"));
+
+        MockMultipartFile file = new MockMultipartFile("file", "skill.zip",
+                "application/zip", new byte[]{0x50, 0x4B, 0x03, 0x04});
+
+        mockMvc.perform(multipart("/api/cli/v1/skills/global/publish/validate")
+                        .file(file)
+                        .file(new MockMultipartFile("visibility", "", "text/plain", "PRIVATE".getBytes()))
+                        .with(authentication(auth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.valid").value(true));
+    }
+
+    @Test
+    void validatePublish_rejectsInvalidVisibility() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "skill.zip",
+                "application/zip", new byte[]{0x50, 0x4B, 0x03, 0x04});
+
+        mockMvc.perform(multipart("/api/cli/v1/skills/global/publish/validate")
+                        .file(file)
+                        .file(new MockMultipartFile("visibility", "", "text/plain", "BOGUS".getBytes()))
+                        .with(authentication(auth())))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliDryRunValidateTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliDryRunValidateTest.java
@@ -37,7 +37,9 @@ class CliDryRunValidateTest {
         PlatformPrincipal principal = new PlatformPrincipal(
                 "user-1", "tester", "t@example.com", "", "api_token", Set.of("USER"));
         return new UsernamePasswordAuthenticationToken(
-                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                principal, null, List.of(
+                        new SimpleGrantedAuthority("ROLE_USER"),
+                        new SimpleGrantedAuthority("SCOPE_skill:publish")));
     }
 
     @Test

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliDryRunValidateTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliDryRunValidateTest.java
@@ -1,0 +1,90 @@
+package com.iflytek.skillhub.controller.cli;
+
+import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
+import com.iflytek.skillhub.dto.cli.CliDryRunResponse;
+import com.iflytek.skillhub.service.cli.CliSkillAppService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CliDryRunValidateTest {
+    @Autowired MockMvc mockMvc;
+    @MockBean CliSkillAppService cliSkillAppService;
+
+    private UsernamePasswordAuthenticationToken auth() {
+        PlatformPrincipal principal = new PlatformPrincipal(
+                "user-1", "tester", "t@example.com", "", "api_token", Set.of("USER"));
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    @Test
+    void validatePublish_returnsValidResult() throws Exception {
+        given(cliSkillAppService.validatePublish(eq("global"), any(), eq("user-1"), eq(Set.of("USER"))))
+                .willReturn(new CliDryRunResponse(
+                        true, List.of(), List.of("Disallowed file extension: data.bin"),
+                        "my-skill", "1.0.0"));
+
+        MockMultipartFile file = new MockMultipartFile("file", "skill.zip",
+                "application/zip", new byte[]{0x50, 0x4B, 0x03, 0x04});
+
+        mockMvc.perform(multipart("/api/cli/v1/skills/global/publish/validate")
+                        .file(file)
+                        .with(authentication(auth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.valid").value(true))
+                .andExpect(jsonPath("$.data.resolvedSlug").value("my-skill"))
+                .andExpect(jsonPath("$.data.resolvedVersion").value("1.0.0"))
+                .andExpect(jsonPath("$.data.warnings[0]").value("Disallowed file extension: data.bin"));
+    }
+
+    @Test
+    void validatePublish_returnsInvalidResult() throws Exception {
+        given(cliSkillAppService.validatePublish(eq("global"), any(), eq("user-1"), eq(Set.of("USER"))))
+                .willReturn(new CliDryRunResponse(
+                        false, List.of("Missing required file: SKILL.md at root"), List.of(),
+                        null, null));
+
+        MockMultipartFile file = new MockMultipartFile("file", "skill.zip",
+                "application/zip", new byte[]{0x50, 0x4B, 0x03, 0x04});
+
+        mockMvc.perform(multipart("/api/cli/v1/skills/global/publish/validate")
+                        .file(file)
+                        .with(authentication(auth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.valid").value(false))
+                .andExpect(jsonPath("$.data.errors[0]").value("Missing required file: SKILL.md at root"))
+                .andExpect(jsonPath("$.data.resolvedSlug").doesNotExist());
+    }
+
+    @Test
+    void validatePublish_requiresAuthentication() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "skill.zip",
+                "application/zip", new byte[]{0x50, 0x4B, 0x03, 0x04});
+
+        mockMvc.perform(multipart("/api/cli/v1/skills/global/publish/validate")
+                        .file(file))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliSkillControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/cli/CliSkillControllerTest.java
@@ -103,7 +103,9 @@ class CliSkillControllerTest {
         PlatformPrincipal principal = new PlatformPrincipal(
                 "user-1", "tester", "t@example.com", "", "api_token", Set.of("USER"));
         var auth = new UsernamePasswordAuthenticationToken(
-                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                principal, null, List.of(
+                        new SimpleGrantedAuthority("ROLE_USER"),
+                        new SimpleGrantedAuthority("SCOPE_skill:delete")));
 
         given(cliSkillAppService.deleteRemote(
                 org.mockito.ArgumentMatchers.eq("global"),

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistry.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistry.java
@@ -82,7 +82,8 @@ public class RouteSecurityPolicyRegistry {
             RouteAuthorizationPolicy.permitAll(HttpMethod.GET, "/api/cli/v1/skills/*/*/download"),
             RouteAuthorizationPolicy.permitAll(HttpMethod.GET, "/api/cli/v1/skills/*/*/versions/*/download"),
             RouteAuthorizationPolicy.authenticated(HttpMethod.DELETE, "/api/cli/v1/skills/*/*"),
-            RouteAuthorizationPolicy.authenticated(HttpMethod.POST, "/api/cli/v1/skills/*/publish")
+            RouteAuthorizationPolicy.authenticated(HttpMethod.POST, "/api/cli/v1/skills/*/publish"),
+            RouteAuthorizationPolicy.authenticated(HttpMethod.POST, "/api/cli/v1/skills/*/publish/validate")
     );
 
     private static final List<ApiTokenPolicy> API_TOKEN_POLICIES = List.of(
@@ -121,7 +122,8 @@ public class RouteSecurityPolicyRegistry {
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/cli/v1/skills/*/*/download"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/cli/v1/skills/*/*/versions/*/download"),
             ApiTokenPolicy.require(HttpMethod.DELETE, "/api/cli/v1/skills/*/*", "skill:delete"),
-            ApiTokenPolicy.require(HttpMethod.POST, "/api/cli/v1/skills/*/publish", "skill:publish")
+            ApiTokenPolicy.require(HttpMethod.POST, "/api/cli/v1/skills/*/publish", "skill:publish"),
+            ApiTokenPolicy.require(HttpMethod.POST, "/api/cli/v1/skills/*/publish/validate", "skill:publish")
     );
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/token/ApiTokenScopeFilter.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/token/ApiTokenScopeFilter.java
@@ -70,7 +70,8 @@ public class ApiTokenScopeFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
         return path == null || (!path.startsWith("/api/v1/")
-                && !path.startsWith("/api/web/"));
+                && !path.startsWith("/api/web/")
+                && !path.startsWith("/api/cli/"));
     }
 
     private boolean isApiTokenAuthentication(Authentication authentication) {

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistryTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistryTest.java
@@ -80,6 +80,8 @@ class RouteSecurityPolicyRegistryTest {
         assertTrue(registry.authorizeApiToken("GET", "/api/cli/v1/skills/global/demo/resolve", Set.of()).allowed());
         assertFalse(registry.authorizeApiToken("POST", "/api/cli/v1/skills/global/publish", Set.of()).allowed());
         assertTrue(registry.authorizeApiToken("POST", "/api/cli/v1/skills/global/publish", Set.of("skill:publish")).allowed());
+        assertFalse(registry.authorizeApiToken("POST", "/api/cli/v1/skills/global/publish/validate", Set.of()).allowed());
+        assertTrue(registry.authorizeApiToken("POST", "/api/cli/v1/skills/global/publish/validate", Set.of("skill:publish")).allowed());
         assertTrue(registry.authorizeApiToken("DELETE", "/api/cli/v1/skills/global/demo", Set.of("skill:delete")).allowed());
     }
 

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/token/ApiTokenScopeFilterTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/token/ApiTokenScopeFilterTest.java
@@ -134,4 +134,40 @@ class ApiTokenScopeFilterTest {
         assertTrue(response.getErrorMessage().contains("Missing API token scope: skill:publish"));
         verify(chain, never()).doFilter(request, response);
     }
+
+    @Test
+    void shouldDenyApiCliRequestsWithoutRequiredScope() throws Exception {
+        AccessDeniedHandler handler = (request, response, accessDeniedException) -> {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+        };
+        ApiTokenScopeFilter filter = new ApiTokenScopeFilter(scopeService, handler);
+
+        PlatformPrincipal principal = new PlatformPrincipal(
+            "user-4",
+            "Dave",
+            "dave@example.com",
+            "",
+            "api_token",
+            Set.of("USER")
+        );
+        var authentication = new UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            List.of(
+                new SimpleGrantedAuthority("ROLE_USER"),
+                new SimpleGrantedAuthority("SCOPE_skill:read")
+            )
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/cli/v1/skills/global/publish/validate");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+        assertTrue(response.getErrorMessage().contains("Missing API token scope: skill:publish"));
+        verify(chain, never()).doFilter(request, response);
+    }
 }

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
@@ -186,7 +186,7 @@ public class SkillPublishService {
 
         SkillMetadata metadata;
         try {
-            metadata = skillMetadataParser.parse(new String(skillMd.content()));
+            metadata = skillMetadataParser.parse(new String(skillMd.content(), java.nio.charset.StandardCharsets.UTF_8));
         } catch (Exception e) {
             errors.add("Invalid SKILL.md: " + e.getMessage());
             return new DryRunResult(false, errors, warnings, null, null);
@@ -212,11 +212,21 @@ public class SkillPublishService {
         errors.addAll(prePublishValidation.errors());
         warnings.addAll(prePublishValidation.warnings());
 
-        // 6. Slug conflict check
+        // 6. Slug conflict, archived skill, and version-exists checks
         if (resolvedSlug != null && errors.isEmpty()) {
             List<Skill> existingSkills = skillRepository.findByNamespaceIdAndSlug(namespace.getId(), resolvedSlug);
             for (Skill existing : existingSkills) {
-                if (!existing.getOwnerId().equals(publisherId)) {
+                if (existing.getOwnerId().equals(publisherId)) {
+                    if (existing.getStatus() == SkillStatus.ARCHIVED) {
+                        errors.add("Cannot publish to archived skill: " + resolvedSlug);
+                    }
+                    if (resolvedVersion != null) {
+                        var existingVersion = skillVersionRepository.findBySkillIdAndVersion(existing.getId(), resolvedVersion);
+                        if (existingVersion.isPresent() && existingVersion.get().getStatus() == SkillVersionStatus.PUBLISHED) {
+                            errors.add("Version already published: " + resolvedVersion);
+                        }
+                    }
+                } else {
                     boolean hasPublished = !skillVersionRepository
                             .findBySkillIdAndStatus(existing.getId(), SkillVersionStatus.PUBLISHED)
                             .isEmpty();

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
@@ -129,12 +129,18 @@ public class SkillPublishService {
 
     /**
      * Validates a package without persisting anything. Used by the --dry-run CLI flow.
+     *
+     * <p>Warnings make the result invalid because the CLI publish flow uses
+     * {@code confirmWarnings=false}, which causes real publish to reject any
+     * package with warnings. Treating warnings as making the dry-run invalid
+     * keeps the two flows in lockstep.
      */
     @Transactional(readOnly = true)
     public DryRunResult validateOnly(
             String namespaceSlug,
             List<PackageEntry> entries,
             String publisherId,
+            SkillVisibility visibility,
             Set<String> platformRoles) {
 
         List<String> errors = new ArrayList<>();
@@ -238,7 +244,10 @@ public class SkillPublishService {
             }
         }
 
-        return new DryRunResult(errors.isEmpty(), errors, warnings, resolvedSlug, resolvedVersion);
+        // Warnings make valid=false: real publish rejects them when confirmWarnings=false,
+        // which is the only mode the CLI uses today.
+        boolean valid = errors.isEmpty() && warnings.isEmpty();
+        return new DryRunResult(valid, errors, warnings, resolvedSlug, resolvedVersion);
     }
 
     /**

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
@@ -119,6 +119,118 @@ public class SkillPublishService {
         this.clock = clock;
     }
 
+    public record DryRunResult(
+            boolean valid,
+            List<String> errors,
+            List<String> warnings,
+            String resolvedSlug,
+            String resolvedVersion
+    ) {}
+
+    /**
+     * Validates a package without persisting anything. Used by the --dry-run CLI flow.
+     */
+    @Transactional(readOnly = true)
+    public DryRunResult validateOnly(
+            String namespaceSlug,
+            List<PackageEntry> entries,
+            String publisherId,
+            Set<String> platformRoles) {
+
+        List<String> errors = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+        String resolvedSlug = null;
+        String resolvedVersion = null;
+
+        // 1. Find namespace
+        var namespaceOpt = namespaceRepository.findBySlug(namespaceSlug);
+        if (namespaceOpt.isEmpty()) {
+            errors.add("Namespace not found: " + namespaceSlug);
+            return new DryRunResult(false, errors, warnings, null, null);
+        }
+        Namespace namespace = namespaceOpt.get();
+        if (namespace.getStatus() == NamespaceStatus.FROZEN) {
+            errors.add("Namespace is frozen: " + namespaceSlug);
+        }
+        if (namespace.getStatus() == NamespaceStatus.ARCHIVED) {
+            errors.add("Namespace is archived: " + namespaceSlug);
+        }
+
+        // 2. Check membership
+        boolean isSuperAdmin = platformRoles.contains("SUPER_ADMIN");
+        if (!isSuperAdmin) {
+            var member = namespaceMemberRepository.findByNamespaceIdAndUserId(namespace.getId(), publisherId);
+            if (member.isEmpty()) {
+                errors.add("Publisher is not a member of namespace: " + namespaceSlug);
+            }
+        }
+
+        // 3. Package validation
+        ValidationResult packageValidation = skillPackageValidator.validate(entries);
+        errors.addAll(packageValidation.errors());
+        warnings.addAll(packageValidation.warnings());
+
+        if (!packageValidation.passed()) {
+            return new DryRunResult(false, errors, warnings, null, null);
+        }
+
+        // 4. Parse SKILL.md
+        PackageEntry skillMd = entries.stream()
+                .filter(e -> e.path().equals("SKILL.md"))
+                .findFirst()
+                .orElse(null);
+        if (skillMd == null) {
+            errors.add("Missing required file: SKILL.md at root");
+            return new DryRunResult(false, errors, warnings, null, null);
+        }
+
+        SkillMetadata metadata;
+        try {
+            metadata = skillMetadataParser.parse(new String(skillMd.content()));
+        } catch (Exception e) {
+            errors.add("Invalid SKILL.md: " + e.getMessage());
+            return new DryRunResult(false, errors, warnings, null, null);
+        }
+
+        if (metadata.version() == null || metadata.version().isBlank()) {
+            resolvedVersion = AUTO_VERSION_FORMATTER.format(currentTime());
+        } else {
+            resolvedVersion = metadata.version();
+        }
+
+        try {
+            resolvedSlug = SlugValidator.slugify(metadata.name());
+        } catch (Exception e) {
+            errors.add("Invalid skill name for slug generation: " + e.getMessage());
+            return new DryRunResult(false, errors, warnings, resolvedSlug, resolvedVersion);
+        }
+
+        // 5. Pre-publish validation (credential scan)
+        PrePublishValidator.SkillPackageContext context = new PrePublishValidator.SkillPackageContext(
+                entries, metadata, publisherId, namespace.getId());
+        ValidationResult prePublishValidation = prePublishValidator.validate(context);
+        errors.addAll(prePublishValidation.errors());
+        warnings.addAll(prePublishValidation.warnings());
+
+        // 6. Slug conflict check
+        if (resolvedSlug != null && errors.isEmpty()) {
+            List<Skill> existingSkills = skillRepository.findByNamespaceIdAndSlug(namespace.getId(), resolvedSlug);
+            for (Skill existing : existingSkills) {
+                if (!existing.getOwnerId().equals(publisherId)) {
+                    boolean hasPublished = !skillVersionRepository
+                            .findBySkillIdAndStatus(existing.getId(), SkillVersionStatus.PUBLISHED)
+                            .isEmpty();
+                    if (hasPublished) {
+                        errors.add("Name conflict: slug \"" + resolvedSlug + "\" is already published by another user");
+                        break;
+                    }
+                }
+            }
+        }
+
+        return new DryRunResult(errors.isEmpty(), errors, warnings, resolvedSlug, resolvedVersion);
+    }
+
     /**
      * Publishes an extracted package into the target namespace.
      *

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -3977,8 +3977,8 @@ export interface components {
             valid?: boolean;
             errors?: string[];
             warnings?: string[];
-            resolvedSlug?: string;
-            resolvedVersion?: string;
+            resolvedSlug?: string | null;
+            resolvedVersion?: string | null;
         };
         UpdateProfileRequest: {
             displayName?: string;
@@ -8340,6 +8340,7 @@ export interface operations {
                 "multipart/form-data": {
                     /** Format: binary */
                     file: string;
+                    visibility?: string;
                 };
             };
         };

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -1652,6 +1652,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/cli/v1/skills/{namespace}/publish/validate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["validatePublish"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/user/profile": {
         parameters: {
             query?: never;
@@ -3947,6 +3963,22 @@ export interface components {
             slug?: string;
             version?: string;
             visibility?: string;
+        };
+        ApiResponseCliDryRunResponse: {
+            /** Format: int32 */
+            code?: number;
+            msg?: string;
+            data?: components["schemas"]["CliDryRunResponse"];
+            /** Format: date-time */
+            timestamp?: string;
+            requestId?: string;
+        };
+        CliDryRunResponse: {
+            valid?: boolean;
+            errors?: string[];
+            warnings?: string[];
+            resolvedSlug?: string;
+            resolvedVersion?: string;
         };
         UpdateProfileRequest: {
             displayName?: string;
@@ -8290,6 +8322,35 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["ApiResponseCliPublishResponse"];
+                };
+            };
+        };
+    };
+    validatePublish: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "multipart/form-data": {
+                    /** Format: binary */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApiResponseCliDryRunResponse"];
                 };
             };
         };


### PR DESCRIPTION
## 概述

为 `skillhub publish` 增加 `--dry-run` 选项，调用后端新增的"仅校验"接口，让开发者在本地即可获知包结构和元数据是否合法，无需实际发布。

## 变更内容

### 后端实现
- `SkillPublishService.validateOnly()` — 提取验证逻辑（包结构、SKILL.md 解析、credential 扫描、slug 冲突检测），只读事务不持久化
- `CliSkillController` 新增 `POST /api/cli/v1/skills/{namespace}/publish/validate` 端点
- `CliSkillAppService.validatePublish()` — 编排层方法
- `CliDryRunResponse` DTO — 返回 valid/errors/warnings/resolvedSlug/resolvedVersion

### CLI 实现
- `SkillHubClient.validatePublish()` — 调用新端点
- `publishCommand` 增加 `--dry-run` 分支，调用 validate 而非 publish
- `index.ts` 注册 `--dry-run` 选项

### 测试覆盖
- 后端：`CliDryRunValidateTest` — 3 个用例（成功、失败、未认证）
- CLI：`publish-dry-run.test.ts` — 6 个集成测试（成功/失败/JSON/namespace/不实际发布/认证）

## 质量门禁

- [x] `make typecheck-web` 通过 (0 errors)
- [x] `make lint-web` 通过 (0 errors, 0 warnings)
- [x] CLI 全量测试通过 (188 tests, 0 failures)
- [x] `make test-backend-app` 通过 (468 tests, 0 failures)
- [x] `make generate-api` 已执行且 `schema.d.ts` 已提交

## 安全考虑

- 新端点复用现有认证机制（Bearer token + PlatformPrincipal）
- 使用 `@Transactional(readOnly = true)` 确保不会意外写入
- Rate limit 与 publish 端点一致（10 req/authenticated user）

## 相关 Issue

Closes #429

## 测试说明

### 本地验证步骤
1. `make dev-all` 启动本地环境
2. `skillhub login --registry http://localhost:8080 --token <your-token>`
3. 创建一个包含 SKILL.md 的目录
4. `skillhub publish ./my-skill --dry-run` — 应输出 "Validation passed" + slug/version
5. 删除 SKILL.md 后再次执行 — 应输出 "Validation failed" + 错误信息
6. `skillhub publish ./my-skill --dry-run --json` — 应输出结构化 JSON

### 回归测试范围
- publish 正常流程不受影响（已通过现有测试验证）
- CLI 其他命令不受影响（188 tests 全部通过）