### PR TITLE
fix(scanner): pin LiteLLM for Alpine builds

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /app
 
 COPY backports/apply_1_0_2_llm_base_url_backport.py /tmp/apply_1_0_2_llm_base_url_backport.py
 
-RUN pip install --no-cache-dir "cisco-ai-skill-scanner==${SKILL_SCANNER_VERSION}" && \
+RUN pip install --no-cache-dir \
+        "cisco-ai-skill-scanner==${SKILL_SCANNER_VERSION}" \
+        "litellm==1.90.2" && \
     python /tmp/apply_1_0_2_llm_base_url_backport.py /usr/local/lib/python3.11/site-packages && \
     rm /tmp/apply_1_0_2_llm_base_url_backport.py && \
     addgroup -S app && \


### PR DESCRIPTION
## What

Pin LiteLLM to 1.90.2 in the scanner image.

## Why

cisco-ai-skill-scanner==1.0.2 declares litellm>=1.77.0. The unbounded transitive dependency recently moved to LiteLLM 1.93.0, whose Alpine installation falls back to a source build and fails because the minimal runtime image intentionally has no C/Rust toolchain.

LiteLLM 1.90.2 is the last version already proven by the scanner image build and ships a universal Python wheel, so this restores reproducible Alpine builds without adding compilers or rolling back scanner behavior.

## How

- Keep cisco-ai-skill-scanner==1.0.2
- Add the exact direct pin litellm==1.90.2
- Preserve the existing non-root runtime, health check, and package-install layer

## Validation

- bash scripts/tests/scanner-llm-base-url-test.sh — passed with a fresh --no-cache build
- Image versions: cisco-ai-skill-scanner=1.0.2, litellm=1.90.2
- python -m pip check — passed
- make test-backend-app — 574 app tests passed; all reactor modules succeeded
- make lint-web — passed
- make typecheck-web — passed
- Frontend unit tests under CI-equivalent Node 20 / pnpm 9 — 180 files, 609 tests passed
- make staging completed backend/frontend builds and reached healthy scanner/server dependencies; the local web container was blocked by an independently reproduced OrbStack read-only single-file bind-mount Operation not permitted error

## Impact

No API, scanner endpoint, backend, or frontend behavior changes. Future scanner dependency upgrades should re-evaluate this compatibility pin.
