### PR TITLE
docs(readme): add star/watch buttons and guidance to first screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 [![Java](https://img.shields.io/badge/java-21-ED8B00?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/21/)
 [![React](https://img.shields.io/badge/react-19-61DAFB?logo=react&logoColor=black)](https://react.dev)
 
+[![GitHub Stars](https://img.shields.io/github/stars/iflytek/skillhub?style=social)](https://github.com/iflytek/skillhub/stargazers)
+[![GitHub Watchers](https://img.shields.io/github/watchers/iflytek/skillhub?style=social)](https://github.com/iflytek/skillhub/watchers)
+
 </div>
 
 <div align="center">
@@ -34,6 +37,8 @@ governed place to share agent skills. Publish a skill package, push
 it to a namespace, and let others find it through search or
 install it via CLI. Built for on-premise deployment behind your
 firewall, with the same polish you'd expect from a public registry.
+
+> ⭐ If SkillHub fits your team, **star** the repo to help other teams find it, and **Watch → Custom → Releases** to get notified when a new version ships.
 
 ## Documentation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,6 +14,9 @@
 [![Java](https://img.shields.io/badge/java-21-ED8B00?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/21/)
 [![React](https://img.shields.io/badge/react-19-61DAFB?logo=react&logoColor=black)](https://react.dev)
 
+[![GitHub Stars](https://img.shields.io/github/stars/iflytek/skillhub?style=social)](https://github.com/iflytek/skillhub/stargazers)
+[![GitHub Watchers](https://img.shields.io/github/watchers/iflytek/skillhub?style=social)](https://github.com/iflytek/skillhub/watchers)
+
 </div>
 
 ---
@@ -23,6 +26,8 @@
 </div>
 
 SkillHub 是一个自托管平台，为团队提供私有的、受治理的智能体技能共享空间。发布技能包，推送到命名空间，让其他人通过搜索发现或通过 CLI 安装。专为防火墙后的本地部署而构建，提供与公共注册中心相同的精致体验。
+
+> ⭐ 如果 SkillHub 适合你的团队，欢迎 **Star** 本仓库帮助更多团队发现它；点 **Watch → Custom → Releases** 可在新版本发布时收到通知。
 
 ## 文档
 


### PR DESCRIPTION
## What

First-screen star/watch guidance for `README.md` and `README_zh.md`:

1. **Social badges** - GitHub Stars / Watchers (`style=social`) appended after the existing badge row; the row previously had docs/Discord/license/build/docker/stack badges but no star affordance at all
2. **One-line note** under the intro paragraph: why a star helps (discoverability for other teams) and how to get release notifications without inbox noise (**Watch → Custom → Releases**)

## Why

Traffic data shows healthy view volume (11.9k views / 4.4k uniques per 14d) with a low view→star conversion. The first screen never asks - this adds a light, standard ask in both languages without touching any other section.

## Notes

Deliberately scoped away from the `Usage with Agent Platforms` section so it does not overlap with #598. Docs-only.