### PR TITLE
docs: add Trendshift trending and AAIF member badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
 
 <div align="center">
 
+<a href="https://trendshift.io/repositories/24384?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-24384" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/24384" alt="iflytek%2Fskillhub | Trendshift" width="250" height="55"/></a>&nbsp;&nbsp;<a href="https://aaif.io/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.sanity.io/images/4o10fa7h/production/16dd7d8270b673d376cadca831ab3d5ea003bb89-838x203.svg" alt="AAIF Associate Member" height="55"/></a>
+
+</div>
+
+<div align="center">
+
 [English](./README.md) | [中文](./README_zh.md)
 
 </div>

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,6 +15,12 @@
 
 </div>
 
+<div align="center">
+
+<a href="https://trendshift.io/repositories/24384?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-24384" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/24384" alt="iflytek%2Fskillhub | Trendshift" width="250" height="55"/></a>&nbsp;&nbsp;<a href="https://aaif.io/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.sanity.io/images/4o10fa7h/production/16dd7d8270b673d376cadca831ab3d5ea003bb89-838x203.svg" alt="AAIF Associate Member" height="55"/></a>
+
+</div>
+
 ---
 
 <div align="center">


### PR DESCRIPTION
## What

Adds two badges to the badge section of both `README.md` and `README_zh.md`:

- **GitHub Trending (Trendshift)** — links to the repository's Trendshift page.
- **AAIF Associate Member** — links to https://aaif.io/.

Both are placed in a centered block right below the existing shields badges, sized to a matching 55px height so they align.

## Why

Surfaces the project's GitHub Trending feature and AAIF associate membership on the landing README.

## Notes

Docs-only change; no code or behavior affected.