### PR TITLE
fix(domain): add DELETED to SkillStatus enum

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/SkillStatus.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/SkillStatus.java
@@ -3,5 +3,6 @@ package com.iflytek.skillhub.domain.skill;
 public enum SkillStatus {
     ACTIVE,
     HIDDEN,
-    ARCHIVED
+    ARCHIVED,
+    DELETED
 }


### PR DESCRIPTION
## Problem

Database has skills with `status='DELETED'` (from cloud storage migration), but the enum was missing this value, causing `InvalidDataAccessApiUsageException` when Hibernate tried to deserialize these records.

## Solution

Add `DELETED` to the `SkillStatus` enum.

## Impact

The existing `isMarketVisibleSkill` filter (`status == ACTIVE`) already excludes DELETED skills from market list, so no logic changes needed.

## Testing

✅ Compiles successfully

## Origin

Synced from SAAS commit 99fbe51e1970cfff7c9f49d0a03577b153d48030

Fixes #483