### PR TITLE
docs(integrations): add HarnessClaw Engine skill guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,13 @@ namespace `my-space` plus skill slug `my-skill`.
 
 📖 **[Complete Hermes Agent Integration Guide →](./docs/hermes-integration-en.md)**
 
+### [HarnessClaw Engine](https://github.com/harnessclaw/harnessclaw-engine)
+
+[HarnessClaw Engine](https://github.com/harnessclaw/harnessclaw-engine) is a Go LLM programming assistant engine that exposes its capabilities over WebSocket. It loads skills from `SKILL.md` files with YAML frontmatter and parameter substitution, scanning each configured directory for `skill-name/SKILL.md` (default `~/.harnessclaw/workspace/skills/`, with earlier directories taking priority on name conflicts). Install a SkillHub package straight into that directory with the CLI's `--dir` option, no registry adapter required:
+
+```bash
+npx clawhub --dir ~/.harnessclaw/workspace/skills install my-skill
+```
 ### [AstronClaw](https://agent.xfyun.cn/astron-claw)
 
 [AstronClaw](https://agent.xfyun.cn/astron-claw) is a cloud AI assistant built on OpenClaw's core capabilities, providing 24/7 online service through enterprise platforms like WeChat Work, DingTalk, and Feishu. It features a built-in skill system with over 130 official skills. You can connect it to a self-hosted SkillHub registry to enable one-click skill installation, search repository, dialogue-based automatic installation, and even custom skills management within your organization.

--- a/README_zh.md
+++ b/README_zh.md
@@ -376,6 +376,13 @@ namespace `my-space` 和 skill slug `my-skill`。
 
 📖 **[完整 Hermes Agent 集成指南 →](./docs/hermes-integration.md)**
 
+### [HarnessClaw Engine](https://github.com/harnessclaw/harnessclaw-engine)
+
+[HarnessClaw Engine](https://github.com/harnessclaw/harnessclaw-engine) 是基于 Go 的 LLM 编程助手引擎，通过 WebSocket 协议对外提供能力。它从 `SKILL.md` 文件加载技能，支持 YAML frontmatter 与参数替换，并按配置顺序扫描各目录下的 `skill-name/SKILL.md`（默认 `~/.harnessclaw/workspace/skills/`，靠前的目录在重名时优先）。通过 SkillHub CLI 的 `--dir` 参数即可把技能包直接安装到该目录，无需新增 registry 适配器：
+
+```bash
+npx clawhub --dir ~/.harnessclaw/workspace/skills install my-skill
+```
 ### [AstronClaw](https://agent.xfyun.cn/astron-claw)
 
 [AstronClaw](https://agent.xfyun.cn/astron-claw) 是基于 OpenClaw 核心能力打造的云端 AI 助手，提供全天候在线服务，随时随地通过企业微信、钉钉、飞书等渠道提供服务。它内置了丰富的技能系统，您可以将其连接到自托管的 SkillHub 注册中心，支持技能市场一键安装、仓库搜索、对话自动安装，甚至管理和分发组织内部的自定义私有技能。


### PR DESCRIPTION
## What

Adds **HarnessClaw Engine** to the `Usage with Agent Platforms` section of `README.md` and `README_zh.md`.

## Why

[HarnessClaw Engine](https://github.com/harnessclaw/harnessclaw-engine) consumes the same skill format SkillHub publishes: it loads skills from `SKILL.md` files with YAML frontmatter and parameter substitution, scanning each configured directory for `skill-name/SKILL.md` (default `~/.harnessclaw/workspace/skills/`, earlier directories win on name conflicts).

That means a SkillHub package installs into it directly through the CLI's existing `--dir` option, with no registry adapter needed - exactly the pattern already documented for Hermes Agent. The entry is placed right after Hermes Agent so the two `--dir`-install runtimes sit together.

## Verification

Facts in the entry were checked against the engine's `README.md`, `configs/config.yaml` (skill directory resolution and priority order) and `internal/skills/` (frontmatter + argument substitution loaders). No claim about MCP support is made, since `internal/mcp/` there is currently an empty placeholder.

Docs-only change; no code paths touched.