### PR TITLE
fix(frontend): support nested preview links

### DIFF
--- a/web/e2e/skill-detail-relative-links.spec.ts
+++ b/web/e2e/skill-detail-relative-links.spec.ts
@@ -28,8 +28,12 @@ test.describe('Skill Detail Relative Links (Real API)', () => {
         extraFiles: [
           {
             path: 'docs/usage.md',
-            content: '# Usage\n\nThis is linked documentation.',
+            content: '# Usage\n\nThis is linked documentation.\n\n[Nested](nested.md)',
           },
+          {
+            path: 'docs/nested.md',
+            content: '# Nested\n\nSecond-level linked documentation.',
+          }
         ],
       })
 
@@ -40,6 +44,11 @@ test.describe('Skill Detail Relative Links (Real API)', () => {
       await page.getByRole('link', { name: 'Usage' }).click()
       await expect(page.getByRole('dialog')).toContainText('usage.md')
       await expect(page.getByRole('dialog')).toContainText('This is linked documentation.')
+      await expect(page.getByRole('dialog').getByRole('link', { name: 'Nested' })).toBeVisible()
+
+      await page.getByRole('dialog').getByRole('link', { name: 'Nested' }).click()
+      await expect(page.getByRole('dialog')).toContainText('nested.md')
+      await expect(page.getByRole('dialog')).toContainText('Second-level linked documentation.')
 
       await page.getByRole('button', { name: 'Close' }).click()
       await expect(page.getByRole('dialog')).toBeHidden()

--- a/web/src/features/skill/file-preview-dialog.tsx
+++ b/web/src/features/skill/file-preview-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type MouseEvent } from 'react'
 import { Copy, Check, Download, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogContent } from '@/shared/ui/dialog'
@@ -18,6 +18,7 @@ interface FilePreviewDialogProps {
   isLoading: boolean
   error: Error | null
   onDownload: () => void
+  onLinkClick?: (href: string, event: MouseEvent<HTMLAnchorElement>) => void
 }
 
 /**
@@ -33,6 +34,7 @@ export function FilePreviewDialog({
   isLoading,
   error,
   onDownload,
+  onLinkClick,
 }: FilePreviewDialogProps) {
   const { t } = useTranslation()
   // Tracks the copy animation state: idle → spinning → done
@@ -143,7 +145,7 @@ export function FilePreviewDialog({
               <Button onClick={onDownload}>{t('filePreview.downloadHint', { name: node.name })}</Button>
             </div>
           ) : content && isMarkdown ? (
-            <MarkdownRenderer content={content} />
+            <MarkdownRenderer content={content} onLinkClick={onLinkClick} />
           ) : content && shouldHighlight ? (
             <CodeRenderer code={content} language={language} />
           ) : content ? (

--- a/web/src/pages/skill-detail.test.tsx
+++ b/web/src/pages/skill-detail.test.tsx
@@ -127,8 +127,27 @@ vi.mock('@/features/skill/markdown-renderer', () => ({
 }))
 
 vi.mock('@/features/skill/file-preview-dialog', () => ({
-  FilePreviewDialog: ({ open, node }: { open: boolean; node: { path: string } | null }) => (
-    open && node ? <div role="dialog">preview:{node.path}</div> : null
+  FilePreviewDialog: ({
+    open,
+    node,
+    onLinkClick,
+  }: {
+    open: boolean
+    node: { path: string } | null
+    onLinkClick?: (href: string, event: MouseEvent<HTMLAnchorElement>) => void
+  }) => (
+    open && node
+      ? (
+          <div role="dialog">
+            preview:{node.path}
+            {onLinkClick && (
+              <a href="nested.md" onClick={(event) => onLinkClick('nested.md', event)}>
+                Nested
+              </a>
+            )}
+          </div>
+        )
+      : null
   ),
 }))
 
@@ -487,6 +506,25 @@ describe('SkillDetailPage', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Usage' }))
 
     expect(screen.getByRole('dialog').textContent).toContain('preview:docs/usage.md')
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it('resolves links inside previewed markdown files against the previewed file path', () => {
+    useSkillFilesMock.mockReturnValue({
+      data: [
+        createSkillFile('README.md'),
+        createSkillFile('docs/usage.md'),
+        createSkillFile('docs/nested.md'),
+      ],
+    })
+
+    render(<SkillDetailPage />)
+    fireEvent.click(screen.getByRole('link', { name: 'Usage' }))
+    expect(screen.getByRole('dialog').textContent).toContain('preview:docs/usage.md')
+
+    fireEvent.click(screen.getByRole('link', { name: 'Nested' }))
+
+    expect(screen.getByRole('dialog').textContent).toContain('preview:docs/nested.md')
     expect(toastMocks.error).not.toHaveBeenCalled()
   })
 

--- a/web/src/pages/skill-detail.tsx
+++ b/web/src/pages/skill-detail.tsx
@@ -300,8 +300,12 @@ export function SkillDetailPage() {
     setPreviewDialogOpen(true)
   }
 
-  const handleOverviewLinkClick = (href: string, event: MouseEvent<HTMLAnchorElement>) => {
-    const resolution = resolvePackageRelativeLink(href, documentationPath, files)
+  const handlePackageMarkdownLinkClick = (
+    href: string,
+    event: MouseEvent<HTMLAnchorElement>,
+    currentFilePath: string | null | undefined,
+  ) => {
+    const resolution = resolvePackageRelativeLink(href, currentFilePath, files)
 
     if (resolution.status === 'ignored') {
       return
@@ -316,6 +320,14 @@ export function SkillDetailPage() {
     }
 
     toast.error(t('skillDetail.packageLinkMissingTitle'), t('skillDetail.packageLinkMissingDescription'))
+  }
+
+  const handleOverviewLinkClick = (href: string, event: MouseEvent<HTMLAnchorElement>) => {
+    handlePackageMarkdownLinkClick(href, event, documentationPath)
+  }
+
+  const handlePreviewLinkClick = (href: string, event: MouseEvent<HTMLAnchorElement>) => {
+    handlePackageMarkdownLinkClick(href, event, previewNode?.path)
   }
 
   // Download a single file from the skill version
@@ -1652,6 +1664,7 @@ export function SkillDetailPage() {
         isLoading={isLoadingPreview}
         error={previewError}
         onDownload={handleDownloadFile}
+        onLinkClick={handlePreviewLinkClick}
       />
     </div>
   )


### PR DESCRIPTION
## What
- route markdown links inside previewed package files through the same package-relative resolver used by the overview
- keep resolving nested links against the currently previewed file path
- add unit and Playwright coverage for the second-level preview flow

## Why
- follow up on issue #500 comment: https://github.com/iflytek/skillhub/issues/500#issuecomment-4786363190
- first-level links were fixed, but links inside the previewed markdown dialog still fell back to native browser navigation instead of opening the next package file

## How
- extract a shared `handlePackageMarkdownLinkClick(...)` path in `SkillDetailPage`
- use `documentationPath` for overview links and `previewNode?.path` for links rendered inside `FilePreviewDialog`
- pass `onLinkClick` through `FilePreviewDialog` into `MarkdownRenderer`
- extend the existing relative-link page test and real-API Playwright test to cover `README.md -> docs/usage.md -> docs/nested.md`

## Testing
- `make typecheck-web`
- `make lint-web`
- `make test-backend-app`
- `cd web && npx -y node@20.19.0 ./node_modules/vitest/vitest.mjs run`
- `cd web && env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u all_proxy -u ALL_PROXY pnpm exec playwright test e2e/skill-detail-relative-links.spec.ts`

## Validation Notes
- `make test-frontend` still fails on the local default Node `v20.18.0` because Vitest/jsdom hits the known `html-encoding-sniffer` -> `@exodus/bytes` ESM mismatch; the full suite passes under `node@20.19.0`
- `make staging` currently fails in the web container startup path with `/docker-entrypoint.d/20-envsubst-on-templates.sh: can't open /etc/nginx/templates/default.conf.template: Operation not permitted`; this happened after backend image build and frontend static build succeeded

## Impact
- nested relative links in previewed markdown files now open the next package file instead of leaving the in-app preview flow
- external links, absolute links, and same-document anchors keep their previous behavior
