### PR TITLE
fix(ci): remove unsupported Python CodeQL scan

### DIFF
--- a/.github/workflows/pr-scripts.yml
+++ b/.github/workflows/pr-scripts.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/pr-tests.yml'
       - '.github/workflows/security.yml'
       - '.github/workflows/pr-scripts.yml'
+      - '**/*.py'
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,8 +50,6 @@ jobs:
             build-mode: manual
           - language: javascript-typescript
             build-mode: none
-          - language: python
-            build-mode: none
 
     steps:
       - name: Check out repository

--- a/scripts/tests/workflow-security-test.sh
+++ b/scripts/tests/workflow-security-test.sh
@@ -37,6 +37,17 @@ grep -Fq 'cd server && ./mvnw -q -DskipTests package' "$SECURITY_WORKFLOW" \
 grep -Fq 'security-events: write' "$SECURITY_WORKFLOW" \
   || fail "security workflow must grant SARIF upload permission"
 
+python_source="$(find "$REPO_ROOT" \
+  \( -path "$REPO_ROOT/.git" -o -path '*/node_modules' -o -path '*/.venv' \) -prune -o \
+  -type f -name '*.py' -print -quit)"
+if [[ -n "$python_source" ]]; then
+  grep -Fq 'language: python' "$SECURITY_WORKFLOW" \
+    || fail "security workflow must run Python CodeQL when Python source exists"
+else
+  ! grep -Fq 'language: python' "$SECURITY_WORKFLOW" \
+    || fail "security workflow must not run Python CodeQL without Python source"
+fi
+
 grep -Fq '.github/workflows/security.yml' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run when security workflow changes"
 grep -Fq '.github/workflows/pr-cli.yml' "$PR_SCRIPTS_WORKFLOW" \
@@ -45,6 +56,8 @@ grep -Fq '.github/workflows/pr-e2e.yml' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run when PR E2E workflow changes"
 grep -Fq '.github/workflows/pr-tests.yml' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run when PR Tests workflow changes"
+grep -Fq "'**/*.py'" "$PR_SCRIPTS_WORKFLOW" \
+  || fail "pr-scripts must run when Python source changes"
 grep -Fq '.env.release.example' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run when release env example changes"
 grep -Fq '.env.release.draft' "$PR_SCRIPTS_WORKFLOW" \


### PR DESCRIPTION
## 概述
修复 Security workflow 在仓库没有 Python 源码时仍运行 Python CodeQL，导致 main push 的 `CodeQL (python)` job 失败。

## 变更内容

### 后端实现
- 无后端代码变更。
- 无 DB migration。
- 无 API 契约变更。

### 前端实现
- 无前端代码变更。

### CI 实现
- 从 `.github/workflows/security.yml` 的 CodeQL matrix 中移除 `python`。
- 在 `scripts/tests/workflow-security-test.sh` 增加源码存在性断言：存在 `.py` 源码时要求 Python CodeQL；不存在时禁止配置 Python CodeQL。
- 在 `.github/workflows/pr-scripts.yml` 增加 `**/*.py` 触发路径，确保未来新增 Python 源码时会运行脚本回归并要求恢复 Python CodeQL。

### 测试覆盖
- 更新 `workflow-security-test.sh` 覆盖 CodeQL 语言矩阵与源码类型一致性。
- 更新 PR Scripts 触发范围，覆盖未来 Python 源码变更。

## 质量门禁
- [x] `bash scripts/tests/workflow-security-test.sh` 通过
- [x] `bash scripts/tests/runtime-secret-test.sh` 通过
- [x] `bash scripts/tests/validate-release-config-test.sh` 通过
- [x] `bash scripts/tests/dev-web-host-test.sh` 通过
- [x] `bash scripts/tests/publish-cli-test.sh` 通过
- [x] `git diff --check` 通过
- [x] 未运行 `make typecheck-web` / `make lint-web` / `make test-frontend`：本次无前端源码变更
- [x] 未运行 `make test-backend-app`：本次无后端 Java 变更
- [x] 未运行 Playwright E2E：本次无 UI 交互变更
- [x] 未运行 `make generate-api`：本次无 Controller/API 变更

## 安全考虑
- 本次变更只调整 CodeQL 扫描语言矩阵，不降低 Java/Kotlin 与 JavaScript/TypeScript 的 CodeQL 覆盖。
- 后续如果仓库重新加入 Python 源码，脚本测试会要求恢复 Python CodeQL，并且 Python 文件变更会触发 PR Scripts workflow。

## 相关 Issue
- Related to failed Security run: https://github.com/iflytek/skillhub/actions/runs/27663113184/job/81811363249

## 测试说明

### 本地验证步骤
1. 运行上述脚本测试。
2. 确认当前仓库没有 `.py` 源码。
3. 确认 Security workflow 的 CodeQL matrix 只包含当前仓库存在的 Java/Kotlin 与 JavaScript/TypeScript 源码语言。
4. 确认 PR Scripts workflow 会在未来 Python 源码变更时运行。

### 回归测试范围
- GitHub Actions Security workflow。
- PR Scripts workflow 中的脚本回归。
