### PR TITLE
chore(logging): include idempotency cleanup threshold

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/task/IdempotencyCleanupTask.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/task/IdempotencyCleanupTask.java
@@ -42,7 +42,7 @@ public class IdempotencyCleanupTask {
         Instant threshold = Instant.now(clock).minusSeconds(STALE_THRESHOLD_MINUTES * 60);
         int updated = idempotencyRecordRepository.markStaleAsFailed(threshold);
         if (updated > 0) {
-            logger.info("Marked {} stale processing records as failed", updated);
+            logger.info("Marked {} stale processing records as failed before threshold={}", updated, threshold);
         }
     }
 }


### PR DESCRIPTION
## Summary
- include the stale-processing cleanup threshold in the idempotency cleanup log line

## Validation
- git diff --check -- server/skillhub-app/src/main/java/com/iflytek/skillhub/task/IdempotencyCleanupTask.java
- make test-backend-app was started, then stopped at user request because this is a one-line logging change