### PR TITLE
fix(search): improve async rebuild observability

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/config/AsyncConfig.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/config/AsyncConfig.java
@@ -1,13 +1,15 @@
 package com.iflytek.skillhub.config;
 
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.slf4j.MDC;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-
-import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Enables asynchronous event handling and other background execution features used by the
@@ -26,7 +28,30 @@ public class AsyncConfig {
         executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("skillhub-event-");
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setTaskDecorator(mdcTaskDecorator());
         executor.initialize();
         return executor;
+    }
+
+    private TaskDecorator mdcTaskDecorator() {
+        return task -> {
+            Map<String, String> callerContext = MDC.getCopyOfContextMap();
+            return () -> {
+                Map<String, String> executorContext = MDC.getCopyOfContextMap();
+                try {
+                    restoreMdc(callerContext);
+                    task.run();
+                } finally {
+                    restoreMdc(executorContext);
+                }
+            };
+        };
+    }
+
+    private void restoreMdc(Map<String, String> context) {
+        MDC.clear();
+        if (context != null) {
+            MDC.setContextMap(context);
+        }
     }
 }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/metrics/SkillHubMetrics.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/metrics/SkillHubMetrics.java
@@ -60,4 +60,8 @@ public class SkillHubMetrics {
             "operation", operation
         ).increment();
     }
+
+    public void incrementSearchRebuildFailure() {
+        meterRegistry.counter("skillhub.search.rebuild.failure").increment();
+    }
 }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/LabelSearchSyncService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/LabelSearchSyncService.java
@@ -1,5 +1,6 @@
 package com.iflytek.skillhub.service;
 
+import com.iflytek.skillhub.metrics.SkillHubMetrics;
 import com.iflytek.skillhub.search.SearchRebuildService;
 import java.util.List;
 import org.slf4j.Logger;
