### PR TITLE
fix(auth): prevent USER_ADMIN from downgrading SUPER_ADMIN users

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/AdminUserAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/AdminUserAppService.java
@@ -84,9 +84,9 @@ public class AdminUserAppService {
         rejectSystemAccountMutation(user);
         String normalizedRoleCode = normalizeRoleCode(roleCode);
 
-        if ("SUPER_ADMIN".equals(normalizedRoleCode)
-                && (actorPlatformRoles == null || !actorPlatformRoles.contains("SUPER_ADMIN"))) {
-            throw new DomainForbiddenException("error.admin.user.role.superAdmin.assignDenied");
+        if (isSuperAdminRoleMutation(user.getId(), normalizedRoleCode)
+                && !isSuperAdmin(actorPlatformRoles)) {
+            throw new DomainForbiddenException("error.admin.user.role.superAdmin.changeDenied");
         }
 
         userRoleBindingRepository.deleteByUserId(user.getId());
@@ -149,6 +149,18 @@ public class AdminUserAppService {
                         .sorted()
                         .toList()
         ));
+    }
+
+    private boolean isSuperAdminRoleMutation(String userId, String normalizedRoleCode) {
+        if ("SUPER_ADMIN".equals(normalizedRoleCode)) {
+            return true;
+        }
+        return userRoleBindingRepository.findByUserId(userId).stream()
+                .anyMatch(binding -> "SUPER_ADMIN".equals(binding.getRole().getCode()));
+    }
+
+    private boolean isSuperAdmin(Set<String> actorPlatformRoles) {
+        return actorPlatformRoles != null && actorPlatformRoles.contains("SUPER_ADMIN");
     }
 
     private Set<String> withDefaultUserRole(List<String> roles) {

--- a/server/skillhub-app/src/main/resources/messages.properties
+++ b/server/skillhub-app/src/main/resources/messages.properties
@@ -136,6 +136,7 @@ error.deviceAuth.deviceCode.used=Device code has already been used
 error.admin.user.notFound=User not found: {0}
 error.admin.user.role.invalid=Invalid role: {0}
 error.admin.user.role.superAdmin.assignDenied=Only SUPER_ADMIN can assign SUPER_ADMIN role
+error.admin.user.role.superAdmin.changeDenied=Only SUPER_ADMIN can change SUPER_ADMIN role
 error.admin.user.systemAccount.immutable=System accounts cannot be modified from user management
 error.admin.user.status.invalid=Invalid user status: {0}
 error.admin.user.status.unsupported=Only ACTIVE or DISABLED status can be managed here

--- a/server/skillhub-app/src/main/resources/messages_zh.properties
+++ b/server/skillhub-app/src/main/resources/messages_zh.properties
@@ -136,6 +136,7 @@ error.deviceAuth.deviceCode.used=设备验证码已被使用
 error.admin.user.notFound=用户不存在：{0}
 error.admin.user.role.invalid=无效的角色：{0}
 error.admin.user.role.superAdmin.assignDenied=只有 SUPER_ADMIN 可以分配 SUPER_ADMIN 角色
+error.admin.user.role.superAdmin.changeDenied=只有 SUPER_ADMIN 可以变更 SUPER_ADMIN 角色
 error.admin.user.systemAccount.immutable=系统账号不能在用户管理中修改
 error.admin.user.status.invalid=无效的用户状态：{0}
 error.admin.user.status.unsupported=这里只允许管理 ACTIVE 或 DISABLED 状态的用户

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/AdminUserAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/AdminUserAppServiceTest.java
@@ -90,6 +90,20 @@ class AdminUserAppServiceTest {
     }
 
     @Test
+    void updateUserRole_nonSuperAdminCannotDemoteSuperAdmin() {
+        when(userAccountRepository.findById("user-1"))
+                .thenReturn(Optional.of(user("user-1", "alice", "alice@example.com", UserStatus.ACTIVE)));
+        when(userRoleBindingRepository.findByUserId("user-1"))
+                .thenReturn(List.of(new UserRoleBinding("user-1", role("SUPER_ADMIN"))));
+
+        assertThrows(DomainForbiddenException.class,
+                () -> service.updateUserRole("user-1", "USER", Set.of("USER_ADMIN")));
+
+        verify(userRoleBindingRepository, never()).deleteByUserId(any());
+        verify(userRoleBindingRepository, never()).save(any(UserRoleBinding.class));
+    }
+
+    @Test
     void updateUserRole_rejectsSystemAccount() {
         when(userAccountRepository.findById("builtin-skill-publisher"))
                 .thenReturn(Optional.of(systemUser()));


### PR DESCRIPTION
## Summary

- Tighten admin user role mutation authorization so only `SUPER_ADMIN` can change role state involving `SUPER_ADMIN`.
- Prevent `USER_ADMIN` from downgrading or replacing an existing `SUPER_ADMIN` account with `USER` or another platform role.
- Add regression coverage to ensure rejected role mutations do not delete or rewrite existing role bindings.

This is needed because the previous backend check only blocked non-`SUPER_ADMIN` actors from assigning `SUPER_ADMIN`; it did not protect target users who already had `SUPER_ADMIN`.

Closes #562

## Validation

- [x] Backend tests passed
- [ ] Frontend typecheck/build passed
- [x] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Commands run:

```bash
make test-backend-app
```

Result:

```text
Tests run: 574, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

OpenAPI impact:

```text
No API contract changes. No SDK regeneration required.
```

Frontend impact:

```text
Backend-only authorization behavior change. Frontend typecheck/build not run.
```

Smoke test:

```text
Not run. This change is covered by backend service regression tests and does not change deployment wiring.
```

## Risk

- User-facing impact: `USER_ADMIN` can still manage ordinary users, but attempts to mutate an existing `SUPER_ADMIN` now return a forbidden error unless the actor is also `SUPER_ADMIN`.
- Deployment or migration impact: none. No schema, API contract, generated SDK, or configuration changes.
- Rollback approach: revert the role mutation guard, localized message keys, and regression test.

## Notes

- Related issue: #562
- Follow-up work: none expected.
- Docs or operator runbooks updated when behavior changed: not required; this is a backend authorization correction for an existing endpoint.