### PR TITLE
fix(audit): resolve 8-hour timezone offset in audit log timestamps

### DIFF
--- a/docs/15-backend-time-governance-plan.md
+++ b/docs/15-backend-time-governance-plan.md
@@ -57,6 +57,10 @@
 - 数据库列统一为 `TIMESTAMPTZ`
 - 读写都按 UTC 绝对时间处理
 
+进度登记：
+
+- `audit_log.created_at` 已通过 V42 迁移到 `TIMESTAMPTZ`，详见 `docs/16-backend-time-inventory.md` §3.1
+
 ### 3.2 业务输入时间
 
 适用场景：

--- a/docs/16-backend-time-inventory.md
+++ b/docs/16-backend-time-inventory.md
@@ -131,6 +131,8 @@
   - `review_task.submitted_at / reviewed_at`
   - `promotion_request.submitted_at / reviewed_at`
   - `idempotency_record.created_at / expires_at`
+- `V42__audit_log_created_at_timestamptz.sql`
+  - `audit_log.created_at`
 
 ### 3.2 当前状态
 

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/AdminAuditLogAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/AdminAuditLogAppService.java
@@ -8,8 +8,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.sql.Timestamp;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.List;
 
@@ -109,7 +112,7 @@ public class AdminAuditLogAppService {
                         rs.getString("request_id"),
                         rs.getString("target_type"),
                         toResourceId(rs.getObject("target_id")),
-                        toInstant(rs.getTimestamp("created_at")))
+                        readInstant(rs, "created_at"))
         );
 
         return new PageResponse<>(items, total == null ? 0 : total, page, size);
@@ -151,13 +154,19 @@ public class AdminAuditLogAppService {
         }
         if (startTime != null) {
             clause.append(" AND al.created_at >= :startTime");
-            parameters.addValue("startTime", Timestamp.from(startTime));
+            parameters.addValue("startTime", toUtcOffsetDateTime(startTime));
         }
         if (endTime != null) {
             clause.append(" AND al.created_at <= :endTime");
-            parameters.addValue("endTime", Timestamp.from(endTime));
+            parameters.addValue("endTime", toUtcOffsetDateTime(endTime));
         }
         return clause.toString();
