### PR TITLE
chore: disable gemini auto review

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,2 @@
+code_review:
+  disable: true


### PR DESCRIPTION
## Summary
- Add repository-level Gemini Code Assist configuration to disable PR code review automation.

## Validation
- git diff --check
- Remote verification pending: monitor this PR for gemini-code-assist bot comments/reviews after opening.