### PR TITLE
fix(auth): keep the OAuth return target through the provider callback

### DIFF
--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/SkillHubOAuth2AuthorizationRequestResolver.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/oauth/SkillHubOAuth2AuthorizationRequestResolver.java
@@ -28,15 +28,26 @@ public class SkillHubOAuth2AuthorizationRequestResolver
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
-        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request);
-        oauthLoginFlowService.rememberReturnTo(request);
-        return authorizationRequest;
+        return rememberIfAuthorizationRequest(request, delegate.resolve(request));
     }
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
-        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request, clientRegistrationId);
-        oauthLoginFlowService.rememberReturnTo(request);
+        return rememberIfAuthorizationRequest(request, delegate.resolve(request, clientRegistrationId));
+    }
+
+    /**
+     * {@code OAuth2AuthorizationRequestRedirectFilter} calls the resolver on every request in the
+     * chain, not only on authorization requests; the delegate simply answers null for the rest.
+     * Recording the return target on those calls would clear it again on the very next request —
+     * including the provider callback, which carries no {@code returnTo} and is processed by this
+     * filter before authentication succeeds. Only an actual authorization request may touch it.
+     */
+    private OAuth2AuthorizationRequest rememberIfAuthorizationRequest(
+            HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest != null) {
+            oauthLoginFlowService.rememberReturnTo(request);
+        }
         return authorizationRequest;
     }
 }

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuth2AuthorizationRequestResolverTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuth2AuthorizationRequestResolverTest.java
@@ -55,6 +55,25 @@ class OAuth2AuthorizationRequestResolverTest {
     }
 
     @Test
+    void resolve_keepsReturnToOnNonAuthorizationRequests() {
+        // The redirect filter runs the resolver on every request in the chain, the provider
+        // callback included. That request carries no returnTo, so treating it as an
+        // authorization request would clear the target before the success handler reads it.
+        MockHttpServletRequest authorization = new MockHttpServletRequest("GET", "/oauth2/authorization/github");
+        authorization.setParameter("returnTo", "/device");
+        resolver.resolve(authorization, "github");
+        HttpSession session = authorization.getSession(false);
+
+        MockHttpServletRequest callback = new MockHttpServletRequest("GET", "/login/oauth2/code/github");
+        callback.setParameter("code", "auth-code");
+        callback.setSession(session);
+
+        assertThat(resolver.resolve(callback)).isNull();
+        assertThat(session.getAttribute(OAuthLoginRedirectSupport.SESSION_RETURN_TO_ATTRIBUTE))
+                .isEqualTo("/device");
+    }
+
+    @Test
     void resolve_ignoresUnsafeReturnTo() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/github");
         request.setParameter("returnTo", "https://evil.example");


### PR DESCRIPTION
## Problem

`returnTo` is never honoured after an OAuth login. Every browser login lands on
the default target (`/dashboard`), no matter what `returnTo` was passed to
`/oauth2/authorization/{provider}`.

This breaks any deep link that goes through login — in our case the device
authorization page, where the user signs in and is then dropped on the
dashboard instead of returning to approve the pending code.

## Cause

`SkillHubOAuth2AuthorizationRequestResolver` calls `rememberReturnTo(request)`
on every `resolve(...)`, including the calls where the delegate returned
`null`. `OAuth2AuthorizationRequestRedirectFilter` runs the resolver on *every*
request passing through the chain, so this happens constantly — and
`rememberReturnTo` removes the session attribute whenever the request has no
`returnTo` parameter.

The provider callback (`/login/oauth2/code/{provider}`) is one of those
requests, and the redirect filter sits ahead of `OAuth2LoginAuthenticationFilter`
in the chain. So the stored target is erased moments before
`OAuth2LoginSuccessHandler` reads it, and `consumeReturnTo` always sees `null`.

## Reproducing it against a running instance

The failure handler reads the same attribute, which makes the state observable
without completing a real login:

```bash
# store returnTo, then fail the callback deliberately
curl -sc jar "$BASE/oauth2/authorization/google?returnTo=%2Fdevice" -o /dev/null
curl -sb jar -o /dev/null -w '%{http_code} %{redirect_url}\n' \
  "$BASE/login/oauth2/code/google?code=bogus&state=bogus"
# 401 — returnTo was already gone

# same request, but with returnTo on the callback itself
curl -sb jar -o /dev/null -w '%{http_code} %{redirect_url}\n' \
  "$BASE/login/oauth2/code/google?code=bogus&state=bogus&returnTo=%2Fdevice"
# 302 .../login?returnTo=%2Fdevice — the resolver wrote it during the callback
```

The second call succeeding is what pins the cause: the resolver is writing
session state on a request that is not an authorization request.

## Fix

Only record the return target when the delegate actually produced an
authorization request. As a side effect, anonymous API requests no longer
allocate an HTTP session — `rememberReturnTo` used `request.getSession()`,
which created one on every request just to remove an attribute.

## Tests

Added `resolve_keepsReturnToOnNonAuthorizationRequests`, which walks the
authorization request and then the callback over the same session and asserts
the target survives. The existing tests only exercised the two-argument
overload on a matching path, where the delegate never returns `null`, so this
path was uncovered.