### PR TITLE
feat(web): link skill labels to search and wrap filter chips

### DIFF
--- a/docs/2026-03-20-skill-label-system-design.md
+++ b/docs/2026-03-20-skill-label-system-design.md
@@ -419,7 +419,7 @@ ClawHub CLI 兼容层的搜索接口 `GET /api/v1/search` 一期不支持 label 
 
 ### 7.1 搜索页
 
-- 搜索框下方增加分类板块，水平排列 label 列表（数据来自 `GET /api/v1/labels`）
+- 搜索框下方增加分类板块，水平排列 label 列表（数据来自 `GET /api/v1/labels`）；标签过多时应允许换行（`flex-wrap`），避免单行溢出
 - 每个 label 显示当前语言的 display_name，fallback 顺序：当前语言 → en → slug
 - 点击某个 label 高亮选中，搜索请求追加 `label` 参数；再次点击取消选中
 - Label 之间单选互斥：点击另一个 label 切换选中，不支持组合筛选
@@ -429,6 +429,8 @@ ClawHub CLI 兼容层的搜索接口 `GET /api/v1/search` 一期不支持 label 
 
 - 在 skill 信息区域以 chip/badge 形式展示该 skill 的所有 label
 - 特权标签使用不同的视觉样式区分（不同颜色或图标）
+- 点击 chip 导航到搜索页并带上 `label=<slug>`（与 §7.1 同一筛选语义，便于从详情发现同标签技能）；默认清空关键词、`sort=newest`、`page=0`
+- 若该 slug 不在搜索页可见筛选列表中（例如 `visible_in_filter=false` 的 PRIVILEGED），URL 仍可携带 `label` 并生效，但筛选条上可能没有对应高亮按钮
 - 有权限的用户（owner / 命名空间管理员 / 超级管理员）看到编辑入口
 - 编辑交互：弹出面板；超级管理员可从全部 label definition 中勾选/取消勾选，owner / 命名空间管理员仅可操作搜索页可见的 RECOMMENDED 标签
 - 特权标签区域仅超级管理员可见和可操作

--- a/web/src/pages/search.test.tsx
+++ b/web/src/pages/search.test.tsx
@@ -158,6 +158,12 @@ describe('SearchPage', () => {
     expect(findButton('Official').variant).toBe('outline')
   })
 
