### PR TITLE
[#618] Fix web ambient type isolation

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -9,6 +9,7 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
+    "types": [],
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
## Summary
- declare an explicit empty `compilerOptions.types` list for the web project
- prevent unrelated or partially restored `node_modules/@types/*` directories from affecting typecheck and build results
- retain imported React, Vitest, and other dependency types without enabling Vite ambient globals

Closes ISSUE-92
Closes #618

## Validation
- injected `web/node_modules/@types/skillhub_ghost_type`, then `pnpm exec tsc --noEmit` — passed
- `make typecheck-web` — passed
- `make lint-web` — passed
- `make test-frontend` under Node 20.20.0 — 181 files / 618 tests passed
- `pnpm --dir web build` — passed

Playwright was not run because this compiler-only change does not touch `web/src` or UI behavior.
