### PR TITLE
fix(validation): accept any-case SKILL.md filename on upload

### DIFF
--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/support/SkillPackageArchiveExtractorTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/support/SkillPackageArchiveExtractorTest.java
@@ -266,6 +266,56 @@ class SkillPackageArchiveExtractorTest {
         assertTrue(result.warnings().isEmpty());
     }
 
+    @Test
+    void canonicalizesLowercaseSkillMdAtRoot() throws Exception {
+        // Regression: a zip with lowercase skill.md at the package root should be
+        // accepted and canonicalized to SKILL.md so downstream validation matches.
+        byte[] zipBytes = createZip(Map.of(
+                "skill.md", "---\nname: test\n---\n".getBytes(),
+                "README.md", "# readme".getBytes()
+        ));
+        MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", zipBytes);
+
+        List<PackageEntry> entries = extractor.extract(file);
+
+        assertTrue(entries.stream().anyMatch(e -> e.path().equals("SKILL.md")),
+                "Expected lowercase skill.md to be canonicalized to SKILL.md");
+        assertTrue(entries.stream().noneMatch(e -> e.path().equals("skill.md")));
+    }
+
+    @Test
+    void canonicalizesMixedCaseSkillMdInSingleRootDirectory() throws Exception {
+        // my-skill/Skill.MD → root prefix stripped, basename canonicalized to SKILL.md
+        byte[] zipBytes = createZip(Map.of(
+                "my-skill/Skill.MD", "---\nname: test\n---\n".getBytes(),
+                "my-skill/config.json", "{}".getBytes()
+        ));
+        MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", zipBytes);
+
+        List<PackageEntry> entries = extractor.extract(file);
+
+        assertTrue(entries.stream().anyMatch(e -> e.path().equals("SKILL.md")));
+        assertTrue(entries.stream().anyMatch(e -> e.path().equals("config.json")));
+    }
+
+    @Test
+    void promotesSubdirectoryWhenSkillMdIsLowercase() throws Exception {
+        // Mixed-root zip: skill.md lives in a single subdirectory and must still be
+        // promoted by extractWithWarnings, with files outside that dir warned.
+        byte[] zipBytes = createZip(Map.of(
+                "my-skill/skill.md", "---\nname: test\n---\n".getBytes(),
+                "my-skill/README.md", "# readme".getBytes(),
+                "stray.txt", "outside".getBytes()
+        ));
+        MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", zipBytes);
+
+        SkillPackageArchiveExtractor.ExtractionResult result = extractor.extractWithWarnings(file);
+
+        assertTrue(result.entries().stream().anyMatch(e -> e.path().equals("SKILL.md")));
+        assertTrue(result.entries().stream().anyMatch(e -> e.path().equals("README.md")));
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("stray.txt")));
+    }
+
     private byte[] createZip(String entryName, String content) throws Exception {
         return createZip(entryName, content.getBytes(StandardCharsets.UTF_8));
     }

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackagePolicy.java
@@ -64,7 +64,25 @@ public final class SkillPackagePolicy {
             throw new IllegalArgumentException("Package entry path must be normalized: " + rawPath);
         }
 
-        return canonical;
+        return canonicalizeSkillMdFilename(canonical);
+    }
+
+    /**
+     * Folds any case variant of the SKILL.md filename ({@code skill.md}, {@code Skill.MD}, ...) to
+     * the canonical {@link #SKILL_MD_PATH}. The OpenSkills protocol specifies SKILL.md uppercase as
+     * the entry-point filename; users packaging on case-insensitive filesystems (macOS, Windows)
+     * frequently submit a lowercase variant. Canonicalizing here lets every downstream {@code
+     * .equals(SKILL_MD_PATH)} check succeed without forcing each call site to do case-insensitive
+     * comparisons.
+     */
+    static String canonicalizeSkillMdFilename(String normalizedPath) {
+        int slashIndex = normalizedPath.lastIndexOf('/');
+        String basename = (slashIndex < 0) ? normalizedPath : normalizedPath.substring(slashIndex + 1);
+        if (basename.equals(SKILL_MD_PATH) || !basename.equalsIgnoreCase(SKILL_MD_PATH)) {
+            return normalizedPath;
+        }
+        String prefix = (slashIndex < 0) ? "" : normalizedPath.substring(0, slashIndex + 1);
+        return prefix + SKILL_MD_PATH;
     }
 
     public static boolean hasAllowedExtension(String path) {

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
@@ -53,6 +53,28 @@ class SkillPackageValidatorTest {
     }
 
     @Test
+    void acceptsLowercaseSkillMdAsCanonical() {
+        // Users sometimes pack their archive with a lowercase skill.md (common on
+        // case-insensitive filesystems). Validation must treat it as the canonical entry.
+        String skillMdContent = """
+            ---
+            name: test-skill
+            description: A test skill
+            version: 1.0.0
+            ---
+            Body
+            """;
+
+        List<PackageEntry> entries = List.of(
+            new PackageEntry("skill.md", skillMdContent.getBytes(), skillMdContent.length(), "text/markdown")
+        );
+
+        ValidationResult result = validator.validate(entries);
+
+        assertTrue(result.passed(), "lowercase skill.md should validate; errors=" + result.errors());
+    }
+
+    @Test
     void testDisallowedExtension() {
         String skillMdContent = """
             ---


### PR DESCRIPTION
Closes #458.

## Summary

- Upload of a skill package with `skill.md` (lowercase, or any other case variant) previously failed with `Missing required file: SKILL.md at root`. This was a frequent papercut on macOS / Windows because their case-insensitive filesystems happily let authors save the file with non-canonical casing.
- Root cause: five call sites compare entry paths against the constant `SKILL_MD_PATH = "SKILL.md"` using case-sensitive `.equals(...)`.
- Fix: fold the basename to the canonical `SKILL.md` inside `SkillPackagePolicy.normalizeEntryPath(...)` — the single normalization point both `SkillPackageValidator` and `SkillPackageArchiveExtractor` already route every path through. Every downstream comparison then succeeds without further changes.

The OpenSkills protocol declares uppercase `SKILL.md` as the canonical filename, so accepting any case but storing the canonical form is the right semantic — not a workaround.

## Test plan

- [x] `SkillPackageArchiveExtractorTest` — 3 new regression tests: lowercase `skill.md` at root, mixed-case `Skill.MD` inside a single root directory, lowercase `skill.md` requiring directory promotion. **18/18 pass.**
- [x] `SkillPackageValidatorTest` — 1 new test covering the validator-only path (e.g., CLI dry-run that doesn't go through the extractor). **17/17 pass.**
- [x] Full sweep on `SkillPublishControllerTest`, `CliDryRunValidateTest`, `BasicPrePublishValidatorTest`, `SkillPublishServiceTest` — no regressions. **27 tests, 0 failures.**