### PR TITLE
fix(notification): avoid publish notice for promotion reviewers

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/listener/NotificationEventListener.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/listener/NotificationEventListener.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 public class NotificationEventListener {
@@ -53,7 +54,7 @@ public class NotificationEventListener {
     @TransactionalEventListener
     public void onSkillPublished(SkillPublishedEvent event) {
         skillRepository.findById(event.skillId()).ifPresent(skill -> {
-            if (!event.publisherId().equals(skill.getCreatedBy())) {
+            if (!Objects.equals(event.publisherId(), skill.getOwnerId())) {
                 return;
             }
             String title = "Skill published: " + skillDisplayName(skill);

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/listener/NotificationEventListenerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/listener/NotificationEventListenerTest.java
@@ -6,6 +6,7 @@ import com.iflytek.skillhub.domain.namespace.Namespace;
 import com.iflytek.skillhub.domain.namespace.NamespaceRepository;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillRepository;
+import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.SkillVersionRepository;
 import com.iflytek.skillhub.notification.domain.NotificationCategory;
 import com.iflytek.skillhub.notification.service.NotificationDispatcher;
@@ -43,6 +44,24 @@ class NotificationEventListenerTest {
         return skill;
     }
 
+    private Skill skill(Long id, String ownerId, String createdBy) {
+        Skill skill = new Skill(5L, "test-skill", ownerId, SkillVisibility.PUBLIC);
+        skill.setCreatedBy(createdBy);
+        skill.setDisplayName("Test Skill");
+        setId(skill, id);
+        return skill;
+    }
+
+    private void setId(Skill skill, Long id) {
+        try {
+            java.lang.reflect.Field field = Skill.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(skill, id);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
     private void mockNamespace() {
         Namespace namespace = mock(Namespace.class);
         when(namespace.getSlug()).thenReturn("demo");
@@ -51,8 +70,7 @@ class NotificationEventListenerTest {
 
     @Test
     void onSkillPublished_shouldDispatchToPublisher() throws Exception {
-        Skill skill = mockSkill(1L);
-        when(skill.getCreatedBy()).thenReturn("publisher-1");
+        Skill skill = skill(1L, "publisher-1", "publisher-1");
         when(skillRepository.findById(1L)).thenReturn(Optional.of(skill));
         mockNamespace();
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
@@ -64,9 +82,19 @@ class NotificationEventListenerTest {
     }
 
     @Test
-    void onSkillPublished_shouldSkipWhenPublisherIsNotSkillCreator() throws Exception {
-        Skill skill = mock(Skill.class);
-        when(skill.getCreatedBy()).thenReturn("submitter-1");
+    void onSkillPublished_shouldSkipWhenPublisherIsNotSkillOwner() throws Exception {
+        Skill skill = skill(1L, "submitter-1", "submitter-1");
+        when(skillRepository.findById(1L)).thenReturn(Optional.of(skill));
+
+        listener.onSkillPublished(new SkillPublishedEvent(1L, 10L, "reviewer-1"));
+
+        verifyNoInteractions(dispatcher);
+    }
+
+    @Test
+    void onSkillPublished_shouldSkipPromotedSkillCopyCreatedByReviewer() throws Exception {
+        Skill skill = skill(1L, "submitter-1", "reviewer-1");
+        skill.setSourceSkillId(99L);
         when(skillRepository.findById(1L)).thenReturn(Optional.of(skill));
 
         listener.onSkillPublished(new SkillPublishedEvent(1L, 10L, "reviewer-1"));


### PR DESCRIPTION
## What
- Change SKILL_PUBLISHED personal notification ownership from skill.createdBy to skill.ownerId.
- Add a regression test for promoted global skill copies where ownerId differs from the reviewer-created copy.

## Why
Fixes #532. Promotion reviewers should not receive publish-success notifications for skills owned by the submitter.

## How
The listener now only dispatches SKILL_PUBLISHED when the event publisher matches the skill owner. Promotion approval continues to use the existing PROMOTION_APPROVED notification for the submitter.

## Testing
- RED: `JDK_JAVA_OPTIONS="-XX:+EnableDynamicAgentLoading" ./mvnw -pl skillhub-app -am -Dtest=NotificationEventListenerTest -Dsurefire.failIfNoSpecifiedTests=false test` failed on `onSkillPublished_shouldSkipPromotedSkillCopyCreatedByReviewer` before the fix.
- GREEN: same focused command passed after the fix: 9 tests, 0 failures.
- `make test-backend-app`: 527 tests, 0 failures.
- `make typecheck-web`
- `make lint-web`
- `git diff --check HEAD~1..HEAD`
- `make staging` attempted but blocked before app startup by Docker Hub TLS handshake timeout while pulling `eclipse-temurin:21-jre-alpine`; standalone `docker pull eclipse-temurin:21-jre-alpine` reproduced the same daemon-level timeout.

## Impact
No API or schema changes. No frontend changes.