### PR TITLE
fix(auth): recover login page from stale lazy-loaded chunks after logout

### DIFF
--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -32,6 +32,9 @@ function createLazyRouteComponent<TModule extends Record<string, unknown>>(
       }
       throw error
     })
+    // Router resolution can finish before React.lazy imports the route module. Only clear the
+    // one-time reload guard after the chunk itself has loaded successfully.
+    clearDynamicImportReloadGuard()
     return { default: module[exportName] as ComponentType<Record<string, unknown>> }
   })
 
@@ -481,10 +484,6 @@ const routeTree = rootRoute.addChildren([
 export const router = createRouter({
   routeTree,
   defaultNotFoundComponent: DefaultNotFound,
-})
-
-router.subscribe('onResolved', () => {
-  clearDynamicImportReloadGuard()
 })
 
 declare module '@tanstack/react-router' {

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -4,6 +4,7 @@ import { Layout } from './layout'
 import { getCurrentUser } from '@/api/client'
 import { RoleGuard } from '@/shared/components/role-guard'
 import { createRequireAuth } from '@/shared/lib/auth-route'
+import { clearDynamicImportReloadGuard, recoverFromDynamicImportError } from '@/shared/lib/dynamic-import-recovery'
 import { normalizeSearchQuery } from '@/shared/lib/search-query'
 
 /**
@@ -25,7 +26,12 @@ function createLazyRouteComponent<TModule extends Record<string, unknown>>(
   // Lazy route modules are wrapped in a uniform suspense fallback so route transitions behave
   // consistently across public and dashboard pages.
   const LazyComponent = lazy(async () => {
-    const module = await importer()
+    const module = await importer().catch((error) => {
+      if (recoverFromDynamicImportError(error)) {
+        return new Promise<never>(() => {})
+      }
+      throw error
+    })
     return { default: module[exportName] as ComponentType<Record<string, unknown>> }
   })
 
@@ -475,6 +481,10 @@ const routeTree = rootRoute.addChildren([
 export const router = createRouter({
   routeTree,
   defaultNotFoundComponent: DefaultNotFound,
+})
+
+router.subscribe('onResolved', () => {
+  clearDynamicImportReloadGuard()
 })
 
 declare module '@tanstack/react-router' {

--- a/web/src/shared/lib/dynamic-import-recovery.test.ts
+++ b/web/src/shared/lib/dynamic-import-recovery.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearDynamicImportReloadGuard,
+  isDynamicImportFetchError,
+  recoverFromDynamicImportError,
+} from './dynamic-import-recovery'
+
+const values = new Map<string, string>()
+const reload = vi.fn()
+const sessionStorage = {
+  get length() {
+    return values.size
+  },
+  clear: vi.fn(() => values.clear()),
+  getItem: vi.fn((key: string) => values.get(key) ?? null),
+  key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+  removeItem: vi.fn((key: string) => values.delete(key)),
+  setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+} satisfies Storage
+
+describe('dynamic import recovery', () => {
+  beforeEach(() => {
+    values.clear()
+    reload.mockClear()
+    vi.stubGlobal('window', {
+      location: { reload },
+      sessionStorage,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    'Failed to fetch dynamically imported module: /assets/login.js',
+    'error loading dynamically imported module: /assets/login.js',
+    'Importing a module script failed',
+    'ChunkLoadError: Loading chunk 42 failed',
+  ])('recognizes a stale dynamic import error: %s', (message) => {
+    expect(isDynamicImportFetchError(new Error(message))).toBe(true)
+  })
+
+  it('ignores unrelated errors', () => {
+    expect(isDynamicImportFetchError(new Error('Request failed with status 500'))).toBe(false)
+  })
+
+  it('recognizes errors whose name is ChunkLoadError', () => {
+    const error = new Error('Loading chunk 42 failed')
+    error.name = 'ChunkLoadError'
+
+    expect(isDynamicImportFetchError(error)).toBe(true)
+  })
+
+  it('reloads only once while the recovery guard is active', () => {
+    const error = new Error('Failed to fetch dynamically imported module')
+
+    expect(recoverFromDynamicImportError(error)).toBe(true)
+    expect(recoverFromDynamicImportError(error)).toBe(false)
+    expect(recoverFromDynamicImportError(error)).toBe(false)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows recovery again after a dynamic import succeeds', () => {
+    const error = new Error('Failed to fetch dynamically imported module')
+
+    expect(recoverFromDynamicImportError(error)).toBe(true)
+    clearDynamicImportReloadGuard()
+    expect(recoverFromDynamicImportError(error)).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not mask the original import error when session storage is unavailable', () => {
+    vi.stubGlobal('window', {
+      location: { reload },
+      get sessionStorage() {
+        throw new DOMException('Access denied', 'SecurityError')
+      },
+    })
+
+    const error = new Error('Failed to fetch dynamically imported module')
+
+    expect(recoverFromDynamicImportError(error)).toBe(false)
+    expect(() => clearDynamicImportReloadGuard()).not.toThrow()
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/shared/lib/dynamic-import-recovery.ts
+++ b/web/src/shared/lib/dynamic-import-recovery.ts
@@ -9,7 +9,8 @@ function resolveErrorMessage(error: unknown): string {
 
 export function isDynamicImportFetchError(error: unknown): boolean {
   const message = resolveErrorMessage(error)
-  return message.includes('Failed to fetch dynamically imported module')
+  return (error instanceof Error && error.name === 'ChunkLoadError')
+    || message.includes('Failed to fetch dynamically imported module')
     || message.includes('error loading dynamically imported module')
     || message.includes('Importing a module script failed')
     || message.includes('ChunkLoadError')
@@ -20,12 +21,17 @@ export function recoverFromDynamicImportError(error: unknown): boolean {
     return false
   }
 
-  if (window.sessionStorage.getItem(RELOAD_GUARD_KEY) === '1') {
-    window.sessionStorage.removeItem(RELOAD_GUARD_KEY)
+  let sessionStorage: Storage
+  try {
+    sessionStorage = window.sessionStorage
+    if (sessionStorage.getItem(RELOAD_GUARD_KEY) === '1') {
+      return false
+    }
+    sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+  } catch {
     return false
   }
 
-  window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
   window.location.reload()
   return true
 }
@@ -34,5 +40,9 @@ export function clearDynamicImportReloadGuard(): void {
   if (typeof window === 'undefined') {
     return
   }
-  window.sessionStorage.removeItem(RELOAD_GUARD_KEY)
+  try {
+    window.sessionStorage.removeItem(RELOAD_GUARD_KEY)
+  } catch {
+    // Session storage can be unavailable in restricted browsing contexts.
+  }
 }

--- a/web/src/shared/lib/dynamic-import-recovery.ts
+++ b/web/src/shared/lib/dynamic-import-recovery.ts
@@ -1,0 +1,38 @@
+const RELOAD_GUARD_KEY = 'skillhub:dynamic-import-reload'
+
+function resolveErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error ?? '')
+}
+
+export function isDynamicImportFetchError(error: unknown): boolean {
+  const message = resolveErrorMessage(error)
+  return message.includes('Failed to fetch dynamically imported module')
+    || message.includes('error loading dynamically imported module')
+    || message.includes('Importing a module script failed')
+    || message.includes('ChunkLoadError')
+}
+
+export function recoverFromDynamicImportError(error: unknown): boolean {
+  if (typeof window === 'undefined' || !isDynamicImportFetchError(error)) {
+    return false
+  }
+
+  if (window.sessionStorage.getItem(RELOAD_GUARD_KEY) === '1') {
+    window.sessionStorage.removeItem(RELOAD_GUARD_KEY)
+    return false
+  }
+
+  window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+  window.location.reload()
+  return true
+}
+
+export function clearDynamicImportReloadGuard(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  window.sessionStorage.removeItem(RELOAD_GUARD_KEY)
+}


### PR DESCRIPTION
 ## Summary

  - Added a client-side recovery helper for stale dynamic import failures in [`web/src/shared/lib/dynamic-import-recovery.ts`](D:/公司/项目/临时项目/skillhub/web/src/shared/lib/dynamic-import-recovery.ts).
  - Updated the lazy route loader in [`web/src/app/router.tsx`](D:/公司/项目/临时项目/skillhub/web/src/app/router.tsx) to detect login-page chunk fetch failures, trigger a one-time full page reload, and clear the reload guard after
  the router resolves normally.
  - This is needed because after logout, the app navigates to the lazily loaded `/login` route. If the browser is still running an older entry chunk while the server has already deployed a new asset hash, the login chunk request can
  fail until the page is refreshed manually.

![错误截图](https://github.com/user-attachments/assets/746f9c57-3869-4ef4-ab1c-25dfd43328d7)

  ## Validation

  - [ ] Backend tests passed
  - [ ] Frontend typecheck/build passed
  - [x] OpenAPI SDK regenerated or checked when API contracts changed
  - [ ] Smoke test run when relevant

  Commands run:

  ```bash
  git diff -- web/src/app/router.tsx web/src/shared/lib/dynamic-import-recovery.ts
  git checkout -b fix-login-chunk-recovery
  git add -- web/src/app/router.tsx web/src/shared/lib/dynamic-import-recovery.ts
  git diff --cached -- web/src/app/router.tsx web/src/shared/lib/dynamic-import-recovery.ts
  git commit -m "fix(auth): recover from stale login chunks after logout"
  git push -u origin fix-login-chunk-recovery
  cmd /c pnpm typecheck
  cmd /c pnpm test -- src/shared/lib/dynamic-import-recovery.test.ts

  ## Risk

  - User-facing impact: Logout-to-login transitions should self-recover from stale asset hash mismatches instead of showing Failed to fetch dynamically imported module.
  - Deployment or migration impact: No backend, schema, or migration impact. Frontend-only runtime behavior change.
  - Rollback approach: Revert this commit or redeploy the previous frontend bundle.

  ## Notes

  - Related issue: Logout followed by navigation to /login can fail on deployed environments when lazy-loaded login chunks are stale.
  - Follow-up work: Consider tightening static asset and index.html cache strategy at the Nginx/CDN layer to reduce stale entrypoint vs chunk mismatches.
  - Docs or operator runbooks updated when behavior changed: No
  