### PR TITLE
fix: normalize SKILL.md filename case-insensitively

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
@@ -64,6 +64,15 @@ public final class SkillPackagePolicy {
             throw new IllegalArgumentException("Package entry path must be normalized: " + rawPath);
         }
 
+        // Normalize SKILL.md basename case-insensitively
+        int lastSlash = canonical.lastIndexOf('/');
+        String fileName = lastSlash >= 0 ? canonical.substring(lastSlash + 1) : canonical;
+        if (fileName.equalsIgnoreCase(SKILL_MD_PATH)) {
+            canonical = lastSlash >= 0
+                    ? canonical.substring(0, lastSlash + 1) + SKILL_MD_PATH
+                    : SKILL_MD_PATH;
+        }
+
         return canonical;
     }
 

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
@@ -68,9 +68,7 @@ public final class SkillPackagePolicy {
         int lastSlash = canonical.lastIndexOf('/');
         String fileName = lastSlash >= 0 ? canonical.substring(lastSlash + 1) : canonical;
         if (fileName.equalsIgnoreCase(SKILL_MD_PATH)) {
-            canonical = lastSlash >= 0
-                    ? canonical.substring(0, lastSlash + 1) + SKILL_MD_PATH
-                    : SKILL_MD_PATH;
+            canonical = canonical.substring(0, lastSlash + 1) + SKILL_MD_PATH;
         }
 
         return canonical;


### PR DESCRIPTION
## Summary

Uploading a skill package whose entry file is named anything other than the exact uppercase `SKILL.md` (for example `skill.md`, `Skill.md`, or `SKILL.MD`) fails validation with:

> Missing required file: SKILL.md at root

This is a frequent papercut on macOS / Windows because their case-insensitive filesystems happily let authors save the file as `skill.md`, but the server rejects the resulting zip.

## Fix

Modified `SkillPackagePolicy.normalizeEntryPath(...)` to fold the entry basename case-insensitively to the canonical `SKILL.md`. Since both `SkillPackageValidator` and `SkillPackageArchiveExtractor` route every path through this single normalization point, all downstream `.equals(SKILL_MD_PATH)` checks now succeed.

## Changes

- `server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java` — added case-insensitive basename normalization in `normalizeEntryPath` method.

## Verification

- [x] `normalizeEntryPath("skill.md")` → `SKILL.md`
- [x] `normalizeEntryPath("Skill.md")` → `SKILL.md`
- [x] `normalizeEntryPath("subdir/skill.md")` → `subdir/SKILL.md`
- [x] `normalizeEntryPath("SKILL.md")` → `SKILL.md` (unchanged)
- [x] Other paths unchanged (e.g. `README.md` stays as-is)

Fixes #458