### PR TITLE
feat(admin): add userId column to user management list

### DIFF
--- a/web/e2e/admin-users-userid-column.spec.ts
+++ b/web/e2e/admin-users-userid-column.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from '@playwright/test'
+import { setEnglishLocale } from './helpers/auth-fixtures'
+
+test.describe('Admin Users - UserId Column', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await setEnglishLocale(page)
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    // Use mock admin user
+    await page.context().setExtraHTTPHeaders({
+      'X-Mock-User-Id': 'local-admin'
+    })
+
+    await page.goto('/admin/users')
+    await page.waitForResponse(resp => resp.url().includes('/api/v1/admin/users') && resp.status() === 200)
+  })
+
+  test('userId column appears after username column', async ({ page }) => {
+    // Wait for table to load
+    await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible()
+
+    // Check userId column exists
+    const userIdHeader = page.getByRole('columnheader', { name: 'User ID' })
+    await expect(userIdHeader).toBeVisible()
+
+    // Verify column order: Username should come before User ID
+    const headers = page.getByRole('columnheader')
+    const headerTexts = await headers.allTextContents()
+
+    const usernameIndex = headerTexts.findIndex(text => text.includes('Username'))
+    const userIdIndex = headerTexts.findIndex(text => text.includes('User ID'))
+
+    expect(usernameIndex).toBeGreaterThanOrEqual(0)
+    expect(userIdIndex).toBeGreaterThan(usernameIndex)
+  })
+
+  test('userId values are displayed in table rows', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+
+    // Wait for at least one row to load
+    const firstRow = page.getByRole('row').nth(1)
+    await expect(firstRow).toBeVisible()
+
+    // Check that userId cells contain non-empty values
+    const userIdCells = page.getByRole('cell').filter({ hasText: /^[a-zA-Z0-9-]+$/ })
+    const count = await userIdCells.count()
+    expect(count).toBeGreaterThan(0)
+  })
+
+  test('copy button exists for each userId', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+
+    // Wait for rows to load
+    const rows = page.getByRole('row')
+    const rowCount = await rows.count()
+
+    if (rowCount <= 1) {
+      test.skip()
+    }
+
+    // Check for copy buttons (they should have aria-label or be buttons)
+    const copyButtons = page.getByRole('button').filter({ hasText: /copy/i })
+    const buttonCount = await copyButtons.count()
+
+    expect(buttonCount).toBeGreaterThan(0)
+  })
+
+  test('clicking copy button copies userId to clipboard', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+
+    // Find first copy button in the table
+    const firstRow = page.getByRole('row').nth(1)
+    await expect(firstRow).toBeVisible()
+
+    // Get the userId text before clicking
+    const userIdCell = firstRow.getByRole('cell').nth(1) // Assuming userId is 2nd column
+    const userIdText = await userIdCell.textContent()
+
+    // Click the copy button
+    const copyButton = firstRow.getByRole('button', { name: /copy/i }).first()
+    await copyButton.click()
+
+    // Wait for clipboard to update
+    await page.waitForTimeout(100)
+
+    // Verify clipboard content
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboardText).toBeTruthy()
+    expect(clipboardText.length).toBeGreaterThan(0)
+  })
+
+  test('copy button shows feedback after clicking', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+
+    const firstRow = page.getByRole('row').nth(1)
+    await expect(firstRow).toBeVisible()
+
+    const copyButton = firstRow.getByRole('button', { name: /copy/i }).first()
+    await copyButton.click()
+
+    // Check for "Copied" feedback
+    await expect(page.getByText(/copied/i)).toBeVisible({ timeout: 2000 })
+  })
+
+  test('userId column persists after search/filter', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+
+    // Perform a search if search input exists
+    const searchInput = page.getByPlaceholder(/search/i).first()
+    if (await searchInput.isVisible()) {
+      await searchInput.fill('test')
+      await page.waitForTimeout(500)
+    }
+
+    // Verify userId column still exists
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+  })
+
+  test('userId column persists across pagination', async ({ page }) => {
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+
+    // Check if pagination exists
+    const nextButton = page.getByRole('button', { name: /next/i })
+
+    if (await nextButton.isVisible() && await nextButton.isEnabled()) {
+      await nextButton.click()
+      await page.waitForTimeout(500)
+
+      // Verify userId column still exists on next page
+      await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+    } else {
+      test.skip()
+    }
+  })
+})

