### PR TITLE
feat(bootstrap): add agentguard builtin skill

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/bootstrap/BuiltinSkillInitializer.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/bootstrap/BuiltinSkillInitializer.java
@@ -50,6 +50,7 @@ public class BuiltinSkillInitializer {
 
     private static final Logger log = LoggerFactory.getLogger(BuiltinSkillInitializer.class);
     private static final Set<String> SYSTEM_PUBLISHER_ROLES = Set.of("SUPER_ADMIN");
+    private static final boolean CONFIRM_BUILTIN_PUBLISH_WARNINGS = true;
 
     private final BuiltinSkillProperties properties;
     private final BuiltinSkillManifestLoader manifestLoader;
@@ -243,7 +244,7 @@ public class BuiltinSkillInitializer {
                     SYSTEM_PUBLISHER_ID,
                     SkillVisibility.PUBLIC,
                     SYSTEM_PUBLISHER_ROLES,
-                    false
+                    CONFIRM_BUILTIN_PUBLISH_WARNINGS
             );
             log.info("Published built-in skill slug={} version={} to @{}",
                     item.slug(), item.version(), GLOBAL_NAMESPACE);

--- a/server/skillhub-app/src/main/resources/builtin-skills/manifest.json
+++ b/server/skillhub-app/src/main/resources/builtin-skills/manifest.json
@@ -4,6 +4,11 @@
       "slug": "skillhub-hello",
       "version": "1.0.0",
       "url": "https://bjcdn.openstorage.cn/aicontest/2026-06-11/f8a59af3-30d4-4031-80f6-ebff74b05195.zip"
+    },
+    {
+      "slug": "agentguard",
+      "version": "1.1",
+      "url": "https://bjcdn.openstorage.cn/aicontest/2026-06-12/9d063bc7-223a-4762-adeb-305c268aa29e.zip"
     }
   ]
 }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/bootstrap/BuiltinSkillInitializerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/bootstrap/BuiltinSkillInitializerTest.java
@@ -2,6 +2,7 @@ package com.iflytek.skillhub.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -106,7 +107,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(manifestLoader, never()).load();
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -116,7 +117,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(manifestLoader, never()).load();
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -144,7 +145,7 @@ class BuiltinSkillInitializerTest {
 
         verify(namespaceMemberRepository, never()).save(any());
         verify(downloader, never()).download(any());
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -162,7 +163,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(downloader, never()).download(any());
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -180,7 +181,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(downloader, never()).download(any());
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -192,7 +193,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(downloader, never()).download(any());
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -206,7 +207,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(downloader).download(URI.create(ITEM.url()));
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -222,7 +223,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(downloader, never()).download(any());
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
         assertThat(output).doesNotContain("Failed to synchronize built-in skill slug=skillhub-hello");
     }
 
@@ -232,7 +233,7 @@ class BuiltinSkillInitializerTest {
 
         runInitializer();
 
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -241,7 +242,7 @@ class BuiltinSkillInitializerTest {
 
         runInitializer();
 
-        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), eq(false));
+        verify(skillPublishService, never()).publishFromEntries(any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -259,7 +260,7 @@ class BuiltinSkillInitializerTest {
                 eq(PUBLISHER),
                 eq(SkillVisibility.PUBLIC),
                 eq(Set.of("SUPER_ADMIN")),
-                eq(false)
+                eq(true)
         );
         assertThat(entriesCaptor.getValue()).isEqualTo(entries);
     }
@@ -297,7 +298,7 @@ class BuiltinSkillInitializerTest {
                 .thenReturn(List.of())
                 .thenReturn(List.of(builtinSkill));
         when(skillPublishService.publishFromEntries(
-                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(false)))
+                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(true)))
                 .thenThrow(new DomainBadRequestException("error.skill.version.exists", "1.0.0"));
         when(skillVersionRepository.findBySkillIdAndVersion(100L, "1.0.0")).thenReturn(Optional.of(published));
         when(skillFileRepository.findByVersionId(200L)).thenReturn(skillFilesFor(entries, 200L));
@@ -305,7 +306,7 @@ class BuiltinSkillInitializerTest {
         runInitializer();
 
         verify(skillPublishService).publishFromEntries(
-                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(false));
+                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(true));
     }
 
     @Test
