### PR TITLE
fix(cli): treat highlighted install target as selected

### DIFF
--- a/cli/src/agents/resolver.ts
+++ b/cli/src/agents/resolver.ts
@@ -160,6 +160,7 @@ function dedupeByRoot(candidates: AgentCandidate[]): AgentCandidate[] {
 
 async function selectTargetsInteractively(candidates: AgentCandidate[]): Promise<AgentCandidate[]> {
   const prompts = await import('prompts')
+  let highlightedIndex = 0
   const { selected } = await prompts.default({
     type: 'multiselect',
     name: 'selected',
@@ -167,7 +168,13 @@ async function selectTargetsInteractively(candidates: AgentCandidate[]): Promise
     choices: candidates.map(c => ({
       title: `${c.agent} (${c.rootDir})`,
       value: c
-    }))
+    })),
+    onRender: function (this: { cursor?: number }) {
+      highlightedIndex = this.cursor ?? highlightedIndex
+    },
+    format: (selectedTargets: AgentCandidate[]) => (
+      selectedTargets.length > 0 ? selectedTargets : [candidates[highlightedIndex] ?? candidates[0]!]
+    )
   })
   if (!selected || selected.length === 0) {
     throw new CliError('installation cancelled', EXIT.usage)

--- a/cli/test/unit/agents/resolver-interactive.test.ts
+++ b/cli/test/unit/agents/resolver-interactive.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type { AgentCandidate } from '../../../src/agents/types'
+
+interface PromptOptions {
+  onRender?: (this: { cursor?: number }) => void
+  format?: (selectedTargets: AgentCandidate[]) => AgentCandidate[]
+}
+
+mock.module('prompts', () => ({
+  default: (options: PromptOptions) => {
+    options.onRender?.call({ cursor: 1 })
+    return { selected: options.format?.([]) ?? [] }
+  }
+}))
+
+const { resolveInstallTargets } = await import('../../../src/agents/resolver')
+
+describe('resolveInstallTargets interactive prompt', () => {
+  test('uses the highlighted target when Enter submits an empty multiselect', async () => {
+    const detected: AgentCandidate[] = [
+      { agent: 'codex', rootDir: '/repo/.codex/skills', scope: 'project', source: 'detected' },
+      { agent: 'claude-code', rootDir: '/repo/.claude/skills', scope: 'project', source: 'detected' }
+    ]
+    const highlighted = detected[1]!
+
+    const targets = await resolveInstallTargets({
+      cwd: '/repo',
+      agents: [],
+      json: false,
+      interactive: true,
+      detected
+    })
+
+    expect(targets).toEqual([highlighted])
+  })
+})


### PR DESCRIPTION
  ## Summary

  - Treat the currently highlighted install target as selected when the interactive multiselect prompt submits an empty selection.
  - Preserve the existing explicit multiselect behavior; only empty submissions use the highlighted fallback.
  - Add a unit test covering the Enter-on-highlighted-target path.

  ## Why

  When `skillhub install` detects multiple install targets, users can move the cursor to a target and press Enter expecting that row to be confirmed. In this flow, `prompts` can return an empty selection unless the user first checks an
  item, so the CLI currently treats it as cancellation.

  Falling back to the highlighted target makes Enter behave like confirm while keeping the existing multiselect flow intact.

## Tests

- `bun test test/unit/agents/resolver-interactive.test.ts test/unit/agents/resolver.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun test`