--- a/web/e2e/admin-users-userid-column.spec.ts
+++ b/web/e2e/admin-users-userid-column.spec.ts
@@ -40,9 +40,9 @@ test.describe('Admin Users - UserId Column', () => {
     const firstRow = page.getByRole('row').nth(1)
     await expect(firstRow).toBeVisible()
 
-    // The userId cell is the 2nd column (index 1). It should contain a non-empty identifier.
-    const userIdCell = firstRow.getByRole('cell').nth(1)
-    const userIdText = (await userIdCell.textContent())?.trim() ?? ''
+    // Assert on the monospace span specifically, not the full cell (which includes button text).
+    const userIdSpan = firstRow.getByRole('cell').nth(1).locator('span.font-mono')
+    const userIdText = (await userIdSpan.textContent())?.trim() ?? ''
     expect(userIdText.length).toBeGreaterThan(0)
   })
 
@@ -50,10 +50,14 @@ test.describe('Admin Users - UserId Column', () => {
     const rowCount = await page.getByRole('row').count()
     test.skip(rowCount <= 1, 'No data rows available to assert copy buttons')
 
-    const copyButtons = page.getByRole('button', { name: /copy/i })
-    const buttonCount = await copyButtons.count()
-    // At least one copy button per row body should be present.
-    expect(buttonCount).toBeGreaterThanOrEqual(rowCount - 1)
+    // Scope to the userId cell (2nd column) in each data row to avoid false positives
+    // from other copy buttons that may appear elsewhere on the page.
+    const dataRows = page.getByRole('row').filter({ hasNot: page.getByRole('columnheader') })
+    const rows = await dataRows.count()
+    for (let i = 0; i < rows; i++) {
+      const userIdCell = dataRows.nth(i).getByRole('cell').nth(1)
+      await expect(userIdCell.getByRole('button', { name: /copy/i })).toBeVisible()
+    }
   })
 
   test('clicking copy button copies the row userId to clipboard', async ({ page }) => {
@@ -65,11 +69,11 @@ test.describe('Admin Users - UserId Column', () => {
     const expectedUserId = (await userIdSpan.textContent())?.trim() ?? ''
     expect(expectedUserId.length).toBeGreaterThan(0)
 
-    const copyButton = firstRow.getByRole('button', { name: /copy/i }).first()
+    const copyButton = firstRow.getByRole('cell').nth(1).getByRole('button').first()
     await copyButton.click()
 
-    // CopyButton flips its label to "Copied" once the clipboard write resolves; wait for that.
-    await expect(firstRow.getByRole('button', { name: /copied/i })).toBeVisible()
+    // Wait for the button text to flip to "Copied" as feedback.
+    await expect(copyButton).toHaveText(/copied/i)
 
     const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
     expect(clipboardText).toBe(expectedUserId)
@@ -79,10 +83,11 @@ test.describe('Admin Users - UserId Column', () => {
     const firstRow = page.getByRole('row').nth(1)
     await expect(firstRow).toBeVisible()
 
-    const copyButton = firstRow.getByRole('button', { name: /copy/i }).first()
+    const copyButton = firstRow.getByRole('cell').nth(1).getByRole('button').first()
     await copyButton.click()
 
-    await expect(firstRow.getByRole('button', { name: /copied/i })).toBeVisible()
+    // Wait for the button text to flip to "Copied" as feedback.
+    await expect(copyButton).toHaveText(/copied/i)
   })
 
   test('userId column persists after triggering a search', async ({ page }) => {

--- a/web/e2e/admin-users-userid-column.spec.ts
+++ b/web/e2e/admin-users-userid-column.spec.ts
@@ -1,135 +1,133 @@
 import { expect, test } from '@playwright/test'
 import { setEnglishLocale } from './helpers/auth-fixtures'
 
+// This spec verifies the admin UI surfaces userId next to username and supports one-click copy.
+// We rely on the `X-Mock-User-Id: local-admin` mock profile (the same approach used by other
+// admin specs such as `my-namespaces-data.spec.ts`). The mock profile activates a deterministic
+// admin session without exercising the full SSO path; treat results here as evidence of the
+// admin UI behavior, not of the real-service auth path.
 test.describe('Admin Users - UserId Column', () => {
   test.beforeEach(async ({ page, context }) => {
     await setEnglishLocale(page)
     await context.grantPermissions(['clipboard-read', 'clipboard-write'])
 
-    // Use mock admin user
     await page.context().setExtraHTTPHeaders({
-      'X-Mock-User-Id': 'local-admin'
+      'X-Mock-User-Id': 'local-admin',
     })
 
-    await page.goto('/admin/users')
-    await page.waitForResponse(resp => resp.url().includes('/api/v1/admin/users') && resp.status() === 200)
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/api/v1/admin/users') && resp.status() === 200,
+      ),
+      page.goto('/admin/users'),
+    ])
+
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
   })
 
   test('userId column appears after username column', async ({ page }) => {
-    // Wait for table to load
-    await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible()
-
-    // Check userId column exists
-    const userIdHeader = page.getByRole('columnheader', { name: 'User ID' })
-    await expect(userIdHeader).toBeVisible()
-
-    // Verify column order: Username should come before User ID
     const headers = page.getByRole('columnheader')
     const headerTexts = await headers.allTextContents()
 
-    const usernameIndex = headerTexts.findIndex(text => text.includes('Username'))
-    const userIdIndex = headerTexts.findIndex(text => text.includes('User ID'))
+    const usernameIndex = headerTexts.findIndex((text) => text.includes('Username'))
+    const userIdIndex = headerTexts.findIndex((text) => text.includes('User ID'))
 
     expect(usernameIndex).toBeGreaterThanOrEqual(0)
-    expect(userIdIndex).toBeGreaterThan(usernameIndex)
+    expect(userIdIndex).toBe(usernameIndex + 1)
   })
 
   test('userId values are displayed in table rows', async ({ page }) => {
-    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
-
-    // Wait for at least one row to load
     const firstRow = page.getByRole('row').nth(1)
     await expect(firstRow).toBeVisible()
 
-    // Check that userId cells contain non-empty values
-    const userIdCells = page.getByRole('cell').filter({ hasText: /^[a-zA-Z0-9-]+$/ })
-    const count = await userIdCells.count()
-    expect(count).toBeGreaterThan(0)
+    // The userId cell is the 2nd column (index 1). It should contain a non-empty identifier.
+    const userIdCell = firstRow.getByRole('cell').nth(1)
+    const userIdText = (await userIdCell.textContent())?.trim() ?? ''
+    expect(userIdText.length).toBeGreaterThan(0)
   })
 
-  test('copy button exists for each userId', async ({ page }) => {
-    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+  test('copy button exists for each userId row', async ({ page }) => {
+    const rowCount = await page.getByRole('row').count()
+    test.skip(rowCount <= 1, 'No data rows available to assert copy buttons')
 
-    // Wait for rows to load
-    const rows = page.getByRole('row')
-    const rowCount = await rows.count()
-
-    if (rowCount <= 1) {
-      test.skip()
-    }
-
-    // Check for copy buttons (they should have aria-label or be buttons)
-    const copyButtons = page.getByRole('button').filter({ hasText: /copy/i })
+    const copyButtons = page.getByRole('button', { name: /copy/i })
     const buttonCount = await copyButtons.count()
-
-    expect(buttonCount).toBeGreaterThan(0)
+    // At least one copy button per row body should be present.
+    expect(buttonCount).toBeGreaterThanOrEqual(rowCount - 1)
   })
 
-  test('clicking copy button copies userId to clipboard', async ({ page }) => {
-    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
-
-    // Find first copy button in the table
+  test('clicking copy button copies the row userId to clipboard', async ({ page }) => {
     const firstRow = page.getByRole('row').nth(1)
     await expect(firstRow).toBeVisible()
 
-    // Get the userId text before clicking
-    const userIdCell = firstRow.getByRole('cell').nth(1) // Assuming userId is 2nd column
-    const userIdText = await userIdCell.textContent()
+    // Extract the displayed userId from the monospace span inside the 2nd column cell.
+    const userIdSpan = firstRow.getByRole('cell').nth(1).locator('span.font-mono')
+    const expectedUserId = (await userIdSpan.textContent())?.trim() ?? ''
+    expect(expectedUserId.length).toBeGreaterThan(0)
 
-    // Click the copy button
     const copyButton = firstRow.getByRole('button', { name: /copy/i }).first()
     await copyButton.click()
 
-    // Wait for clipboard to update
-    await page.waitForTimeout(100)
+    // CopyButton flips its label to "Copied" once the clipboard write resolves; wait for that.
+    await expect(firstRow.getByRole('button', { name: /copied/i })).toBeVisible()
 
-    // Verify clipboard content
     const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
-    expect(clipboardText).toBeTruthy()
-    expect(clipboardText.length).toBeGreaterThan(0)
+    expect(clipboardText).toBe(expectedUserId)
   })
 
   test('copy button shows feedback after clicking', async ({ page }) => {
-    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
-
     const firstRow = page.getByRole('row').nth(1)
     await expect(firstRow).toBeVisible()
 
     const copyButton = firstRow.getByRole('button', { name: /copy/i }).first()
     await copyButton.click()
 
-    // Check for "Copied" feedback
-    await expect(page.getByText(/copied/i)).toBeVisible({ timeout: 2000 })
+    await expect(firstRow.getByRole('button', { name: /copied/i })).toBeVisible()
   })
 
-  test('userId column persists after search/filter', async ({ page }) => {
+  test('userId column persists after triggering a search', async ({ page }) => {
+    const searchInput = page.getByLabel('Search users')
+    await expect(searchInput).toBeVisible()
+
+    // Trigger the actual search by clicking the Search button and wait for the API response,
+    // rather than relying on debounced input.
+    await searchInput.fill('admin')
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/api/v1/admin/users') && resp.status() === 200,
+      ),
+      page.getByRole('button', { name: 'Search', exact: true }).click(),
+    ])
+
     await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
+  })
 
-    // Perform a search if search input exists
-    const searchInput = page.getByPlaceholder(/search/i).first()
-    if (await searchInput.isVisible()) {
-      await searchInput.fill('test')
-      await page.waitForTimeout(500)
-    }
+  test('userId column persists after applying a status filter', async ({ page }) => {
+    // Open the status filter Select and pick "Active". This exercises the filter path that the
+    // previous test version skipped entirely.
+    await page.getByLabel('Status filter').click()
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/api/v1/admin/users') && resp.status() === 200,
+      ),
+      page.getByRole('option', { name: 'Active' }).click(),
+    ])
 
-    // Verify userId column still exists
     await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
   })
 
   test('userId column persists across pagination', async ({ page }) => {
-    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
-
-    // Check if pagination exists
     const nextButton = page.getByRole('button', { name: /next/i })
+    const isReachable = (await nextButton.isVisible()) && (await nextButton.isEnabled())
+    test.skip(!isReachable, 'Pagination not reachable with current data set')
 
-    if (await nextButton.isVisible() && await nextButton.isEnabled()) {
-      await nextButton.click()
-      await page.waitForTimeout(500)
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/api/v1/admin/users') && resp.status() === 200,
+      ),
+      nextButton.click(),
+    ])
 
-      // Verify userId column still exists on next page
-      await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
-    } else {
-      test.skip()
-    }
+    await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible()
   })
 })

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -564,6 +564,7 @@
     "filterDisabled": "Disabled",
     "empty": "No user data",
     "colUsername": "Username",
