### PR TITLE
fix(web): ISSUE-56 show security settings for local accounts

### DIFF
--- a/web/e2e/user-menu-security-settings.spec.ts
+++ b/web/e2e/user-menu-security-settings.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test, type Page } from '@playwright/test'
+import { setEnglishLocale } from './helpers/auth-fixtures'
+
+type AuthUser = {
+  userId: string
+  displayName: string
+  email: string
+  avatarUrl: string
+  oauthProvider?: string
+  platformRoles: string[]
+}
+
+function apiEnvelope(data: unknown) {
+  return {
+    code: 0,
+    msg: 'ok',
+    data,
+    timestamp: new Date().toISOString(),
+    requestId: 'user-menu-security-settings',
+  }
+}
+
+async function mockSession(page: Page, user: AuthUser) {
+  await page.route('**/api/v1/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(apiEnvelope(user)),
+    })
+  })
+
+  await page.route('**/api/web/me/namespaces', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(apiEnvelope([])),
+    })
+  })
+
+  await page.route('**/api/web/notifications/unread-count', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(apiEnvelope({ count: 0 })),
+    })
+  })
+
+  await page.route('**/api/web/notifications/sse', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: '',
+    })
+  })
+}
+
+async function openUserMenu(page: Page, displayName: string) {
+  await page.goto('/settings/security')
+  await expect(page.getByRole('heading', { name: 'Security Settings' })).toBeVisible()
+  await page.getByRole('button', { name: displayName }).click()
+  await expect(page.getByRole('menu')).toBeVisible()
+}
+
+test.describe('User menu security settings visibility', () => {
+  test.use({ baseURL: 'http://127.0.0.1:3000' })
+
+  test.beforeEach(async ({ page }) => {
+    await setEnglishLocale(page)
+  })
+
+  test('shows security settings for local password accounts', async ({ page }) => {
+    await mockSession(page, {
+      userId: 'docker-admin',
+      displayName: 'Platform Admin',
+      email: 'admin@skillhub.local',
+      avatarUrl: '',
+      oauthProvider: 'local',
+      platformRoles: ['SUPER_ADMIN'],
+    })
+
+    await openUserMenu(page, 'Platform Admin')
+
+    await expect(page.getByRole('menu').getByRole('link', { name: 'Security Settings' })).toBeVisible()
+  })
+
+  test('hides security settings for OAuth provider accounts', async ({ page }) => {
+    await mockSession(page, {
+      userId: 'oauth-admin',
+      displayName: 'OAuth Admin',
+      email: 'oauth-admin@example.com',
+      avatarUrl: '',
+      oauthProvider: 'github',
+      platformRoles: ['SUPER_ADMIN'],
+    })
+
+    await openUserMenu(page, 'OAuth Admin')
+
+    await expect(page.getByRole('menu').getByRole('link', { name: 'Security Settings' })).toHaveCount(0)
+  })
+})

--- a/web/src/shared/components/user-menu.test.ts
+++ b/web/src/shared/components/user-menu.test.ts
@@ -1,18 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import * as mod from './user-menu'
+import { canShowSecuritySettings } from './user-menu'
 