@@ -15,9 +16,12 @@ public class LabelSearchSyncService {
     private static final Logger log = LoggerFactory.getLogger(LabelSearchSyncService.class);
 
     private final SearchRebuildService searchRebuildService;
+    private final SkillHubMetrics metrics;
 
-    public LabelSearchSyncService(SearchRebuildService searchRebuildService) {
+    public LabelSearchSyncService(SearchRebuildService searchRebuildService,
+                                  SkillHubMetrics metrics) {
         this.searchRebuildService = searchRebuildService;
+        this.metrics = metrics;
     }
 
     @Async("skillhubEventExecutor")
@@ -25,6 +29,7 @@ public class LabelSearchSyncService {
         try {
             searchRebuildService.rebuildBySkill(skillId);
         } catch (RuntimeException ex) {
+            metrics.incrementSearchRebuildFailure();
             log.error("Failed to rebuild search document for skill {}", skillId, ex);
         }
     }
@@ -41,6 +46,7 @@ public class LabelSearchSyncService {
                 try {
                     searchRebuildService.rebuildBySkill(skillId);
                 } catch (RuntimeException ex) {
+                    metrics.incrementSearchRebuildFailure();
                     log.error("Failed to rebuild search document for skill {} after label change", skillId, ex);
                 }
             }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/config/AsyncConfigTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/config/AsyncConfigTest.java
@@ -2,9 +2,13 @@ package com.iflytek.skillhub.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class AsyncConfigTest {
 
@@ -12,5 +16,27 @@ class AsyncConfigTest {
     void asyncConfig_enablesAsyncAndScheduling() {
         assertThat(AsyncConfig.class).hasAnnotation(EnableAsync.class);
         assertThat(AsyncConfig.class).hasAnnotation(EnableScheduling.class);
+    }
+
+    @Test
+    void skillhubEventExecutor_propagatesAndClearsMdc() throws Exception {
+        ThreadPoolTaskExecutor executor =
+                (ThreadPoolTaskExecutor) new AsyncConfig().skillhubEventExecutor();
+        try {
+            MDC.put("requestId", "req-597");
+            CompletableFuture<String> propagatedRequestId = new CompletableFuture<>();
+            executor.execute(() -> propagatedRequestId.complete(MDC.get("requestId")));
+            MDC.clear();
+
+            assertThat(propagatedRequestId.get(5, TimeUnit.SECONDS)).isEqualTo("req-597");
+
+            CompletableFuture<String> nextRequestId = new CompletableFuture<>();
+            executor.execute(() -> nextRequestId.complete(MDC.get("requestId")));
+
+            assertThat(nextRequestId.get(5, TimeUnit.SECONDS)).isNull();
+        } finally {
+            MDC.clear();
+            executor.shutdown();
+        }
     }
 }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/metrics/PrometheusEndpointTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/metrics/PrometheusEndpointTest.java
@@ -39,6 +39,7 @@ class PrometheusEndpointTest {
         skillHubMetrics.incrementUserRegister();
         skillHubMetrics.recordLocalLogin(true);
         skillHubMetrics.incrementSkillPublish("global", "PENDING_REVIEW");
+        skillHubMetrics.incrementSearchRebuildFailure();
 
         assertThat(environment.getProperty("management.endpoints.web.exposure.include"))
             .doesNotContain("prometheus")
@@ -52,6 +53,9 @@ class PrometheusEndpointTest {
         assertThat(meterRegistry.get("skillhub.skill.publish")
             .tag("namespace", "global")
             .tag("status", "PENDING_REVIEW")
+            .counter()
+            .count()).isEqualTo(1.0d);
+        assertThat(meterRegistry.get("skillhub.search.rebuild.failure")
             .counter()
             .count()).isEqualTo(1.0d);
     }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/LabelSearchSyncServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/LabelSearchSyncServiceTest.java
@@ -1,13 +1,19 @@
 package com.iflytek.skillhub.service;
 
+import com.iflytek.skillhub.metrics.SkillHubMetrics;
 import com.iflytek.skillhub.search.SearchRebuildService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class LabelSearchSyncServiceTest {
@@ -15,7 +21,8 @@ class LabelSearchSyncServiceTest {
     @Test
     void rebuildSkillsShouldSkipNullsAndDuplicatesWhileProcessingLargeLists() {
         SearchRebuildService rebuildService = mock(SearchRebuildService.class);
-        LabelSearchSyncService service = new LabelSearchSyncService(rebuildService);
+        SkillHubMetrics metrics = mock(SkillHubMetrics.class);
+        LabelSearchSyncService service = new LabelSearchSyncService(rebuildService, metrics);
         List<Long> skillIds = new ArrayList<>();
         skillIds.add(null);
         for (long i = 1; i <= 120; i++) {
@@ -30,5 +37,58 @@ class LabelSearchSyncServiceTest {
             verify(rebuildService).rebuildBySkill(i);
         }
         verifyNoMoreInteractions(rebuildService);
+        verifyNoInteractions(metrics);
+    }
+
+    @Test
+    void rebuildSkillFailureShouldIncrementMetric() {
+        SearchRebuildService rebuildService = mock(SearchRebuildService.class);
+        doThrow(new IllegalStateException("search unavailable"))
+                .when(rebuildService)
+                .rebuildBySkill(42L);
+
+        contextRunner(rebuildService).run(context -> {
+            LabelSearchSyncService service = context.getBean(LabelSearchSyncService.class);
+            SimpleMeterRegistry meterRegistry = context.getBean(SimpleMeterRegistry.class);
+
+            service.rebuildSkill(42L);
+
+            assertThat(meterRegistry.get("skillhub.search.rebuild.failure").counter().count())
+                    .isEqualTo(1.0d);
+        });
+    }
+
+    @Test
+    void rebuildSkillsShouldCountEachFailureAndContinue() {
+        SearchRebuildService rebuildService = mock(SearchRebuildService.class);
+        doThrow(new IllegalStateException("search unavailable"))
+                .when(rebuildService)
+                .rebuildBySkill(2L);
+        doThrow(new IllegalStateException("search unavailable"))
+                .when(rebuildService)
+                .rebuildBySkill(3L);
+
+        contextRunner(rebuildService).run(context -> {
+            LabelSearchSyncService service = context.getBean(LabelSearchSyncService.class);
+            SimpleMeterRegistry meterRegistry = context.getBean(SimpleMeterRegistry.class);
+
+            service.rebuildSkills(List.of(1L, 2L, 3L, 4L));
+
+            assertThat(meterRegistry.get("skillhub.search.rebuild.failure").counter().count())
+                    .isEqualTo(2.0d);
+            verify(rebuildService).rebuildBySkill(1L);
+            verify(rebuildService).rebuildBySkill(2L);
+            verify(rebuildService).rebuildBySkill(3L);
+            verify(rebuildService).rebuildBySkill(4L);
+            verifyNoMoreInteractions(rebuildService);
+        });
+    }
+
+    private ApplicationContextRunner contextRunner(SearchRebuildService rebuildService) {
+        return new ApplicationContextRunner()
+                .withBean(SearchRebuildService.class, () -> rebuildService)
+                .withBean(SimpleMeterRegistry.class)
+                .withBean(SkillHubMetrics.class)
+                .withBean(LabelSearchSyncService.class);
     }
 }


### PR DESCRIPTION
## 修改内容

- 为 `skillhubEventExecutor` 增加 MDC 上下文传播与执行后恢复。
- 搜索索引重建失败时增加 `skillhub.search.rebuild.failure` 计数。
- 覆盖单个重建、批量部分失败、MDC 传播和 Registry 记录行为。

## 修复原因

标签搜索索引重建已是异步任务，但执行线程读取不到原始请求 MDC；重建异常也只有 ERROR 日志，无法通过指标发现。

Closes #597

## 实现方式

- 任务提交时复制调用线程 MDC，执行结束后恢复工作线程原有上下文，避免线程复用串号。
- 每个重建失败的 Skill 计数一次，正常重建不计数。
- 不在线程池任务内增加重试，避免阻塞共享事件执行器；持久化补偿作为独立扩展。

## 验证

- 当前 `main` 基线：MDC 断言稳定得到 `null`，两个指标断言均报告指标不存在。
- Java 21 定向测试：6/6 通过。
- 后端完整 reactor：662 项，失败 0、错误 0、跳过 1；已知顺序污染用例隔离运行 9/9 通过。
- 前端：TypeScript、ESLint、181 个 Vitest 文件共 618 项测试通过。
- 隔离 staging：15/15 smoke 通过，Web 健康检查通过。
- 精确合入 `big-main` 的镜像远端隔离验证：83/83 通过。
- 远端覆盖正常/失败/恢复、两个并发 request ID 的 MDC 隔离、单项与批量逐 Skill 计数、主事务、审计、幂等、权限、数据库级联、搜索结果和异常扫描。
- 测试结束后隔离资源全部清理，既有服务镜像未变且保持健康。
- 公开内容隐私扫描通过。

## 影响

- 无 API、数据库、前端或依赖变更。
- MDC 传播适用于共享执行器上的全部异步任务。
- 新增一个无标签、低基数 Micrometer Counter。