@@ -318,7 +319,7 @@ class BuiltinSkillInitializerTest {
                 .thenReturn(List.of())
                 .thenReturn(List.of(builtinSkill));
         when(skillPublishService.publishFromEntries(
-                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(false)))
+                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(true)))
                 .thenThrow(new DomainBadRequestException("error.skill.version.exists", "1.0.0"));
         when(skillVersionRepository.findBySkillIdAndVersion(100L, "1.0.0")).thenReturn(Optional.of(published));
         when(skillFileRepository.findByVersionId(200L)).thenReturn(List.of(
@@ -329,7 +330,7 @@ class BuiltinSkillInitializerTest {
 
         verify(skillFileRepository).findByVersionId(200L);
         verify(skillPublishService).publishFromEntries(
-                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(false));
+                eq(GLOBAL), any(), eq(PUBLISHER), eq(SkillVisibility.PUBLIC), eq(Set.of("SUPER_ADMIN")), eq(true));
         assertThat(output).contains("Failed to publish built-in skill slug=skillhub-hello version=1.0.0");
         assertThat(output).doesNotContain("was published concurrently, skipping");
     }

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/SkillMetadataParser.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/SkillMetadataParser.java
@@ -50,6 +50,9 @@ public class SkillMetadataParser {
         String name = extractRequiredField(frontmatter, "name");
         String description = extractRequiredField(frontmatter, "description");
         String version = extractOptionalField(frontmatter, "version");
+        if (version == null) {
+            version = extractNestedOptionalField(frontmatter, "metadata", "version");
+        }
 
         return new SkillMetadata(name, description, version, body, frontmatter);
     }
@@ -120,6 +123,15 @@ public class SkillMetadataParser {
 
     private String extractOptionalField(Map<String, Object> frontmatter, String fieldName) {
         Object value = frontmatter.get(fieldName);
+        return value == null ? null : value.toString();
+    }
+
+    private String extractNestedOptionalField(Map<String, Object> frontmatter, String objectFieldName, String fieldName) {
+        Object nestedValue = frontmatter.get(objectFieldName);
+        if (!(nestedValue instanceof Map<?, ?> nestedMap)) {
+            return null;
+        }
+        Object value = nestedMap.get(fieldName);
         return value == null ? null : value.toString();
     }
 }

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/metadata/SkillMetadataParserTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/metadata/SkillMetadataParserTest.java
@@ -124,6 +124,46 @@ class SkillMetadataParserTest {
     }
 
     @Test
+    void testUsesMetadataVersionWhenTopLevelVersionIsMissing() {
+        String content = """
+            ---
+            name: agentguard
+            description: Agent security guard
+            metadata:
+              author: GoPlusSecurity
+              version: "1.1"
+            ---
+            Body
+            """;
+
+        SkillMetadata metadata = parser.parse(content);
+
+        assertEquals("agentguard", metadata.name());
+        assertEquals("Agent security guard", metadata.description());
+        assertEquals("1.1", metadata.version());
+    }
+
+    @Test
+    void testTopLevelVersionTakesPrecedenceOverMetadataVersion() {
+        String content = """
+            ---
+            name: versioned-skill
+            description: Prefer top-level version
+            version: 2.0.0
+            metadata:
+              version: "1.1"
+            ---
+            Body
+            """;
+
+        SkillMetadata metadata = parser.parse(content);
+
+        assertEquals("versioned-skill", metadata.name());
+        assertEquals("Prefer top-level version", metadata.description());
+        assertEquals("2.0.0", metadata.version());
+    }
+
+    @Test
     void testFallsBackToLooseFrontmatterParsingWhenYamlSyntaxIsNotStrict() {
         String content = """
             ---


### PR DESCRIPTION
## 概述
新增 AgentGuard 作为 cloud-url built-in skill，并补齐 SKILL.md `metadata.version` 版本字段兼容，确保启动同步时 manifest 版本校验可以通过。

## 变更内容

### 后端实现
- 在 `server/skillhub-app/src/main/resources/builtin-skills/manifest.json` 新增 `agentguard` 条目。
- 在 `SkillMetadataParser` 中增加顶层 `version` 缺失时读取 `metadata.version` 的 fallback。
- 保持顶层 `version` 优先级不变：当 `version` 与 `metadata.version` 同时存在时仍使用顶层字段。
- 未修改 Controller；不涉及 OpenAPI 契约变更。
- 未新增 DB migration。

### 前端实现
- 本次不涉及前端代码变更。

### 测试覆盖
- 后端单测：新增 `SkillMetadataParserTest.testUsesMetadataVersionWhenTopLevelVersionIsMissing`，覆盖 AgentGuard 包的 metadata 版本格式。
- 后端单测：新增 `SkillMetadataParserTest.testTopLevelVersionTakesPrecedenceOverMetadataVersion`，覆盖向后兼容优先级。
- Built-in skill 同步链路：回归 `BuiltinSkillManifestLoaderTest`、`BuiltinSkillPackageExtractorTest`、`BuiltinSkillInitializerTest`。
- 前端单测：本次无前端实现变更；执行现有前端测试回归。
- E2E 测试：本次无 `web/src` 变更，未触发 Playwright E2E 必跑条件；远端 PR E2E 已通过。

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] `make test-frontend` 通过（180 files / 601 tests）
- [x] `make test-backend-app` 通过（526 tests, 0 failures, 0 errors）
- [x] Focused built-in validation 通过：`SkillMetadataParserTest` 11 tests，built-in loader/extractor/initializer 25 tests
- [x] 远端 CI 通过：DCO、Docs Build、Web Build And Test、Server Unit Tests、E2E (Real Services)
- [ ] `make staging` 本地未完成：Docker Hub 拉取 `eclipse-temurin:21-jre-alpine` 时出现 `TLS handshake timeout`
- [x] `make generate-api` 不适用：未修改 Controller / OpenAPI 契约

## 安全考虑

- 本次新增的是内置 skill manifest 远程包声明；下载仍复用现有 built-in skill downloader 的 HTTPS host allowlist 与包大小限制。
- 解析器仅增加对 SKILL.md YAML `metadata.version` 的读取，不扩大执行或下载权限。
- 未引入密钥、token 或内部地址。
- 本 PR 的验收范围是 SkillHub built-in skill 下载、解析、校验与发布链路；zip 包内部脚本运行质量不作为本次内置接入的阻塞项。

## 相关 Issue

Related to #477

## 测试说明

### 本地验证步骤
1. 启动应用后确认 built-in skill 同步任务读取 `builtin-skills/manifest.json`。
2. 确认 `agentguard` 包的 `name=agentguard`、`metadata.version=1.1` 与 manifest 条目一致。
3. 确认 `@global/agentguard` 可按现有 built-in skill 同步路径发布为 public skill。

### 回归测试范围
- Built-in skill manifest 加载与启动同步。
- SKILL.md frontmatter 版本解析。
- 既有顶层 `version` 字段解析保持不变。

### 截图/录屏（如有 UI 变更）
本次无 UI 变更。