-/**
- * UserMenu is a React component that renders a hover/click dropdown menu with
- * role-based navigation links (dashboard, reviews, admin, etc.) and logout.
- * Internal helpers (hasRole, closeMenu, handleMouseEnter/Leave) and the
- * menuItemClassName constant are scoped inside the component function.
- * There are no exported pure helpers or constants to test here.
- *
- * We verify the module shape so downstream consumers break fast
- * if the export contract changes.
- */
-describe('user-menu module exports', () => {
-  it('exports the UserMenu component', () => {
-    expect(mod.UserMenu).toBeTypeOf('function')
+describe('canShowSecuritySettings', () => {
+  it('allows local password accounts to open security settings', () => {
+    expect(canShowSecuritySettings({ oauthProvider: 'local' })).toBe(true)
+  })
+
+  it('keeps security settings hidden for OAuth provider accounts', () => {
+    expect(canShowSecuritySettings({ oauthProvider: 'github' })).toBe(false)
   })
 })

--- a/web/src/shared/components/user-menu.tsx
+++ b/web/src/shared/components/user-menu.tsx
@@ -21,6 +21,10 @@ interface UserMenuProps {
   triggerClassName?: string
 }
 
+export function canShowSecuritySettings(user: Pick<User, 'oauthProvider'>) {
+  return !user.oauthProvider || user.oauthProvider === 'local'
+}
+
 export function UserMenu({ user, triggerClassName }: UserMenuProps) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
@@ -37,7 +41,7 @@ export function UserMenu({ user, triggerClassName }: UserMenuProps) {
   const isAuditor = hasRole('AUDITOR') || hasRole('SUPER_ADMIN')
   const isSuperAdmin = hasRole('SUPER_ADMIN')
   const reviewCenterVisible = canAccessReviewCenter(user.platformRoles, myNamespaces)
-  const isLocalAccount = !user.oauthProvider
+  const isLocalAccount = canShowSecuritySettings(user)
   const open = isHovered || isClickOpen
 
   const clearCloseTimer = () => {


### PR DESCRIPTION
## 概述
Restore the Security Settings entry for local password accounts whose `oauthProvider` is returned as `local`.

## 变更内容

### 后端实现
- 无后端变更。
- 无 DB migration 变更。
- 无 API 契约变更。

### 前端实现
- `UserMenu` now treats missing provider and `oauthProvider: 'local'` as local password accounts for the Security Settings link.
- OAuth provider accounts such as `github` continue to hide the Security Settings link.

### 测试覆盖
- 前端单测：`web/src/shared/components/user-menu.test.ts` 覆盖 local provider 显示与 OAuth provider 隐藏。
- E2E 测试：`web/e2e/user-menu-security-settings.spec.ts` 覆盖实际 header user menu 的 local/OAuth 可见性。

## 质量门禁

- [x] `make typecheck-web` 通过（0 errors）
- [x] `make lint-web` 通过（0 errors, 0 warnings）
- [x] Focused unit test: `cd web && pnpm exec vitest run src/shared/components/user-menu.test.ts` 通过（2/2）
- [x] Focused Playwright E2E: `cd web && pnpm exec playwright test e2e/user-menu-security-settings.spec.ts` 通过（2/2）
- [x] `make build-frontend` 通过
- [ ] `make test-frontend` full suite: blocked by existing jsdom worker startup issue in unrelated jsdom tests (`html-encoding-sniffer` CJS requiring `@exodus/bytes` ESM); run produced 584 passed tests and 3 worker startup errors.
- [ ] `make test-backend-app` 未执行（无后端变更）
- [ ] `make generate-api` 未执行（无 Controller/API 变更）

## 安全考虑
- This only restores visibility for the existing authenticated local-account password page.
- It does not change route guards, password-change API behavior, password validation, or OAuth account handling.
- OAuth provider accounts still do not see the Security Settings entry.

## 相关 Issue
Fixes ISSUE-56
Fixes #541

## 测试说明

### 本地验证步骤
1. Local account response: `/api/v1/auth/me` returns `oauthProvider: "local"` and `platformRoles: ["SUPER_ADMIN"]`.
2. Open user menu from the header.
3. Expected: `Security Settings` is visible and links to `/settings/security`.
4. OAuth response: `/api/v1/auth/me` returns `oauthProvider: "github"`.
5. Expected: `Security Settings` is hidden.

### 回归测试范围
- Header user menu settings links.
- Local password account password-change entry point.
- OAuth account menu behavior.

### 截图/录屏
- Playwright screenshots: `web/test-results/user-menu-security-setting-1511a-for-local-password-accounts-chromium/test-finished-1.png`
- Playwright screenshots: `web/test-results/user-menu-security-setting-cedcf-for-OAuth-provider-accounts-chromium/test-finished-1.png`
