### PR TITLE
fix: SUPER_ADMIN 无法审核自己提出的提升请求

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java
@@ -108,7 +108,7 @@ public class ReviewPermissionChecker {
             String userId,
             Set<String> platformRoles) {
         if (request.getSubmittedBy().equals(userId)) {
-            return false;
+            return platformRoles.contains("SUPER_ADMIN");
         }
         return hasPlatformReviewRole(platformRoles);
     }


### PR DESCRIPTION
## 问题描述

SUPER_ADMIN 提出的提升请求（promotion request），SUPER_ADMIN 自己无法审核批准。理论上 SUPER_ADMIN 应该拥有系统的所有权限能力，包括有资格审核自己提交的提升请求。

## 根因

`ReviewPermissionChecker.canReviewPromotion()` 中，当请求的提交者和审核者是同一人时，无条件返回 `false`，连 SUPER_ADMIN 也不放过。

而普通审核的对应方法 `canReview()` 对 SUPER_ADMIN 有豁免（`platformRoles.contains("SUPER_ADMIN")`），提升审核却缺失了这个豁免。

## 修复

将自审核检查从无条件的 `return false` 改为 `return platformRoles.contains("SUPER_ADMIN")`，与 `canReview()` 保持一致。

```diff
-            return false;
+            return platformRoles.contains("SUPER_ADMIN");
```

## 变更文件

- `server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/review/ReviewPermissionChecker.java`: 1 行

## 测试

现有测试兼容：
- `cannotReviewOwnPromotion`（SKILL_ADMIN 自审核仍被阻止）✓
- `superAdminCanReviewPromotion`（SUPER_ADMIN 审核他人仍正常）✓

新增行为：SUPER_ADMIN 现在可以审核自己提交的提升请求。

Closes #509