+  it('wraps the filter chip row so many labels can flow onto multiple lines', () => {
+    const html = renderToStaticMarkup(<SearchPage />)
+
+    expect(html).toContain('flex flex-wrap items-center gap-2')
+  })
+
   it('toggles the selected label off and resets paging', () => {
     renderToStaticMarkup(<SearchPage />)
 

--- a/web/src/pages/search.tsx
+++ b/web/src/pages/search.tsx
@@ -272,8 +272,8 @@ export function SearchPage() {
           </div>
         ) : null}
 
-        <div className="flex items-center gap-3">
-          <span className="text-sm font-medium text-muted-foreground">{t('search.filters.label')}</span>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="shrink-0 text-sm font-medium text-muted-foreground">{t('search.filters.label')}</span>
           <Button
             variant={starredOnly ? 'default' : 'outline'}
             size="sm"

--- a/web/src/pages/skill-detail.test.tsx
+++ b/web/src/pages/skill-detail.test.tsx
@@ -3,7 +3,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { MouseEvent } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 import type { SkillFile } from '@/api/types'
 
 const toastMocks = vi.hoisted(() => ({
@@ -32,6 +32,21 @@ vi.mock('@tanstack/react-router', () => ({
   useParams: () => ({ namespace: 'global', slug: 'demo-skill' }),
   useRouterState: () => ({ pathname: '/space/global/demo-skill', searchStr: '', hash: '' }),
   useSearch: () => ({ returnTo: '/dashboard/skills' }),
+  Link: ({
+    to,
+    search,
+    children,
+    className,
+  }: {
+    to: string
+    search?: Record<string, unknown>
+    children?: ReactNode
+    className?: string
+  }) => (
+    <a href={to} data-search={JSON.stringify(search ?? {})} className={className}>
+      {children}
+    </a>
+  ),
 }))
 
 vi.mock('react-i18next', async () => {
@@ -347,6 +362,25 @@ describe('SkillDetailPage', () => {
     expect(html).toContain('skillDetail.labelsSectionTitle')
     expect(html).toContain('skillDetail.removeLabel')
     expect(html).toContain('skillDetail.addLabel')
+  })
+
+  it('links skill label chips to the search page filtered by that label', () => {
+    useSkillDetailMock.mockReturnValue({
+      data: createSkill({
+        ownerId: 'someone-else',
+        canManageLifecycle: false,
+        labels: [{ slug: 'code-generation', type: 'RECOMMENDED', displayName: 'Code Generation' }],
+      }),
+      isLoading: false,
+      isFetching: false,
+      error: null,
+    })
+
+    const html = renderToStaticMarkup(<SkillDetailPage />)
+
+    expect(html).toContain('href="/search"')
+    expect(html).toContain('&quot;label&quot;:&quot;code-generation&quot;')
+    expect(html).toContain('Code Generation')
   })
 
   it('hides the label management panel when the viewer lacks label permissions', () => {

--- a/web/src/pages/skill-detail.tsx
+++ b/web/src/pages/skill-detail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useParams, useNavigate, useRouterState, useSearch } from '@tanstack/react-router'
+import { Link, useParams, useNavigate, useRouterState, useSearch } from '@tanstack/react-router'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, ArrowUpCircle, ChevronDown, ChevronUp, Clock, Folder, Globe, Lock, RefreshCw, ShieldCheck, Terminal, User, Users } from 'lucide-react'
 import { MarkdownRenderer } from '@/features/skill/markdown-renderer'
@@ -30,7 +30,7 @@ import { useSubmitSkillReport } from '@/features/report/use-skill-reports'
 import { SecurityAuditSummary } from '@/features/security-audit/security-audit-summary'
 import { formatLocalDateTime } from '@/shared/lib/date-time'
 import { incrementSkillDownloadCount } from '@/shared/lib/skill-download-cache'
-import { getSkillSquareSearch, normalizeSkillDetailReturnTo } from '@/shared/lib/skill-navigation'
+import { getSkillLabelSearch, getSkillSquareSearch, normalizeSkillDetailReturnTo } from '@/shared/lib/skill-navigation'
 import { formatCompactCount } from '@/shared/lib/number-format'
 import { resolveDocumentationFilePath } from '@/shared/lib/skill-documentation'
 import { getHeadlineVersion, getOwnerPreviewVersion, getPublishedVersion } from '@/shared/lib/skill-lifecycle'
@@ -830,17 +830,19 @@ export function SkillDetailPage() {
           {(skill.labels?.length ?? 0) > 0 && (
             <div className="flex flex-wrap gap-2">
               {skill.labels!.map((label) => (
-                <span
+                <Link
                   key={label.slug}
+                  to="/search"
+                  search={getSkillLabelSearch(label.slug)}
                   className={cn(
-                    'inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium',
+                    'inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2',
                     label.type === 'PRIVILEGED'
-                      ? 'border-amber-500/40 bg-amber-100 text-amber-900'
-                      : 'border-slate-300 bg-slate-100 text-slate-800',
+                      ? 'border-amber-500/40 bg-amber-100 text-amber-900 hover:bg-amber-200/80'
+                      : 'border-slate-300 bg-slate-100 text-slate-800 hover:bg-slate-200/80',
                   )}
                 >
                   {label.displayName}
-                </span>
+                </Link>
               ))}
             </div>
           )}

--- a/web/src/shared/lib/skill-navigation.test.ts
+++ b/web/src/shared/lib/skill-navigation.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from 'vitest'
-import { getSkillSquareSearch, normalizeSkillDetailReturnTo } from './skill-navigation'
+import { getSkillSquareSearch, getSkillLabelSearch, normalizeSkillDetailReturnTo } from './skill-navigation'
 
 describe('getSkillSquareSearch', () => {
   it('returns the default search params for the skill square', () => {
     expect(getSkillSquareSearch()).toEqual({
       q: '',
       sort: 'relevance',
+      page: 0,
+      starredOnly: false,
+    })
+  })
+})
+
+describe('getSkillLabelSearch', () => {
+  it('returns search params that filter by the given label', () => {
+    expect(getSkillLabelSearch('code-generation')).toEqual({
+      q: '',
+      label: 'code-generation',
+      sort: 'newest',
       page: 0,
       starredOnly: false,
     })

--- a/web/src/shared/lib/skill-navigation.ts
+++ b/web/src/shared/lib/skill-navigation.ts
@@ -10,6 +10,17 @@ export function getSkillSquareSearch() {
   }
 }
 
+/** Search params for browsing skills that share a given label (from detail chips). */
+export function getSkillLabelSearch(label: string) {
+  return {
+    q: '',
+    label,
+    sort: 'newest' as const,
+    page: 0,
+    starredOnly: false,
+  }
+}
+
 export function normalizeSkillDetailReturnTo(returnTo?: string) {
   return returnTo && returnTo.startsWith('/') ? returnTo : undefined
 }


### PR DESCRIPTION
## Summary
- Skill detail label chips are links to `/search` with `label=<slug>`, so clicking a tag shows skills that share it.
- Search filter chip row uses `flex-wrap` so many labels wrap to additional lines instead of overflowing in one row.
- Shared helper `getSkillLabelSearch` keeps default search params in one place; unit tests cover both behaviors.
- Design doc `docs/2026-03-20-skill-label-system-design.md` §7.1 / §7.2 updated to match this discovery UX (CONTRIBUTING: update docs when workflows change).

## Test plan
- [ ] Open a skill with labels → click a chip → lands on `/search?label=…` with that filter active
- [ ] On `/search` with many labels (e.g. POC stand), filters wrap to multiple lines at typical viewport widths
- [ ] Toggle label / sort / pagination still preserves URL state as before
- [ ] `pnpm exec vitest run src/shared/lib/skill-navigation.test.ts src/pages/search.test.tsx src/pages/skill-detail.test.tsx`