### PR TITLE
fix(domain): clear skill.latest_version_id before deleting skill_version

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillGovernanceService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillGovernanceService.java
@@ -182,12 +182,15 @@ public class SkillGovernanceService {
         deleteStorageAfterCommit(skill, namespaceSlug, storageKeys);
         skillFileRepository.deleteByVersionId(version.getId());
         securityScanService.softDeleteByVersionId(version.getId());
-        skillVersionRepository.delete(version);
+        // FK 约束 fk_skill_latest_version 阻止删除 skill_version 当 skill.latest_version_id 还指向它。
+        // 必须先解开引用并 flush，让 PG 在 delete 时看不到引用。
         if (version.getId().equals(skill.getLatestVersionId())) {
             skill.setLatestVersionId(findLatestPublishedVersionId(skill.getId()));
             skill.setUpdatedBy(actorUserId);
             skillRepository.save(skill);
+            skillRepository.flush();
         }
+        skillVersionRepository.delete(version);
         auditLogService.record(
                 actorUserId,
                 "DELETE_SKILL_VERSION",

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
@@ -564,6 +564,14 @@ public class SkillPublishService {
             throw new DomainBadRequestException("error.skill.version.exists", version.getVersion());
         }
 
+        // FK 约束 fk_skill_latest_version 阻止删除 skill_version 当 skill.latest_version_id 还指向它。
+        // 必须先解开引用并 flush，让 PG 在 delete 时看不到引用。
+        if (version.getId().equals(skill.getLatestVersionId())) {
+            skill.setLatestVersionId(null);
+            skillRepository.save(skill);
+            skillRepository.flush();
+        }
+
         reviewTaskRepository.findBySkillVersionIdAndStatus(version.getId(), ReviewTaskStatus.PENDING)
                 .ifPresent(reviewTaskRepository::delete);
 
@@ -579,10 +587,6 @@ public class SkillPublishService {
         securityScanService.softDeleteByVersionId(version.getId());
         skillVersionRepository.delete(version);
         skillVersionRepository.flush();
-
-        if (version.getId().equals(skill.getLatestVersionId())) {
-            skill.setLatestVersionId(null);
-        }
     }
 
     private String resolveNamespaceSlug(Long namespaceId) {


### PR DESCRIPTION
## Changes

Clear `skill.latest_version_id` and flush BEFORE deleting the SkillVersion row in two services:
- SkillPublishService.deleteReplaceableVersionArtifacts
- SkillGovernanceService.deleteVersion

## Problem

The PG FK constraint `fk_skill_latest_version` blocks deleting a SkillVersion whenever `Skill.latest_version_id` still references it. Two services had the wrong order, causing database constraint violations.

**Reproduction scenarios:**
- Re-uploading the same version (UPLOADED -> overwritten)
- Admin deletes a draft version that happens to be skill.latest_version_id

## Solution

Move the `skill.latest_version_id` clearing logic BEFORE the delete operation and add `flush()` to ensure PG sees no live reference at delete time.

## Origin

Synced from SAAS commit 4626f0c117d9c0544c4dc1115c3aac7468f0d277

Fixes #485