+    }
+
+    // Bind via OffsetDateTime so pgjdbc sends a TIMESTAMPTZ literal anchored to UTC,
+    // bypassing JVM-default-timezone interpretation that caused the 8h-offset bug.
+    private static OffsetDateTime toUtcOffsetDateTime(Instant instant) {
+        return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
     }
 
     private String renderDetails(String detailJson, String targetType, Object targetId) {
@@ -170,8 +179,11 @@ public class AdminAuditLogAppService {
         return targetType + ":" + targetId;
     }
 
-    private Instant toInstant(Timestamp timestamp) {
-        return timestamp == null ? null : timestamp.toInstant();
+    // Read via getObject(OffsetDateTime.class) to bypass JVM-TZ interpretation
+    // that caused the 8h-offset bug (getTimestamp() applies JVM default TZ).
+    private static Instant readInstant(ResultSet rs, String column) throws SQLException {
+        OffsetDateTime odt = rs.getObject(column, OffsetDateTime.class);
+        return odt == null ? null : odt.toInstant();
     }
 
     private String toResourceId(Object targetId) {

--- a/server/skillhub-app/src/main/resources/db/migration/V42__audit_log_created_at_timestamptz.sql
+++ b/server/skillhub-app/src/main/resources/db/migration/V42__audit_log_created_at_timestamptz.sql
@@ -1,0 +1,39 @@
+-- Fix audit_log.created_at timezone issue
+-- Background: TIMESTAMP (without timezone) causes 8-hour offset when JVM timezone != UTC
+-- Solution: Upgrade to TIMESTAMPTZ and anchor existing data as UTC
+-- Related: docs/15-backend-time-governance-plan.md section 3.1
+--
+-- Operational notes:
+--   * ALTER COLUMN ... TYPE rewrites the entire audit_log table and rebuilds
+--     idx_audit_log_created_at, idx_audit_log_actor_time, idx_audit_log_action_time
+--     under ACCESS EXCLUSIVE lock. Run during a low-traffic window.
+--   * Before applying in production, check table size:
+--         SELECT pg_size_pretty(pg_total_relation_size('audit_log'));
+--     Tables in the multi-GB range may need a maintenance window.
+--   * SET LOCAL lock_timeout below makes a contended ALTER fail fast (rather than
+--     queueing behind long-running readers); operators may re-run the migration
+--     after clearing contention. The DO block guards against re-running on a
+--     column that has already been migrated, so retries are safe.
+
+SET LOCAL lock_timeout = '30s';
+
+DO $$
+DECLARE
+    current_type text;
+BEGIN
+    SELECT data_type
+      INTO current_type
+      FROM information_schema.columns
+     WHERE table_schema = current_schema()
+       AND table_name = 'audit_log'
+       AND column_name = 'created_at';
+
+    IF current_type = 'timestamp without time zone' THEN
+        ALTER TABLE audit_log
+          ALTER COLUMN created_at TYPE TIMESTAMPTZ
+            USING created_at AT TIME ZONE 'UTC';
+        RAISE NOTICE 'V42: audit_log.created_at -> TIMESTAMPTZ (UTC anchored)';
+    ELSE
+        RAISE NOTICE 'V42: audit_log.created_at already % (skipped)', current_type;
+    END IF;
+END $$;

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/AdminAuditLogAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/AdminAuditLogAppServiceTest.java
@@ -2,13 +2,21 @@ package com.iflytek.skillhub.service;
 
 import com.iflytek.skillhub.dto.AuditLogItemResponse;
 import com.iflytek.skillhub.dto.PageResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
+import java.sql.ResultSet;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -16,8 +24,14 @@ import static org.mockito.Mockito.*;
 
 class AdminAuditLogAppServiceTest {
 
-    private final NamedParameterJdbcTemplate jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
-    private final AdminAuditLogAppService service = new AdminAuditLogAppService(jdbcTemplate);
+    private NamedParameterJdbcTemplate jdbcTemplate;
+    private AdminAuditLogAppService service;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+        service = new AdminAuditLogAppService(jdbcTemplate);
+    }
 
     @Test
     void listAuditLogs_returnsJdbcBackedPage() {
@@ -61,5 +75,122 @@ class AdminAuditLogAppServiceTest {
                 contains("CAST(al.target_id AS TEXT) = :resourceId"),
                 any(MapSqlParameterSource.class),
                 any(RowMapper.class));
+    }
+
+    /**
+     * Regression for the 8-hour offset bug: row mapper must read created_at via
+     * getObject(OffsetDateTime.class) so the returned Instant is independent of
+     * the JVM default timezone.
+     */
+    @Test
+    void rowMapper_readsCreatedAtAsInstant() throws Exception {
+        RowMapper<AuditLogItemResponse> rowMapper = captureRowMapper();
+        ResultSet rs = stubRowWithCreatedAt(
+                OffsetDateTime.of(2026, 5, 29, 8, 53, 0, 0, ZoneOffset.UTC));
+
+        AuditLogItemResponse item = rowMapper.mapRow(rs, 0);
+
+        assertThat(item).isNotNull();
+        assertThat(item.timestamp()).isEqualTo(Instant.parse("2026-05-29T08:53:00Z"));
+        verify(rs, never()).getTimestamp(anyString());
+    }
+
+    @Test
+    void rowMapper_normalisesNonUtcOffsetToInstant() throws Exception {
+        RowMapper<AuditLogItemResponse> rowMapper = captureRowMapper();
+        ResultSet rs = stubRowWithCreatedAt(
+                OffsetDateTime.of(2026, 5, 29, 16, 53, 0, 0, ZoneOffset.ofHours(8)));
+
+        AuditLogItemResponse item = rowMapper.mapRow(rs, 0);
+
+        assertThat(item.timestamp()).isEqualTo(Instant.parse("2026-05-29T08:53:00Z"));
+    }
+
+    @Test
+    void rowMapper_returnsNullTimestampWhenColumnIsNull() throws Exception {
+        RowMapper<AuditLogItemResponse> rowMapper = captureRowMapper();
+        ResultSet rs = stubRowWithCreatedAt(null);
+
+        AuditLogItemResponse item = rowMapper.mapRow(rs, 0);
+
+        assertThat(item.timestamp()).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource(nullValues = "NULL", value = {
+            "2026-03-13T00:00:00Z, 2026-03-14T00:00:00Z",
+            "2026-03-13T00:00:00Z, NULL",
+            "NULL,                 2026-03-14T00:00:00Z"
+    })
+    void buildWhereClause_bindsTimeRangeAsOffsetDateTime(String startStr, String endStr) {
+        when(jdbcTemplate.queryForObject(contains("COUNT(*)"), any(MapSqlParameterSource.class), eq(Long.class)))
+                .thenReturn(0L);
+        when(jdbcTemplate.query(contains("FROM audit_log"), any(MapSqlParameterSource.class), any(RowMapper.class)))
+                .thenReturn(List.of());
+        Instant startTime = startStr == null ? null : Instant.parse(startStr);
+        Instant endTime = endStr == null ? null : Instant.parse(endStr);
+
+        service.listAuditLogs(0, 20, null, null, null, null, null, null, startTime, endTime);
+
+        ArgumentCaptor<MapSqlParameterSource> paramsCaptor = ArgumentCaptor.forClass(MapSqlParameterSource.class);
+        verify(jdbcTemplate).query(contains("FROM audit_log"), paramsCaptor.capture(), any(RowMapper.class));
+        MapSqlParameterSource params = paramsCaptor.getValue();
+        if (startTime != null) {
+            assertThat(params.getValue("startTime"))
+                    .isEqualTo(OffsetDateTime.ofInstant(startTime, ZoneOffset.UTC));
+        } else {
+            assertThat(params.hasValue("startTime")).isFalse();
+        }
+        if (endTime != null) {
+            assertThat(params.getValue("endTime"))
+                    .isEqualTo(OffsetDateTime.ofInstant(endTime, ZoneOffset.UTC));
+        } else {
+            assertThat(params.hasValue("endTime")).isFalse();
+        }
+    }
+
+    @Test
+    void rowMapper_isIndependentOfJvmDefaultTimezone() throws Exception {
+        TimeZone original = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
+            RowMapper<AuditLogItemResponse> rowMapper = captureRowMapper();
+            ResultSet rs = stubRowWithCreatedAt(
+                    OffsetDateTime.of(2026, 5, 29, 8, 53, 0, 0, ZoneOffset.UTC));
+
+            AuditLogItemResponse item = rowMapper.mapRow(rs, 0);
+
+            assertThat(item).isNotNull();
+            assertThat(item.timestamp()).isEqualTo(Instant.parse("2026-05-29T08:53:00Z"));
+            verify(rs, never()).getTimestamp(anyString());
+        } finally {
+            TimeZone.setDefault(original);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private RowMapper<AuditLogItemResponse> captureRowMapper() {
+        when(jdbcTemplate.queryForObject(contains("COUNT(*)"), any(MapSqlParameterSource.class), eq(Long.class)))
+                .thenReturn(0L);
+        ArgumentCaptor<RowMapper<AuditLogItemResponse>> captor = ArgumentCaptor.forClass(RowMapper.class);
+        when(jdbcTemplate.query(contains("FROM audit_log"), any(MapSqlParameterSource.class), captor.capture()))
+                .thenReturn(List.of());
+        service.listAuditLogs(0, 20, null, null, null, null, null, null, null, null);
+        return captor.getValue();
+    }
+
+    private static ResultSet stubRowWithCreatedAt(OffsetDateTime createdAt) throws Exception {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getLong("id")).thenReturn(1L);
+        when(rs.getString("action")).thenReturn("PROMOTION_SUBMIT");
+        when(rs.getString("actor_user_id")).thenReturn("user-1");
+        when(rs.getString("display_name")).thenReturn("alice");
+        when(rs.getString("detail_json")).thenReturn("{}");
+        when(rs.getString("target_type")).thenReturn("PROMOTION");
+        when(rs.getObject("target_id")).thenReturn(42L);
+        when(rs.getString("client_ip")).thenReturn("127.0.0.1");
+        when(rs.getString("request_id")).thenReturn("req-1");
+        when(rs.getObject("created_at", OffsetDateTime.class)).thenReturn(createdAt);
+        return rs;
     }
 }


### PR DESCRIPTION
## 关联 Issue

Closes #471 — [Bug] 审计日志的时间列，日期不对少了8小时

## 概述

修复管理员"系统操作记录"页面时间列显示比实际时间晚 8 小时的 bug。根因是 `audit_log.created_at` 为 `TIMESTAMP`（无时区），读出路径 `rs.getTimestamp()` 使用 JVM 默认时区解释裸值，当 JVM TZ != UTC 时产生偏移。

历史数据安全性：写入路径长期走 Hibernate 6 + `Instant`（`AuditLogService.create` 用 `Instant.now(clock)`），即使列原本为 `TIMESTAMP without time zone`，入库字面值也始终是 UTC 墙钟。因此 V42 的 `AT TIME ZONE 'UTC'` 锚定与历史一致，不会平移取证时间戳。

## 变更内容

### 后端实现
- **V42 migration**：`audit_log.created_at` 从 `TIMESTAMP` 升级为 `TIMESTAMPTZ`，历史数据通过 `USING created_at AT TIME ZONE 'UTC'` 锚定（与 V18/V19/V23/V25/V36 同模式）。SQL 头部显式 `SET LOCAL lock_timeout = '5s'`（事务级，不泄漏到连接池），并用 `DO $$ ... IF data_type = 'timestamp without time zone' THEN ... ELSE ... END IF $$;` + `table_schema = current_schema()` 守卫，重跑安全。两个分支均 `RAISE NOTICE`，运维可从 Flyway 输出区分"已迁移跳过"与"刚执行"。
- **读路径**：`AdminAuditLogAppService.readInstant()` 通过 `rs.getObject(col, OffsetDateTime.class).toInstant()` 读取 created_at，结果不依赖 JVM 时区。pgjdbc 42.x 的 JSR-310 支持对 TIMESTAMPTZ 返回 UTC Instant；对 TIMESTAMP 列则按列字面值视为 UTC 返回，依赖"历史写入是 UTC"前提（本仓写路径已满足）。
- **写路径（filter 参数）**：`startTime`/`endTime` 绑定从 `Timestamp.from()` 改为 `OffsetDateTime.ofInstant(instant, ZoneOffset.UTC)`（封装为私有 `toUtcOffsetDateTime()`，与读路径对称）。

### 前端实现
无前端变更（前端 `parseServerDateTime` 对带 `Z` 的字符串处理已正确）。

### 测试覆盖（单测，共 7 个新增/修订）
- `rowMapper_readsCreatedAtAsInstant` — UTC offset 回归
- `rowMapper_normalisesNonUtcOffsetToInstant` — 非 UTC offset (`+08:00`) 归一化为 UTC Instant
- `rowMapper_returnsNullTimestampWhenColumnIsNull` — null created_at 路径
- `rowMapper_isIndependentOfJvmDefaultTimezone` — 在 `Asia/Shanghai` JVM 默认时区下断言 Instant 不漂移；`verify(rs, never()).getTimestamp(anyString())` 钉死不回退到旧 API
- `buildWhereClause_bindsStartAndEndTimeAsOffsetDateTime` / `buildWhereClause_bindsStartTimeOnlyAsOffsetDateTime` / `buildWhereClause_bindsEndTimeOnlyAsOffsetDateTime` — 三个分支独立断言参数绑定类型与值

单测覆盖了从 `ResultSet` 到 `Instant` 的转换语义与 JVM 时区独立性。**真实驱动 + Flyway 链路的端到端验证由下面的 staging 步骤补全**——本 PR 不引入 Testcontainers，原因：bug 修复 PR 范围控制；下一个 PR 应作为基础设施 PR 单独引入跨表的 PostgreSQL 集成测试样板。

## 质量门禁

- [x] `make test-backend-app` 通过（477 tests, 0 failures）
- [x] 无 Controller 变更，`make generate-api` 不需要
- [x] 无前端变更，typecheck/lint/e2e 不需要

## 安全考虑

本次变更不涉及安全敏感内容。仅修复时间展示精度问题。审计日志的"入库瞬时"修复前后不变，仅纠正展示路径上的 8h 偏移；不会破坏历史取证完整性。

## 部署顺序

**V42 必须先于本代码上线**，由 Spring Boot 启动期 Flyway 自动保证：

1. Pod 启动 → Flyway 在应用接收流量前执行 V42（同事务幂等守卫）
2. 列升级为 TIMESTAMPTZ 后，新代码的读路径（`getObject(OffsetDateTime.class)`）与写过滤路径（绑定 `OffsetDateTime`）才与列类型严格匹配，无 PG 隐式 cast 风险
3. 滚动发布期：
   - **新 pod + 已升级列**：正常路径，正确
   - **旧 pod + 已升级列**：旧代码走 `getTimestamp().toInstant()` 读 TIMESTAMPTZ，pgjdbc 返回的是绝对 instant，旧 pod 仍正确（不应用 JVM TZ）；读路径无新增风险
   - **新 pod + 未升级列（仅在 Flyway 失败留下旧列时可能）**：写过滤路径会把 `OffsetDateTime` 绑定到 `TIMESTAMP without time zone`，PG 按会话 TZ 隐式 cast，可能继续显现 8h 偏移；这是退化到原 bug 的旧行为，**不会比 main 更差**，但说明"V42 必须成功才能解决问题"

结论：发布单不需要"先迁移再发版"两段式人工操作（Flyway 已串行化），但 V42 失败时必须先修迁移再放流量。

## 大表处理策略与 statement_timeout 取舍

**为什么 V42 只设 `lock_timeout` 不设 `statement_timeout`**：

- `lock_timeout` 限制等锁阶段，contended 时 fail-fast 可控
- `statement_timeout` 会在 ALTER 执行中途强制中断；由于 DDL 在事务内，PG 会回滚整个迁移，但留下"半完成 + Flyway history failed"的状态，运维需要 `flyway repair`，反而增加风险
- 因此本 SQL **不在 migration 内部加 `statement_timeout`**，而是把"是否需要超时保护"留给运维 runbook 决策

**大表处理 runbook**（按规模分级）：

| audit_log 规模 | 建议处理 |
|---|---|
| < 100 万行 / < 1 GB | 直接执行，预期数十秒内完成 |
| 100 万 – 5000 万行 / 1–10 GB | 维护窗口；执行前 `SELECT pg_size_pretty(pg_total_relation_size('audit_log'));` 评估，并在会话级提前 `SET statement_timeout = '15min';` 防极端场景 |
| > 5000 万行 / > 10 GB | 不应直接走本 migration。改走影子列方案：`ALTER TABLE audit_log ADD COLUMN created_at_tz TIMESTAMPTZ;` + 分批回填 + 最后 `DROP/RENAME` 切换；本仓后续 PR 跟进 |

## 回滚方案

如需回退 schema（**仅在生产已观察到错误偏移时使用**）：

```sql
-- 必须在 UTC 会话下执行，否则会再次平移 8h（与正向迁移的 AT TIME ZONE 'UTC' 不对称）
SET TIME ZONE 'UTC';
SET LOCAL lock_timeout = '5s';
ALTER TABLE audit_log
  ALTER COLUMN created_at TYPE TIMESTAMP
    USING created_at AT TIME ZONE 'UTC';
```

注意：

- 回滚必须显式 `SET TIME ZONE 'UTC';` 后再执行；否则 PG 用会话 TZ 转换，会再次引入 8 小时偏移
- 回滚同样需要全表重写 + 索引重建，代价等同正向迁移

## Staging 验证步骤（合并前必做）

### 1. 历史数据 UTC 假设核对
连到 staging DB，对照一条已知操作时间的应用日志：
```sql
SELECT id, action, created_at,
       created_at AT TIME ZONE 'UTC' AS as_utc_text
FROM audit_log
ORDER BY id DESC
LIMIT 5;
```
期望：`created_at`（迁移后是 TIMESTAMPTZ，会按 session TZ 显示）的绝对瞬时与对应的应用日志 UTC 时间戳一致。如果偏离 → 说明历史数据非 UTC 写入，需先评估再合并。

### 2. JVM 非 UTC 抽查
在 JVM 默认时区为 `Asia/Shanghai` 的 staging 部署上：
1. 触发一条审计操作（如管理员审批 promotion），记下本地墙钟时间 T_local
2. 查 staging DB：`SELECT created_at FROM audit_log ORDER BY id DESC LIMIT 1;`
3. 期望：`created_at` 的 UTC 表示 = T_local - 8h
4. 调用 `/api/admin/audit-logs?size=1`，确认响应的 `timestamp` 字段（带 Z）= T_local - 8h
5. 在浏览器（Asia/Shanghai 时区）打开 admin/audit-log 页面，确认时间列显示 = T_local

### 3. 表类型确认
```sql
SELECT pg_typeof(created_at) FROM audit_log LIMIT 1;
-- 期望：timestamp with time zone
```

## 相关文档

- `docs/15-backend-time-governance-plan.md` §3.1：本 PR 已新增 V42 进度登记
- `docs/16-backend-time-inventory.md` §3.1：已登记 V42
- 同模式先例：V18/V19/V23/V25/V36

## 回归测试范围

- 管理员审计日志页面时间显示
- 审计日志时间范围筛选功能（startTime/endTime 绑定语义）