+    "colUserId": "User ID",
     "colEmail": "Email",
     "colStatus": "Status",
     "colRole": "Role",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -565,6 +565,7 @@
     "empty": "No user data",
     "colUsername": "Username",
     "colUserId": "User ID",
+    "copyUserId": "Copy user ID for {{username}}",
     "colEmail": "Email",
     "colStatus": "Status",
     "colRole": "Role",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -564,6 +564,7 @@
     "filterDisabled": "已禁用",
     "empty": "暂无用户数据",
     "colUsername": "用户名",
+    "colUserId": "用户 ID",
     "colEmail": "邮箱",
     "colStatus": "状态",
     "colRole": "角色",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -565,6 +565,7 @@
     "empty": "暂无用户数据",
     "colUsername": "用户名",
     "colUserId": "用户 ID",
+    "copyUserId": "复制 {{username}} 的用户 ID",
     "colEmail": "邮箱",
     "colStatus": "状态",
     "colRole": "角色",

--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -29,6 +29,7 @@ import {
   DialogTitle,
 } from '@/shared/ui/dialog'
 import { Label } from '@/shared/ui/label'
+import { CopyButton } from '@/shared/components/copy-button'
 import {
   useAdminUsers,
   useApproveUser,
@@ -213,6 +214,7 @@ export function AdminUsersPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>{t('adminUsers.colUsername')}</TableHead>
+                  <TableHead>{t('adminUsers.colUserId')}</TableHead>
                   <TableHead>{t('adminUsers.colEmail')}</TableHead>
                   <TableHead>{t('adminUsers.colStatus')}</TableHead>
                   <TableHead>{t('adminUsers.colRole')}</TableHead>
@@ -224,6 +226,12 @@ export function AdminUsersPage() {
                 {data.items.map((user) => (
                   <TableRow key={user.userId}>
                     <TableCell className="font-medium">{user.username}</TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-xs text-muted-foreground">{user.userId}</span>
+                        <CopyButton text={user.userId} />
+                      </div>
+                    </TableCell>
                     <TableCell>{user.email || '-'}</TableCell>
                     <TableCell>
                       <span

--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -228,8 +228,8 @@ export function AdminUsersPage() {
                     <TableCell className="font-medium">{user.username}</TableCell>
                     <TableCell>
                       <div className="flex items-center gap-2">
-                        <span className="font-mono text-xs text-muted-foreground">{user.userId}</span>
-                        <CopyButton text={user.userId} />
+                        <span className="font-mono text-xs text-muted-foreground min-w-0 max-w-[14rem] truncate" title={user.userId}>{user.userId}</span>
+                        <CopyButton text={user.userId} ariaLabel={t('adminUsers.copyUserId', { username: user.username })} />
                       </div>
                     </TableCell>
                     <TableCell>{user.email || '-'}</TableCell>

--- a/web/src/shared/components/copy-button.tsx
+++ b/web/src/shared/components/copy-button.tsx
@@ -5,9 +5,10 @@ import { useCopyToClipboard } from '@/shared/lib/clipboard'
 interface CopyButtonProps {
   text: string
   className?: string
+  ariaLabel?: string
 }
 
-export function CopyButton({ text, className }: CopyButtonProps) {
+export function CopyButton({ text, className, ariaLabel }: CopyButtonProps) {
   const { t } = useTranslation()
   const [copied, copy] = useCopyToClipboard()
 
@@ -25,6 +26,7 @@ export function CopyButton({ text, className }: CopyButtonProps) {
       size="sm"
       onClick={handleCopy}
       className={className}
+      aria-label={ariaLabel}
     >
       {copied ? t('copyButton.copied') : t('copyButton.copy')}
     </Button>


### PR DESCRIPTION
## 概述
在用户管理列表中添加 userId 列，支持一键复制功能，方便管理员进行批量操作（如命名空间成员管理）。

## 变更内容

### 前端实现
- 在用户名列后添加 userId 列
- 集成 CopyButton 组件实现一键复制
- 使用等宽字体和弱化颜色显示 userId
- 长 userId 自动截断（max-w-[14rem]），hover 显示完整值
- 添加中英文 i18n 翻译
- CopyButton 新增 ariaLabel 属性，屏幕阅读器可区分不同行的复制按钮

### 测试覆盖
- E2E 测试: 8 个测试用例（7 passed, 1 skipped）
  - ✅ 列顺序验证（userId 紧跟 username 之后）
  - ✅ 数据显示验证（span.font-mono 精确断言）
  - ✅ 复制按钮存在性（限定到 userId cell 内）
  - ✅ 复制功能验证（剪贴板内容 === 显示的 userId）
  - ✅ 复制反馈验证（按钮文本变为 "Copied"）
  - ✅ 搜索持久性（点击 Search 按钮触发真实搜索）
  - ✅ 状态过滤持久性（切换 Active 过滤器）
  - ⏭️ 分页持久性（数据不足跳过）

## 质量门禁

- [x] `make typecheck-web` 通过 (0 errors)
- [x] `make lint-web` 通过 (0 errors, 0 warnings)
- [x] `make test-frontend` 通过 (577 tests)
- [x] E2E 测试通过 (7 passed, 1 skipped)
- [x] Server Unit Tests 通过

## 安全考虑

本次变更不涉及安全敏感内容：
- 仅展示已有的 userId 字段（只读）
- 复制功能使用浏览器 Clipboard API（用户主动触发）
- 无新增权限或数据访问逻辑

## 相关 Issue

Closes #426

## 测试说明

### 本地验证步骤
1. 启动开发环境: `make dev-all`
2. 访问 http://localhost:3000/admin/users
3. 使用 mock admin 用户: `X-Mock-User-Id: local-admin`
4. 验证 userId 列显示在用户名列之后
5. 点击复制按钮，验证 userId 已复制到剪贴板
6. 验证复制按钮显示 "Copied" 反馈
7. 使用屏幕阅读器验证复制按钮的 aria-label 包含用户名

### 回归测试范围
- 用户管理列表的其他功能（搜索、过滤、分页、角色变更）
- 表格布局和响应式设计
- 其他使用 CopyButton 的页面（新增 ariaLabel 为可选属性，不影响现有用法）