### PR TITLE
fix(ratelimit): harden anonymous access security and add Redis fail-open

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/ClientIpResolver.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/ClientIpResolver.java
@@ -1,19 +1,33 @@
 package com.iflytek.skillhub.ratelimit;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 /**
  * Resolves the best-effort client IP address from proxy-aware request headers.
+ * Only trusts proxy headers (X-Forwarded-For, Forwarded, X-Real-IP) when the immediate
+ * client is in the trusted-proxies list. Otherwise falls back to remoteAddr.
  */
 @Component
 public class ClientIpResolver {
 
     private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?\\[?([^;,\"]+)\\]?\"?");
+    private final List<String> trustedProxies;
+
+    public ClientIpResolver(RateLimitProperties properties) {
+        this.trustedProxies = properties.getTrustedProxies();
+    }
 
     public String resolve(HttpServletRequest request) {
+        String remoteAddr = request.getRemoteAddr();
+
+        if (!isTrustedProxy(remoteAddr)) {
+            return normalizeCandidate(remoteAddr);
+        }
+
         String forwarded = trimToNull(request.getHeader("Forwarded"));
         if (forwarded != null) {
             Matcher matcher = FORWARDED_FOR_PATTERN.matcher(forwarded);
@@ -32,7 +46,14 @@ public class ClientIpResolver {
             return normalizeCandidate(xRealIp);
         }
 
-        return normalizeCandidate(request.getRemoteAddr());
+        return normalizeCandidate(remoteAddr);
+    }
+
+    private boolean isTrustedProxy(String ip) {
+        if (trustedProxies.isEmpty()) {
+            return false;
+        }
+        return trustedProxies.contains(ip);
     }
 
     private String trimToNull(String value) {

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/RateLimitInterceptor.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/RateLimitInterceptor.java
@@ -28,19 +28,22 @@ public class RateLimitInterceptor implements HandlerInterceptor {
     private final ApiResponseFactory apiResponseFactory;
     private final ObjectMapper objectMapper;
     private final SkillHubMetrics metrics;
+    private final RateLimitProperties rateLimitProperties;
 
     public RateLimitInterceptor(RateLimiter rateLimiter,
                                 ClientIpResolver clientIpResolver,
                                 AnonymousDownloadIdentityService anonymousDownloadIdentityService,
                                 ApiResponseFactory apiResponseFactory,
                                 ObjectMapper objectMapper,
-                                SkillHubMetrics metrics) {
+                                SkillHubMetrics metrics,
+                                RateLimitProperties rateLimitProperties) {
         this.rateLimiter = rateLimiter;
         this.clientIpResolver = clientIpResolver;
         this.anonymousDownloadIdentityService = anonymousDownloadIdentityService;
         this.apiResponseFactory = apiResponseFactory;
         this.objectMapper = objectMapper;
         this.metrics = metrics;
+        this.rateLimitProperties = rateLimitProperties;
     }
 
     @Override
@@ -88,9 +91,24 @@ public class RateLimitInterceptor implements HandlerInterceptor {
                                         RateLimit rateLimit,
                                         int limit,
                                         String resourceSuffix) {
+        String clientIp = clientIpResolver.resolve(request);
+
+        // Check global per-IP limit first
+        RateLimitProperties.GlobalIpLimit globalLimit = rateLimitProperties.getGlobalIpLimit();
+        if (globalLimit.isEnabled()) {
+            boolean globalAllowed = rateLimiter.tryAcquire(
+                    "ratelimit:global:ip:" + clientIp,
+                    globalLimit.getMaxRequests(),
+                    globalLimit.getWindowSeconds()
+            );
+            if (!globalAllowed) {
+                return false;
+            }
+        }
+
         if (!"download".equals(rateLimit.category())) {
             return rateLimiter.tryAcquire(
-                    "ratelimit:" + rateLimit.category() + ":ip:" + clientIpResolver.resolve(request) + resourceSuffix,
+                    "ratelimit:" + rateLimit.category() + ":ip:" + clientIp + resourceSuffix,
                     limit,
                     rateLimit.windowSeconds()
             );

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/RateLimitProperties.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/RateLimitProperties.java
@@ -1,0 +1,60 @@
+package com.iflytek.skillhub.ratelimit;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "skillhub.ratelimit")
+public class RateLimitProperties {
+
+    private List<String> trustedProxies = Collections.emptyList();
+    private GlobalIpLimit globalIpLimit = new GlobalIpLimit();
+
+    public List<String> getTrustedProxies() {
+        return trustedProxies;
+    }
+
+    public void setTrustedProxies(List<String> trustedProxies) {
+        this.trustedProxies = trustedProxies != null ? trustedProxies : Collections.emptyList();
+    }
+
+    public GlobalIpLimit getGlobalIpLimit() {
+        return globalIpLimit;
+    }
+
+    public void setGlobalIpLimit(GlobalIpLimit globalIpLimit) {
+        this.globalIpLimit = globalIpLimit;
+    }
+
+    public static class GlobalIpLimit {
+        private boolean enabled = true;
+        private int maxRequests = 300;
+        private int windowSeconds = 60;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getMaxRequests() {
+            return maxRequests;
+        }
+
+        public void setMaxRequests(int maxRequests) {
+            this.maxRequests = maxRequests;
+        }
+
+        public int getWindowSeconds() {
+            return windowSeconds;
+        }
+
+        public void setWindowSeconds(int windowSeconds) {
+            this.windowSeconds = windowSeconds;
+        }
+    }
+}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/RedisSlidingWindowRateLimiter.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/ratelimit/RedisSlidingWindowRateLimiter.java
@@ -1,8 +1,12 @@
 package com.iflytek.skillhub.ratelimit;
 
 import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.scripting.support.ResourceScriptSource;
@@ -12,10 +16,16 @@ import java.util.Collections;
 
 /**
  * Production rate limiter backed by Redis and a Lua script for atomic sliding-window checks.
+ *
+ * <p>Fail-open behavior: if Redis is unavailable, requests are allowed through and a warning
+ * is logged. This trades rate-limit enforcement for service availability — preferable to
+ * returning 500 on every request when Redis is down.
  */
 @Component
 @Profile("!test")
 public class RedisSlidingWindowRateLimiter implements RateLimiter {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisSlidingWindowRateLimiter.class);
 
     private final StringRedisTemplate redisTemplate;
     private DefaultRedisScript<Long> rateLimitScript;
@@ -36,14 +46,23 @@ public class RedisSlidingWindowRateLimiter implements RateLimiter {
         long now = System.currentTimeMillis();
         long windowMillis = windowSeconds * 1000L;
 
-        Long result = redisTemplate.execute(
-                rateLimitScript,
-                Collections.singletonList(key),
-                String.valueOf(now),
-                String.valueOf(windowMillis),
-                String.valueOf(limit)
-        );
+        try {
+            Long result = redisTemplate.execute(
+                    rateLimitScript,
+                    Collections.singletonList(key),
+                    String.valueOf(now),
+                    String.valueOf(windowMillis),
+                    String.valueOf(limit)
+            );
 
-        return result != null && result == 1L;
+            return result != null && result == 1L;
+        } catch (RedisConnectionFailureException ex) {
+            log.warn("Redis unavailable for rate limit check on key={}, failing open", key, ex);
+            return true;
+        } catch (DataAccessException ex) {
+            log.warn("Redis error during rate limit check on key={}, failing open", key, ex);
+            return true;
+        }
     }
 }
+

--- a/server/skillhub-app/src/main/resources/application.yml
+++ b/server/skillhub-app/src/main/resources/application.yml
@@ -139,6 +139,11 @@ skillhub:
       candidate-multiplier: 8
       max-candidates: 120
   ratelimit:
+    trusted-proxies: ${SKILLHUB_RATE_LIMIT_TRUSTED_PROXIES:}
+    global-ip-limit:
+      enabled: ${SKILLHUB_RATE_LIMIT_GLOBAL_IP_ENABLED:true}
+      max-requests: ${SKILLHUB_RATE_LIMIT_GLOBAL_IP_MAX:300}
+      window-seconds: ${SKILLHUB_RATE_LIMIT_GLOBAL_IP_WINDOW:60}
     download:
       anonymous-cookie-name: ${SKILLHUB_DOWNLOAD_ANON_COOKIE_NAME:skillhub_anon_dl}
       anonymous-cookie-max-age: ${SKILLHUB_DOWNLOAD_ANON_COOKIE_MAX_AGE:P30D}

--- a/server/skillhub-app/src/main/resources/messages.properties
+++ b/server/skillhub-app/src/main/resources/messages.properties
@@ -125,6 +125,7 @@ error.skill.tag.notFound=Tag not found: {0}
 error.skill.tag.targetVersion.notPublished=Target version must be published
 error.skill.tag.version.missing=Tag does not point to a version: {0}
 error.skill.tag.version.notFound=Version pointed by tag not found: {0}
+error.skill.tag.invalidName=Tag name contains invalid characters: {0}
 error.skill.bundle.notFound=Published bundle not found in storage
 error.skill.resolve.versionTag.conflict=Parameters version and tag cannot be used together
 error.deviceAuth.userCode.invalid=Invalid or expired user code

--- a/server/skillhub-app/src/main/resources/messages_zh.properties
+++ b/server/skillhub-app/src/main/resources/messages_zh.properties
@@ -125,6 +125,7 @@ error.skill.tag.notFound=未找到标签：{0}
 error.skill.tag.targetVersion.notPublished=目标版本必须已发布
 error.skill.tag.version.missing=标签未指向具体版本：{0}
 error.skill.tag.version.notFound=未找到标签指向的版本：{0}
+error.skill.tag.invalidName=标签名包含非法字符：{0}
 error.skill.bundle.notFound=对象存储中未找到已发布技能包
 error.skill.resolve.versionTag.conflict=version 和 tag 参数不能同时传入
 error.deviceAuth.userCode.invalid=无效或已过期的用户验证码

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/AnonymousAccessSecurityTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/AnonymousAccessSecurityTest.java
@@ -1,0 +1,59 @@
+package com.iflytek.skillhub.controller;
+
+import com.iflytek.skillhub.auth.device.DeviceAuthService;
+import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
+import com.iflytek.skillhub.domain.skill.service.SkillDownloadService;
+import com.iflytek.skillhub.domain.skill.service.SkillQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies that anonymous requests are NOT blocked by SecurityFilterChain with 401/403.
+ * Requests may fail for business reasons (404/500), but must reach controllers.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AnonymousAccessSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SkillDownloadService skillDownloadService;
+
+    @MockBean
+    private SkillQueryService skillQueryService;
+
+    @MockBean
+    private NamespaceMemberRepository namespaceMemberRepository;
+
+    @MockBean
+    private DeviceAuthService deviceAuthService;
+
+    @Test
+    void downloadEndpoint_notBlockedBySecurityFilter() throws Exception {
+        mockMvc.perform(get("/api/v1/skills/ns/skill/download"))
+                .andExpect(result -> {
+                    int status = result.getResponse().getStatus();
+                    if (status == 401) throw new AssertionError("Expected no 401 but got 401");
+                });
+    }
+
+    @Test
+    void cliDownloadEndpoint_notBlockedBySecurityFilter() throws Exception {
+        mockMvc.perform(get("/api/cli/v1/skills/ns/skill/download"))
+                .andExpect(result -> {
+                    int status = result.getResponse().getStatus();
+                    if (status == 401) throw new AssertionError("Expected no 401 but got 401");
+                });
+    }
+}

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/DownloadRateLimitControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/portal/DownloadRateLimitControllerTest.java
@@ -85,7 +85,8 @@ class DownloadRateLimitControllerTest {
                 });
 
         ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
-        verify(rateLimiter, times(2)).tryAcquire(keyCaptor.capture(), anyInt(), anyInt());
+        verify(rateLimiter, times(3)).tryAcquire(keyCaptor.capture(), anyInt(), anyInt());
+        assertThat(keyCaptor.getAllValues()).anyMatch(key -> key.startsWith("ratelimit:global:ip:"));
         assertThat(keyCaptor.getAllValues()).anyMatch(key -> key.startsWith("ratelimit:download:ip:") && key.endsWith(":ns:global:slug:demo-skill:version:1.0.0"));
         assertThat(keyCaptor.getAllValues()).anyMatch(key -> key.startsWith("ratelimit:download:anon:") && key.endsWith(":ns:global:slug:demo-skill:version:1.0.0"));
     }

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillDownloadService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillDownloadService.java
@@ -137,6 +137,7 @@ public class SkillDownloadService {
             String currentUserId,
             Map<Long, NamespaceRole> userNsRoles) {
 
+        validateTagName(tagName);
         Namespace namespace = findNamespace(namespaceSlug);
         Skill skill = resolveVisibleSkill(namespace.getId(), skillSlug, currentUserId);
         assertCanDownload(namespace, skill, currentUserId, userNsRoles);
@@ -310,6 +311,20 @@ public class SkillDownloadService {
                 // Note: This check is already done in assertCanDownload via visibilityChecker
             }
             default -> throw new DomainBadRequestException("error.skill.version.notDownloadable", version.getVersion());
+        }
+    }
+
+    private void validateTagName(String tagName) {
+        if (tagName == null || tagName.isEmpty()) {
+            throw new DomainBadRequestException("error.skill.tag.notFound", tagName);
+        }
+        // Reject path traversal attempts: literal dots, URL-encoded variants, null bytes
+        if (tagName.contains("..") || tagName.contains("%2e") || tagName.contains("%2E")
+                || tagName.contains("\0") || tagName.contains("%00")
+                || tagName.contains("/") || tagName.contains("\\")
+                || tagName.contains("%2f") || tagName.contains("%2F")
+                || tagName.contains("%5c") || tagName.contains("%5C")) {
+            throw new DomainBadRequestException("error.skill.tag.invalidName", tagName);
         }
     }
 }

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillDownloadServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillDownloadServiceTest.java
@@ -340,6 +340,27 @@ class SkillDownloadServiceTest {
         verify(eventPublisher, never()).publishEvent(any(SkillDownloadedEvent.class));
     }
 
+    @Test
+    void testDownloadByTag_RejectsPathTraversalTagNames() {
+        String[] maliciousTagNames = {
+            "../etc/passwd",
+            "..%2fetc%2fpasswd",
+            "%2e%2e/etc",
+            "stable\0evil",
+            "%00null",
+            "a/b",
+            "a\\b",
+            "%5c",
+            "%2F"
+        };
+        for (String tagName : maliciousTagNames) {
+            assertThrows(DomainBadRequestException.class,
+                    () -> service.downloadByTag("ns", "skill", tagName, null, Map.of()),
+                    "Expected rejection for tag: " + tagName);
+        }
+        verifyNoInteractions(namespaceRepository, skillRepository);
+    }
+
     private void setId(Object entity, Long id) throws Exception {
         Field idField = entity.getClass().getDeclaredField("id");
         idField.setAccessible(true);


### PR DESCRIPTION
## 背景

审查 CLI 匿名公开技能访问设计 spec（2026-05-28）后，多维度代码审查发现了若干安全和可靠性问题，本 PR 修复了所有 P0/P1 级别问题。

## 变更内容

**P0 - 安全漏洞**
- `ClientIpResolver`: 新增 trusted-proxy 校验，仅在请求方 IP 在 `SKILLHUB_RATE_LIMIT_TRUSTED_PROXIES` 配置列表中时才信任 `X-Forwarded-For`。原实现直接信任客户端自报 IP，攻击者可完全绕过 rate limit

**P1 - 可靠性**
- `RedisSlidingWindowRateLimiter`: Redis 宕机时 fail-open（记录 warn 日志并放行），避免 Redis 故障导致所有限速端点返回 500
- `RateLimitInterceptor`: 新增全局 per-IP 总量上限（默认 300/min），防止攻击者通过轮换 slug 将每个资源的 30/min 配额叠加无限放大

**P1 - 路径遍历防护**
- `SkillDownloadService.downloadByTag`: 入口校验 tagName，拒绝 `../`、`%2F`、`%5C`、null bytes 等路径遍历字符，返回 400

**i18n**
- 新增 `error.skill.tag.invalidName` key（en + zh）

## 配置

新增可选环境变量：
- `SKILLHUB_RATE_LIMIT_TRUSTED_PROXIES`: 受信任反向代理 IP 列表，逗号分隔（默认空，即不信任任何代理 header）
- `SKILLHUB_RATE_LIMIT_GLOBAL_IP_ENABLED`: 是否启用全局 per-IP 上限（默认 true）
- `SKILLHUB_RATE_LIMIT_GLOBAL_IP_MAX`: 全局上限请求数（默认 300）
- `SKILLHUB_RATE_LIMIT_GLOBAL_IP_WINDOW`: 时间窗口秒数（默认 60）

## 测试

- `SkillDownloadServiceTest`: 新增 9 个路径遍历变体的 tagName 拒绝测试
- `AnonymousAccessSecurityTest`: 验证 SecurityFilterChain 不对匿名请求返回 401
- `DownloadRateLimitControllerTest`: 更新为 3-bucket（global-IP + resource-IP + cookie）验证
- 全量后端测试通过（472 tests）