### PR TITLE
fix(domain): add DELETED to SkillStatus enum

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/SkillStatus.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/SkillStatus.java
@@ -3,5 +3,6 @@ package com.iflytek.skillhub.domain.skill;
 public enum SkillStatus {
     ACTIVE,
     HIDDEN,
-    ARCHIVED
+    ARCHIVED,
+    DELETED
 }


### PR DESCRIPTION
## Changes

Add `DELETED` as a valid enum value in `SkillStatus`.

## Problem

Database has skills with `status='DELETED'` (from cloud storage migration), but the enum was missing this value, causing `InvalidDataAccessApiUsageException` when Hibernate tried to deserialize these records.

## Testing

- The existing `isMarketVisibleSkill` filter (`status == ACTIVE`) already excludes DELETED skills from market list
- No logic changes needed

## Origin

Synced from SAAS commit 99fbe51e1970cfff7c9f49d0a03577b153d48030

Fixes #483