### PR TITLE
test(auth): strengthen identity core guardrails

### DIFF
--- a/docs/verification/issue-640.md
+++ b/docs/verification/issue-640.md
@@ -5,7 +5,7 @@
 - Issue: <https://github.com/iflytek/skillhub/issues/640>
 - Pull request: <https://github.com/iflytek/skillhub/pull/643>
 - Integration target: `big-main`
-- Validation environment: dedicated Hong Kong test server
+- Validation environment: isolated, production-equivalent test deployment
 - Production/default branch: not modified
 
 This record covers P1 / PR 1 from
@@ -15,7 +15,7 @@ plugins remain outside this PR.
 
 ## Automated gates
 
-The following checks ran on the Hong Kong test server:
+The following checks ran against the isolated test deployment:
 
 | Gate | Result |
 |---|---|
@@ -27,11 +27,9 @@ The following checks ran on the Hong Kong test server:
 | DCO | passed |
 | CLA | passed |
 
-The server image used for pre-integration runtime validation was
-`skillhub-server:identity-core-9818333c`, image ID
-`sha256:a9055606ad2a551f12319e66f7056e4bda072a8e14a238882cdbdbeb871cf6c8`.
 The clean PR branch was rebuilt from the latest `big-main`; its unified-identity
-file tree is identical to the validated feature tree.
+file tree is identical to the validated feature tree. Runtime artifact identity
+and operational logs are intentionally omitted from the public repository.
 
 ## PostgreSQL and runtime scenarios
 

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/admin/IdentityProviderAdminController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/admin/IdentityProviderAdminController.java
@@ -7,6 +7,9 @@ import com.iflytek.skillhub.dto.ApiResponseFactory;
 import com.iflytek.skillhub.dto.IdentityProviderAuthorityRecoveryResponse;
 import com.iflytek.skillhub.service.AuditRequestContext;
 import com.iflytek.skillhub.service.IdentityProviderAdminAppService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,6 +34,27 @@ public class IdentityProviderAdminController extends BaseApiController {
         this.providerAdminAppService = providerAdminAppService;
     }
 
+    @Operation(
+            summary = "Recover an identity provider authority lock",
+            description = "Restores a provider from AUTHORITY_MISMATCH only when the current "
+                    + "trusted configuration matches its pinned authority.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Provider recovered or already ready"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "Caller is not a super administrator",
+                    content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "Enabled provider configuration not found",
+                    content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "Current configuration does not match the pinned authority",
+                    content = @Content)
+    })
     @PostMapping("/{providerCode}/authority/recover")
     @PreAuthorize("hasRole('SUPER_ADMIN')")
     public ApiResponse<IdentityProviderAuthorityRecoveryResponse>

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuthAdapterBoundaryTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/oauth/OAuthAdapterBoundaryTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.Test;
 class OAuthAdapterBoundaryTest {
 
     private static final List<Class<?>> ADAPTERS = List.of(
+            OAuthClaimsExtractor.class,
             GitHubClaimsExtractor.class,
             GitLabClaimsExtractor.class,
+            CustomOAuth2UserService.class,
             CustomOidcUserService.class);
 
     private static final List<String> FORBIDDEN_DEPENDENCIES = List.of(

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/token/ApiTokenAuthenticationFilterTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/token/ApiTokenAuthenticationFilterTest.java
@@ -10,6 +10,7 @@ import com.iflytek.skillhub.domain.user.UserAccount;
 import com.iflytek.skillhub.domain.user.UserAccountRepository;
 import com.iflytek.skillhub.domain.user.UserStatus;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -42,6 +43,11 @@ class ApiTokenAuthenticationFilterTest {
         roleBindingRepository,
         scopeService
     );
+
+    @BeforeEach
+    void initializeSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
 
     @AfterEach
     void clearSecurityContext() {

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -1629,6 +1629,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /**
+         * Recover an identity provider authority lock
+         * @description Restores a provider from AUTHORITY_MISMATCH only when the current trusted configuration matches its pinned authority.
+         */
         post: operations["recoverSameAuthority"];
         delete?: never;
         options?: never;
@@ -8367,7 +8371,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description OK */
+            /** @description Provider recovered or already ready */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -8375,6 +8379,27 @@ export interface operations {
                 content: {
                     "*/*": components["schemas"]["ApiResponseIdentityProviderAuthorityRecoveryResponse"];
                 };
+            };
+            /** @description Caller is not a super administrator */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Enabled provider configuration not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Current configuration does not match the pinned authority */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## What

Follow up #640 / #643 with the final authority-recovery API contract, generated OpenAPI annotations, and test isolation guardrails required before Binding V2 begins.

## Why

The PR 1 implementation is already in `big-main`, but its recovery endpoint contract and two order-sensitive auth tests need explicit guardrails so later identity migrations cannot hide regressions through test ordering or stale generated types.

## How

- Document the authority recovery response codes without changing endpoint behavior.
- Regenerate the checked-in OpenAPI schema from the annotated controller.
- Strengthen OAuth adapter and API-token filter isolation.
- Remove private infrastructure details from the public PR 1 verification record.

## Testing

- The exact changes are included in the subsequently validated Binding V2 Expand head.
- Shared isolated environment: backend regression 675 tests, 0 failures/errors, 5 skipped.
- Web typecheck, lint, build: passed.
- Web unit tests: 181 files / 618 tests passed.
- This Draft PR also starts CI against the current `big-main` merge result.

## Impact

No database or runtime behavior change. The OpenAPI update adds documentation for the existing recovery endpoint only. Target is `big-main`, not `main`.
