### PR TITLE
fix(web): allow anonymous downloads for global PUBLIC skills

### DIFF
--- a/web/src/pages/skill-detail.tsx
+++ b/web/src/pages/skill-detail.tsx
@@ -287,6 +287,11 @@ export function SkillDetailPage() {
 
   // Download a single file from the skill version
   const handleDownloadFile = () => {
+    const isAnonymousAllowed = namespace === 'global' && skill?.visibility === 'PUBLIC'
+    if (!user && !isAnonymousAllowed) {
+      requireLogin()
+      return
+    }
     if (!previewNode || !selectedVersion) return
     const cleanNamespace = namespace.startsWith('@') ? namespace.slice(1) : namespace
     const url = buildApiUrl(
@@ -302,7 +307,8 @@ export function SkillDetailPage() {
   }
 
   const handleDownload = async () => {
-    if (!user) {
+    const isAnonymousAllowed = namespace === 'global' && skill?.visibility === 'PUBLIC'
+    if (!user && !isAnonymousAllowed) {
       requireLogin()
       return
     }


### PR DESCRIPTION
## 问题

`web/src/pages/skill-detail.tsx` 中的 `handleDownload` / `handleDownloadFile` 在 `user` 未登录时无条件触发 `requireLogin()` 跳转登录页，未区分技能的 namespace 与 visibility。这导致原本应该允许匿名下载的 `global` 命名空间下 `PUBLIC` 可见性的技能也被拦截，与后端 `SkillDownloadService.isAnonymousDownloadAllowed` 的规则不一致。

## 修复

在两个下载 handler 中加入匿名放行判断，仅在「非 global 命名空间」或「非 PUBLIC 可见性」时才要求登录：

```ts
const isAnonymousAllowed = namespace === 'global' && skill?.visibility === 'PUBLIC'
if (!user && !isAnonymousAllowed) {
  requireLogin()
  return
}
```

`namespace` 取自路由 `/space/$namespace/$slug` 的 `useParams`，实际值为 `'global'`（无 `@` 前缀，与后端常量 `GLOBAL_NAMESPACE_SLUG` 一致）。

## 关联

Closes iflytek/skillhub#468

## 验证

- `make typecheck-web` 通过
- `make lint-web` 通过（0 warnings）