### PR TITLE
chore: remove gemini code assist auto review config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,6 +1,0 @@
-# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
-have_fun: false  # Just review the code
-code_review:
-  comment_severity_threshold: HIGH  # Reduce quantity of comments
-  pull_request_opened:
-    summary: false  # Don't summarize the PR in a separate comment


### PR DESCRIPTION
## 概述

关闭 GitHub 上的 Gemini Code Assist 自动 PR 评审，删除仓库级配置文件 `.gemini/config.yaml`。

## 变更内容

### 配置变更
- 删除 `.gemini/config.yaml`（Gemini Code Assist for GitHub 的仓库级配置）
- 删除后 PR 不再触发 Gemini 自动生成的 summary 与 review comments

### 不动的部分
- `cli/src/agents/profiles/gemini-cli.ts` 等 SkillHub CLI 内部对 `gemini-cli` 工具的检测/适配代码属于产品功能，与 PR 自动评审无关，保持不变
- `cli/README.md`、`docs/skillhub/guide/cli.md` 等文档中对 gemini-cli 的描述同上，保留

### 测试覆盖
本次仅为删除一个仓库级 GitHub App 配置文件，无代码逻辑变更，无新增/调整测试。

## 质量门禁

- [x] 无前后端代码变更，跳过 typecheck / lint / 单测 / E2E
- [x] 无 Controller 变更，跳过 `make generate-api`

## 安全考虑

本次变更不涉及安全敏感内容。删除的是第三方 GitHub App 的非敏感行为配置（review 严重度阈值、是否生成 summary），不含密钥或访问凭据。

## 相关 Issue

无关联 Issue。

## 测试说明

### 本地验证步骤
1. 确认 `.gemini/` 目录已不存在：`ls .gemini 2>/dev/null` 返回为空
2. 合并后开新 PR 验证 Gemini Code Assist 不再自动评论

### 回归测试范围
- 仅影响 GitHub PR 上 Gemini 自动评审行为；不影响 CI、构建、运行时