### PR TITLE
docs(weekly): mirror reports into project Pages

### DIFF
--- a/.agents/skills/generate-skillhub-weekly-report/SKILL.md
+++ b/.agents/skills/generate-skillhub-weekly-report/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: generate-skillhub-weekly-report
+description: Generate or revise concise SkillHub weekly open-source reports in formal Chinese Markdown and self-contained tabbed HTML for GitHub Pages. Use for weekly summaries of repository key metrics, feature iteration, ecosystem progress, project health, releases, promotion activities, and value-ranked Issues/PRs; also use when GitHub access is partial and the report must be assembled from API results, cached exports, local Git history, or maintainer notes.
+---
+
+# Generate SkillHub Weekly Report
+
+Generate a report whose overview can be understood in three minutes. Treat Markdown as the content source and self-contained HTML as its public presentation.
+
+## Default Invocation
+
+When the user only says “使用 Skill 生成本周周报”:
+
+- display the reporting period as the previous Thursday through the current Thursday in `Asia/Shanghai`;
+- use explicit cutoff timestamps for event filtering: after the previous Thursday cutoff through the current Thursday cutoff. Treat the previous cutoff as exclusive and the current cutoff as inclusive so an event is counted once across adjacent reports;
+- when invoked on Friday or later, use the most recently completed Thursday cutoff; when invoked on Thursday before the report is released, end at the explicit snapshot and label it as partial;
+- when migrating an existing archive from another cadence, keep the requested Thursday—Thursday label. If no previous Thursday cutoff exists, begin at the previous Thursday 00:00 and disclose any overlap with an older report in the data Tab; do not shorten the visible reporting period into a transition snapshot;
+- use `iflytek/skillhub` as the source repository unless the user names another repository;
+- discover an existing sibling or configured `skillhub-weekly` site repository and reuse its latest report, theme, manifest, and build scripts;
+- collect repository facts automatically and continue when promotion links are absent; do not stop at a draft;
+- generate the report, update `reports.json`, rebuild the archive, validate, and render-check locally.
+
+When the user says “生成并发布本周周报”, additionally commit the weekly-site changes, push its configured publishing branch, monitor the Pages workflow, and verify the live report URL. When the SkillHub source repository contains a configured `weekly/` mirror, also synchronize the canonical site sources into that mirror, validate them, submit a source-repository PR, and verify the official mirror after merge. Do not push directly to the SkillHub default branch.
+
+## Workflow
+
+1. Resolve the previous-Thursday—current-Thursday `Asia/Shanghai` reporting label and the exact cutoff timestamps. Ask only when the user requests a non-default period or the boundary is ambiguous.
+2. Read [references/metrics.md](references/metrics.md) for data semantics.
+3. Read [references/report-structure.md](references/report-structure.md) for the overview and Tab structure.
+4. Collect available facts with source timestamps. If GitHub is inaccessible, continue with cached data, local Git, release pages, or maintainer notes; mark missing data instead of using zero.
+5. Separate weekly facts, current snapshot, and post-period progress.
+6. Select decision-relevant overview information:
+   - 4–6 repository metrics;
+   - 3–5 feature iterations;
+   - 3–5 ecosystem developments;
+   - at most 3 next-week priorities.
+7. Add compact evidence visuals when the underlying data is verified:
+   - overview: repository scale and weekly collaboration flow;
+   - ecosystem: independent participation and adoption signals;
+   - health: Actions outcome composition, Issue/PR age, and `needs-info` proportion.
+8. Put workflow details and current A/B value queues in separate Tabs. Do not repeat them in the overview.
+9. Add maintainer-provided articles, talks, community sharing, and partner projects under ecosystem progress.
+10. Generate Markdown, then fill [assets/weekly-report-template.html](assets/weekly-report-template.html). Replace every `{{PLACEHOLDER}}`, including repository name, source summary, overall status, and all four metric values and labels.
+11. When publishing through a weekly-site repository:
+    - write the canonical report to `site/reports/<YYYY-Www>/index.html`;
+    - append its metadata to `site/reports.json` and update `latest`;
+    - run the repository's theme sync, build, and validation scripts so the home and archive pages stay aligned.
+    - when a SkillHub source checkout with `weekly/` is available, mirror `site/`, `assets/`, and `scripts/` byte-for-byte into `weekly/`; never copy `_site/`;
+    - rebuild and validate from the SkillHub checkout, then submit a normal PR that links the weekly-report tracking Issue;
+    - preserve one authoritative content source: edit the weekly-site repository first and treat the SkillHub copy as a reviewed mirror.
+12. Run:
+
+```bash
+python3 .agents/skills/generate-skillhub-weekly-report/scripts/validate_report.py <report.md>
+python3 .agents/skills/generate-skillhub-weekly-report/scripts/validate_report.py <report.html>
+```
+
+13. Render HTML at desktop and narrow widths when a browser is available. Verify mouse, keyboard, direct-hash, no-JavaScript, and print behavior.
+
+## Official SkillHub Mirror
+
+When the SkillHub source repository contains `weekly/`, treat it as a reviewed
+mirror of the standalone weekly-site repository:
+
+1. Resolve both repository roots and confirm both worktrees are clean enough to
+   isolate the report changes. Preserve unrelated and untracked files.
+2. Update and validate the standalone site first.
+3. Create a fresh SkillHub branch from the latest `origin/main`; do not reuse a
+   stale report branch.
+4. Synchronize these trees exactly, including upstream deletions:
+   - standalone `site/` to SkillHub `weekly/site/`;
+   - standalone `assets/` to SkillHub `weekly/assets/`;
+   - standalone `scripts/` to SkillHub `weekly/scripts/`.
+5. Do not copy `_site/`, a standalone Pages workflow, or repository credentials.
+6. Update `weekly/source.json` to the exact standalone commit and verify the
+   mirrored trees byte-for-byte before committing.
+7. Build and validate from `weekly/`, then build VitePress and place the weekly
+   output under `.vitepress/dist/weekly/`.
+8. Submit a normal SkillHub PR linked to the tracking Issue. After merge,
+   monitor the existing `Deploy Docs` workflow and verify:
+   - `https://iflytek.github.io/skillhub/weekly/`;
+   - `https://iflytek.github.io/skillhub/weekly/archive.html`;
+   - the current report route under `/skillhub/weekly/reports/<YYYY-Www>/`.
+
+Do not wrap the report in a VitePress page or restyle it for the official
+mirror. The report HTML, inlined Notion-light CSS, charts, Tabs, and responsive
+behavior must remain identical to the standalone site.
+
+## Default HTML
+
+Use two required Tabs and up to two optional Tabs:
+
+1. **总览**（required）：keep to about 2–3 desktop screens and use these modules when they have content:
+   - **仓库关键信息**：Stars/Forks 规模与变化、本周 Issue/PR 流转图、Release、CI 和一句风险判断。
+   - **功能迭代信息**：已完成、推进中、期后完成、待设计的 3–5 个重要事项。
+   - **生态相关进展**：社区参与信号、Fork/下载、文档或集成成果、传播与合作动作。
+2. **项目健康**（optional）：health cards plus engineering, security pipeline, release, backlog age, and community response evidence.
+3. **Issue 与 PR**（optional）：weekly flow plus current A/B value queues; collapse cleanup candidates.
+4. **数据说明**（required）：time boundaries, sources, missing permissions, and post-period semantics.
+
+End with no more than three “下周关注” items. Keep statistical definitions in the data Tab.
+
+## Module Rules
+
+- Wrap every independently optional content block in a complete element with `data-module="<stable-name>"`.
+- Omit an entire module when it has no verified content. Never emit an empty heading, empty table, or placeholder row.
+- Keep `repository-summary` required. Treat feature, ecosystem, promotion, response, workflow, and queue modules as optional.
+- Treat each chart as an optional submodule. Omit its title, container, legend, and axis when its source data is missing.
+- If a detail panel has no modules, omit both its Tab button and its panel.
+- Keep “未取得” only when the data gap itself affects interpretation; do not use it to preserve an otherwise empty module.
+
+## Full Governance Mode
+
+Only when the user explicitly requests a full backlog or governance appendix:
+
+- rank full queues A—D;
+- place complete Issue/PR tables in appendices.
+
+Do not put all 21/19 open items into the normal weekly report.
+
+## Rules
+
+- Explain a metric once. Do not repeat KPI grids across sections.
+- Keep headline metrics to four and use tables or lists instead of card grids.
+- Keep post-period progress beside the affected feature or Release and exclude it from weekly totals.
+- Do not infer “no vulnerabilities” from successful security workflows.
+- Do not infer weekly Star growth from a single snapshot.
+- Do not turn forks, downloads, Issue authors, and PR authors into a funnel without cohort evidence.
+- Preserve links for Releases, material Issues/PRs, and promotion actions.
+- Use the bundled Notion-light theme: white canvas, warm-gray sections, near-black text, light borders, and one blue interaction accent.
+- Use formal, direct language. Avoid slogans, decorative charts, and long methodology prose.
+- Give every chart primitive (`.bars`, `.segbar`, `.donut`, `.ecosystem-signals`) `role="img"` and a complete numeric `aria-label`; also keep visible numeric labels beside the graphic.
+- Use accessible `button` Tabs with matching `aria-controls`/`aria-labelledby`, arrow-key navigation, direct hashes, and a no-JavaScript fallback.
+- Keep report HTML self-contained. Do not load external CSS, JavaScript, images, or fonts.
+
+## Completion Gate
+
+Finish only when:
+
+- the overview contains the required repository module and any available optional modules in order;
+- two to four Tabs are present, with matching panels and keyboard access;
+- no empty module or panel is emitted;
+- feature iteration contains concrete links and status;
+- ecosystem includes both participation and delivered progress;
+- verified repository flow and ecosystem signals are visualized without implying a funnel;
+- available Actions and backlog distributions have accessible charts;
+- Issue/PR detail is value-ranked without dumping the full backlog;
+- no more than three next-week priorities remain;
+- missing data is explicit;
+- the weekly-site home, archive, and report routes build successfully when a site repository is used;
+- a configured SkillHub mirror has source parity, passes its own build, and is
+  assembled into the existing VitePress Pages artifact;
+- validation passes.

--- a/.agents/skills/generate-skillhub-weekly-report/agents/openai.yaml
+++ b/.agents/skills/generate-skillhub-weekly-report/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "生成 SkillHub 开源周报"
+  short_description: "生成精炼总览与详情 Tab 的 SkillHub 开源周报"
+  default_prompt: "使用 $generate-skillhub-weekly-report 生成本周 SkillHub 开源周报，按上一个完整自然周统计，更新周报站点并完成构建与校验。"

--- a/.agents/skills/generate-skillhub-weekly-report/assets/weekly-report-template.html
+++ b/.agents/skills/generate-skillhub-weekly-report/assets/weekly-report-template.html
@@ -1,0 +1,1287 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="{{REPORT_DESCRIPTION}}">
+<title>{{REPORT_TITLE}}</title>
+<script>document.documentElement.classList.add('js')</script>
+<style data-report-theme="notion-light">
+:root {
+  color-scheme: light;
+  --page: #ffffff;
+  --paper: #ffffff;
+  --warm: #f6f5f4;
+  --ink: #0d0d0d;
+  --ink-soft: #31302e;
+  --muted: #615d59;
+  --faint: #76716c;
+  --line: #e5e3e1;
+  --line-soft: #efeeec;
+  --blue: #0075de;
+  --blue-active: #005bab;
+  --blue-soft: #f2f9ff;
+  --green: #147a33;
+  --green-soft: #e9f7ec;
+  --orange: #b84d00;
+  --orange-soft: #fdf0e3;
+  --red: #b52d25;
+  --red-soft: #fdecea;
+  --neutral-soft: #f1f0ef;
+  --focus: #097fe8;
+  --radius-sm: 8px;
+  --radius: 12px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 4%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 15px/1.65 Inter, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--blue-active);
+  text-decoration: underline;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--neutral-soft);
+  color: var(--ink-soft);
+  font-size: .92em;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 30;
+  top: 8px;
+  left: -999px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background: var(--ink-soft);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: 8px;
+}
+
+.report {
+  width: min(1200px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.masthead {
+  padding: 44px 28px 36px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 26px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: var(--ink-soft);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.brand-name {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+}
+
+.brand-tag {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--neutral-soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.utility-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 820px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(32px, 4vw, 44px);
+  line-height: 1.15;
+  letter-spacing: -.025em;
+}
+
+.report-sub {
+  margin: 8px 0 24px;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: 1.15fr .85fr;
+  gap: 16px;
+}
+
+.meta-card,
+.headline {
+  border-radius: var(--radius-sm);
+  padding: 20px 22px;
+}
+
+.meta-card {
+  background: var(--warm);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.meta-item .key,
+.headline-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--faint);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: .01em;
+}
+
+.meta-item .value {
+  color: var(--ink-soft);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.period {
+  margin: 0;
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  border: 0;
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.headline-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 7px;
+}
+
+.headline-status strong {
+  color: var(--orange);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.headline p {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 18px;
+  border: 0;
+}
+
+.metric {
+  min-width: 0;
+  padding: 16px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.metric strong {
+  display: block;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.tabs-wrap {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+  background: rgb(255 255 255 / 97%);
+  backdrop-filter: saturate(1.1) blur(5px);
+}
+
+.tabs {
+  display: flex;
+  min-width: max-content;
+  padding: 0 28px;
+}
+
+.tab {
+  position: relative;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.tab::after {
+  position: absolute;
+  right: 14px;
+  bottom: -1px;
+  left: 14px;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.tab:hover,
+.tab[aria-selected="true"] {
+  color: var(--ink);
+}
+
+.tab[aria-selected="true"] {
+  font-weight: 600;
+}
+
+.tab[aria-selected="true"]::after {
+  background: var(--ink-soft);
+}
+
+main {
+  padding: 0 28px 48px;
+}
+
+.tab-panel {
+  padding-top: 4px;
+}
+
+.js .tab-panel[hidden] {
+  display: none;
+}
+
+.panel-intro {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.panel-intro p {
+  margin: 0;
+}
+
+section.report-section {
+  margin: 0;
+  padding: 48px 0;
+  border: 0;
+}
+
+.tab-panel > section.report-section:nth-of-type(even) {
+  background: var(--warm);
+  box-shadow: 0 0 0 100vmax var(--warm);
+  clip-path: inset(0 -100vmax);
+}
+
+section.report-section:first-of-type {
+  padding-top: 42px;
+}
+
+h2 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+h3 {
+  margin: 30px 0 12px;
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.35;
+  letter-spacing: -.01em;
+}
+
+p {
+  max-width: 75ch;
+  text-wrap: pretty;
+}
+
+.section-lead {
+  margin: -7px 0 18px;
+  color: var(--muted);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+}
+
+table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+caption {
+  padding: 10px 14px;
+  background: var(--warm);
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: #faf9f8;
+}
+
+.number {
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.status,
+.value-level {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 25px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.status::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.status.ok {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status.warn {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.status.risk {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-a {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-b {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.value-c {
+  background: var(--blue-soft);
+  color: var(--blue-active);
+}
+
+.value-d {
+  background: var(--neutral-soft);
+  color: var(--muted);
+}
+
+.risk-note {
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.repo-visuals {
+  display: grid;
+  grid-template-columns: minmax(280px, .85fr) minmax(0, 1.15fr);
+  gap: 18px;
+}
+
+.snapshot-list {
+  display: grid;
+  gap: 0;
+}
+
+.snapshot-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto;
+  gap: 4px 16px;
+  align-items: center;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.snapshot-row:first-child {
+  padding-top: 0;
+}
+
+.snapshot-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.snapshot-row .snapshot-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.snapshot-row strong {
+  color: var(--ink);
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.snapshot-row .snapshot-change {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.snapshot-row .snapshot-change.positive {
+  color: var(--green);
+}
+
+.snapshot-row .snapshot-change.missing {
+  color: var(--orange);
+}
+
+.chart-note {
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.ecosystem-signal {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.ecosystem-signal strong {
+  display: block;
+  color: var(--ink);
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecosystem-signal span {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signal-note {
+  grid-column: 1 / -1;
+  margin: -3px 0 0;
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.ecosystem-list,
+.method-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.ecosystem-list li,
+.method-list li {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.method-list li {
+  grid-template-columns: 180px 1fr;
+}
+
+.ecosystem-list strong,
+.method-list strong {
+  color: var(--ink);
+}
+
+.next-actions {
+  margin: 4px 0 30px;
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.next-actions h2 {
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.next-actions ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.next-actions li {
+  margin: 7px 0;
+}
+
+.health-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.health-card,
+.chart-box,
+.health-note {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.health-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 20px 22px;
+}
+
+.health-card .top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.health-card .name {
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.health-card .health-metric {
+  color: var(--ink);
+  font-size: 27px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.health-card .health-metric small {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.health-card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.health-card .detail {
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.segbar {
+  display: flex;
+  height: 24px;
+  overflow: hidden;
+  margin: 15px 0 10px;
+  border-radius: 6px;
+  background: var(--neutral-soft);
+}
+
+.segbar > span {
+  min-width: 2px;
+  height: 100%;
+}
+
+.seg-success {
+  background: #1aae39;
+}
+
+.seg-failure {
+  background: #e16259;
+}
+
+.seg-auth {
+  background: #e8a94b;
+}
+
+.seg-skipped {
+  background: #d6d2cd;
+}
+
+.seg-cancelled {
+  background: #8e8984;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chart-legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.chart-legend b {
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.chart-box {
+  padding: 20px 22px;
+}
+
+.chart-box h3 {
+  margin: 0 0 14px;
+  font-size: 15px;
+}
+
+.bars {
+  display: grid;
+  gap: 11px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 42px;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.repo-visuals .bar-row {
+  grid-template-columns: 112px 1fr 36px;
+}
+
+.bar-label {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 16px;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--neutral-soft);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 5px;
+  background: var(--blue);
+}
+
+.bar-fill.hot {
+  background: var(--orange);
+}
+
+.bar-value {
+  color: var(--ink-soft);
+  font-weight: 700;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.donut-layout {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 22px;
+  align-items: center;
+}
+
+.donut {
+  position: relative;
+  width: 142px;
+  height: 142px;
+  border-radius: 50%;
+  background: conic-gradient(var(--orange) 0 var(--value), #d6d2cd var(--value) 100%);
+}
+
+.donut::after {
+  position: absolute;
+  inset: 24px;
+  border-radius: 50%;
+  background: var(--paper);
+  content: "";
+}
+
+.donut-center {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.donut-center strong {
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+.donut-center span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.donut-copy p {
+  margin: 0 0 9px;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.donut-copy p:last-child {
+  margin-bottom: 0;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chart-box + .table-wrap {
+  margin-top: 18px;
+}
+
+.health-note {
+  padding: 18px;
+}
+
+.health-note h3 {
+  margin: 0 0 7px;
+  font-size: 15px;
+}
+
+.health-note p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.flow-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0 24px;
+}
+
+.flow-item {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.flow-item strong {
+  display: block;
+  color: var(--ink);
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-item span {
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+details {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+summary {
+  padding: 14px 18px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.details-body {
+  padding: 0 18px 16px;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 28px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .masthead,
+  main,
+  footer {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .topline,
+  footer,
+  .panel-intro {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .header-grid,
+  .meta-grid,
+  .repo-visuals,
+  .chart-grid,
+  .health-grid,
+  .flow-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tabs {
+    padding: 0 6px;
+  }
+
+  section.report-section {
+    padding: 38px 0;
+  }
+
+  .ecosystem-list li,
+  .method-list li {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+
+  .ecosystem-signals {
+    grid-template-columns: 1fr;
+  }
+
+  .ecosystem-signal-note {
+    grid-column: auto;
+  }
+
+  .donut-layout {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .donut-copy {
+    text-align: center;
+  }
+}
+
+@media (max-width: 430px) {
+  .bar-row {
+    grid-template-columns: 76px 1fr 32px;
+    gap: 7px;
+  }
+
+  .repo-visuals .bar-row {
+    grid-template-columns: 98px 1fr 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media print {
+  @page {
+    size: A4;
+    margin: 13mm;
+  }
+
+  body {
+    background: #fff;
+    font-size: 10px;
+  }
+
+  .report {
+    width: 100%;
+  }
+
+  .masthead,
+  main,
+  footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .tabs-wrap,
+  .skip-link,
+  .utility-links {
+    display: none !important;
+  }
+
+  .tab-panel[hidden] {
+    display: block !important;
+  }
+
+  .tab-panel {
+    break-before: page;
+  }
+
+  .tab-panel:first-child {
+    break-before: auto;
+  }
+
+  .tab-panel > section.report-section:nth-of-type(even) {
+    background: #fff;
+    box-shadow: none;
+    clip-path: none;
+  }
+
+  section.report-section {
+    padding: 16px 0;
+  }
+
+  h1 {
+    font-size: 27px;
+  }
+
+  h2,
+  h3,
+  tr,
+  .health-card,
+  .health-note,
+  .chart-box,
+  .next-actions {
+    break-inside: avoid;
+  }
+
+  table {
+    min-width: 0;
+    font-size: 8px;
+  }
+
+  th,
+  td {
+    padding: 5px 6px;
+  }
+
+  .health-card,
+  .health-note,
+  .chart-box {
+    box-shadow: none;
+  }
+
+  .segbar,
+  .bar-fill,
+  .donut,
+  .status,
+  .value-level,
+  .metric,
+  .headline {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}
+</style>
+<noscript><style>.tabs-wrap{display:none!important}.tab-panel[hidden]{display:block!important}</style></noscript>
+</head>
+<body>
+<a class="skip-link" href="#content">跳到报告正文</a>
+<article class="report">
+  <header class="masthead">
+    <div class="topline">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">SH</span>
+        <span class="brand-name">SkillHub</span>
+        <span class="brand-tag">开源周报</span>
+      </div>
+      <nav class="utility-links" aria-label="站点链接">
+        <a href="{{ARCHIVE_HREF}}">历史周报</a>
+        <a href="{{DOCS_HREF}}">项目文档</a>
+        <a href="{{REPOSITORY_URL}}">GitHub 仓库</a>
+      </nav>
+    </div>
+    <h1>{{REPORT_TITLE}}</h1>
+    <p class="report-sub">项目健康 · 版本交付 · 开源生态 · Issue/PR 流转与价值队列</p>
+    <div class="header-grid">
+      <div class="meta-card">
+        <div class="meta-grid">
+          <div class="meta-item"><span class="key">统计周期</span><span class="value">{{REPORTING_PERIOD}}</span></div>
+          <div class="meta-item"><span class="key">当前状态快照</span><span class="value">{{SNAPSHOT_TIME}}</span></div>
+          <div class="meta-item"><span class="key">项目仓库</span><span class="value"><a href="{{REPOSITORY_URL}}">{{REPOSITORY_NAME}}</a></span></div>
+          <div class="meta-item"><span class="key">数据来源</span><span class="value">{{DATA_SOURCE_SUMMARY}}</span></div>
+        </div>
+      </div>
+      <div class="headline">
+        <span class="headline-label">总体状态</span>
+        <div class="headline-status">
+          <strong>{{OVERALL_STATUS}}</strong>
+          <span class="status {{OVERALL_STATUS_CLASS}}">{{OVERALL_STATUS_EN}}</span>
+        </div>
+        <p>{{OVERALL_CONCLUSION}}</p>
+      </div>
+    </div>
+    <div class="metrics" aria-label="四项核心指标">
+      <div class="metric"><strong>{{METRIC_1_VALUE}}</strong><span>{{METRIC_1_LABEL}}</span></div>
+      <div class="metric"><strong>{{METRIC_2_VALUE}}</strong><span>{{METRIC_2_LABEL}}</span></div>
+      <div class="metric"><strong>{{METRIC_3_VALUE}}</strong><span>{{METRIC_3_LABEL}}</span></div>
+      <div class="metric"><strong>{{METRIC_4_VALUE}}</strong><span>{{METRIC_4_LABEL}}</span></div>
+    </div>
+  </header>
+
+  <div class="tabs-wrap">
+    <nav class="tabs" role="tablist" aria-label="周报视图">
+      <button class="tab" id="tab-overview" type="button" role="tab" aria-selected="true"
+        aria-controls="panel-overview" tabindex="0" data-tab="overview">总览</button>
+      {{HEALTH_TAB}}
+      {{ISSUE_PR_TAB}}
+      <button class="tab" id="tab-method" type="button" role="tab" aria-selected="false"
+        aria-controls="panel-method" tabindex="-1" data-tab="method">数据说明</button>
+    </nav>
+  </div>
+
+  <main id="content">
+    <div class="tab-panel" id="panel-overview" role="tabpanel" tabindex="0"
+      aria-labelledby="tab-overview" data-panel="overview">
+      <p class="panel-intro">三分钟总览：只保留仓库、迭代和生态三类决策信息。</p>
+      {{REPOSITORY_MODULE}}
+      {{FEATURE_MODULE}}
+      {{ECOSYSTEM_MODULE}}
+      {{NEXT_ACTIONS_MODULE}}
+    </div>
+
+    {{HEALTH_PANEL}}
+    {{ISSUE_PR_PANEL}}
+
+    <div class="tab-panel" id="panel-method" role="tabpanel" tabindex="0"
+      aria-labelledby="tab-method" data-panel="method" hidden>
+      <p class="panel-intro">时间边界、数据来源、公式与缺失项。</p>
+      {{DATA_MODULES}}
+    </div>
+  </main>
+  <footer><span>{{FOOTER_LEFT}}</span><span>{{FOOTER_RIGHT}}</span></footer>
+</article>
+
+<script>
+(function () {
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
+  var panels = Array.prototype.slice.call(document.querySelectorAll('[role="tabpanel"]'));
+  function activate(name, moveFocus, updateHash) {
+    var next = tabs.find(function (tab) { return tab.dataset.tab === name; }) || tabs[0];
+    tabs.forEach(function (tab) {
+      var selected = tab === next;
+      tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+      tab.tabIndex = selected ? 0 : -1;
+    });
+    panels.forEach(function (panel) { panel.hidden = panel.dataset.panel !== next.dataset.tab; });
+    if (moveFocus) next.focus();
+    if (updateHash && history.replaceState) history.replaceState(null, '', '#' + next.dataset.tab);
+  }
+  tabs.forEach(function (tab, index) {
+    tab.addEventListener('click', function () { activate(tab.dataset.tab, false, true); });
+    tab.addEventListener('keydown', function (event) {
+      var nextIndex = index;
+      if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+      else if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+      else if (event.key === 'Home') nextIndex = 0;
+      else if (event.key === 'End') nextIndex = tabs.length - 1;
+      else return;
+      event.preventDefault();
+      activate(tabs[nextIndex].dataset.tab, true, true);
+    });
+  });
+  window.addEventListener('hashchange', function () {
+    activate(location.hash.replace('#', ''), false, false);
+  });
+  activate(location.hash.replace('#', ''), false, false);
+}());
+</script>
+</body>
+</html>

--- a/.agents/skills/generate-skillhub-weekly-report/references/metrics.md
+++ b/.agents/skills/generate-skillhub-weekly-report/references/metrics.md
@@ -1,0 +1,192 @@
+# SkillHub Weekly Metrics
+
+## Source Priority
+
+Use the highest available source and retain retrieval timestamps:
+
+1. Authenticated GitHub REST API or GitHub CLI output.
+2. Public GitHub REST API and release pages.
+3. Saved JSON/CSV snapshots from the reporting period.
+4. Maintainer-provided Issue/PR notes and promotion links.
+5. Local Git history and repository workflow files.
+
+If a higher-priority source is inaccessible, continue with the next source. State the gap and never substitute zero.
+
+## Time Boundaries
+
+- Reporting label: previous Thursday through current Thursday in `Asia/Shanghai`.
+- Event period: after the previous Thursday cutoff through the current Thursday cutoff, expressed as `(previous_cutoff, current_cutoff]`. Store both exact timestamps so boundary-day events are counted once across adjacent reports.
+- If no previous Thursday cutoff exists, use the previous Thursday 00:00 as the fallback start and state that fallback in the data Tab.
+- API period: convert both endpoints to UTC before filtering timestamps.
+- Current snapshot: capture a single explicit timestamp after the reporting period.
+- Thursday invocation before the report cutoff: end at the explicit snapshot and label the cycle as partial.
+- Post-period progress: events after the current Thursday cutoff. Report them beside the relevant item and exclude them from weekly totals.
+- Cadence migration: retain the requested previous-Thursday—current-Thursday label. If the fallback start overlaps an older Monday—Sunday report, disclose the overlapping dates rather than shortening the new report. Subsequent reports must use the prior cutoff timestamp to avoid duplicate events.
+
+Use `created_at` for inflow, `closed_at` for closures, `merged_at` for merges, and `published_at` for Releases.
+
+## GitHub Semantics
+
+The GitHub REST Issues endpoint returns both Issues and pull requests. Identify PR-shaped entries by the presence of the `pull_request` key, or use the Pull Requests endpoint for PR calculations. Do not use repository `open_issues_count` as an Issue-only count.
+
+Relevant read endpoints:
+
+| Data | REST path | Notes |
+|---|---|---|
+| Repository snapshot | `/repos/{owner}/{repo}` | Stars, forks, subscribers/watchers and repository metadata |
+| Issues | `/repos/{owner}/{repo}/issues` | Includes PRs; paginate and separate them |
+| Pull requests | `/repos/{owner}/{repo}/pulls` | Use detailed PR reads for additions, deletions, changed files and merge state |
+| Releases | `/repos/{owner}/{repo}/releases` | Filter by `published_at`; distinguish app and `cli-*` tags |
+| Workflow runs | `/repos/{owner}/{repo}/actions/runs` | Paginate and filter by `created_at` |
+| Forks | `/repos/{owner}/{repo}/forks` | Paginate before filtering by creation time |
+| Traffic | `/repos/{owner}/{repo}/traffic/*` | May require additional repository access; record unavailable responses |
+
+Use a page size up to 100 and follow pagination until the time boundary is safely crossed. Do not rely on the first page.
+
+## Default Overview Selection
+
+The overview does not display every available metric. Select only:
+
+- current Stars and Forks;
+- weekly Actions effective success rate;
+- weekly app/CLI Release result;
+- weekly Issue created/closed;
+- weekly PR created/merged/closed;
+- weekly Forks or CLI downloads when they materially describe ecosystem activity.
+
+Visualize only verified relationships:
+
+- repository scale: current Stars/Forks with valid timestamped changes;
+- collaboration flow: Issue created/closed and PR created/merged/closed-unmerged;
+- ecosystem signals: authors, merged contributors, Forks, and downloads as separate signals, never as a funnel.
+
+Put Actions composition, queue age, security details, and response latency in the corresponding detail Tab. Do not repeat them in the overview.
+
+## Default Detail Tabs
+
+Use the normal HTML report to expose concise detail without turning the overview into a dashboard:
+
+- **项目健康**: one health judgment table, one workflow table, release/security notes, age bands, and response evidence;
+- **Issue 与 PR**: weekly flow, weekly value ranking, current A/B priorities, and a collapsed cleanup list;
+- **数据说明**: time boundaries, formulas, source coverage, permissions, and missing data.
+
+Reserve complete A—D queues and every open item for explicit full governance mode.
+
+## Health Dimensions
+
+### Engineering Stability
+
+Report:
+
+- total Actions records;
+- actually executed runs;
+- successes and failures;
+- `action_required`;
+- conditional `skipped`;
+- effective success rate;
+- failure concentration by workflow or PR;
+- recovery evidence.
+
+Calculate:
+
+```text
+effective_success_rate = success / (success + failure)
+```
+
+Exclude `action_required` and conditional `skipped` from the denominator, but display their counts because they indicate coverage gaps.
+
+### Security and Supply Chain
+
+Report:
+
+- executed Security runs and failures;
+- runs awaiting authorization;
+- presence of scheduled CodeQL/dependency review controls when verified from workflow files;
+- public security issues or supply-chain proposals.
+
+Successful runs mean the pipeline executed successfully. They do not prove that open vulnerability counts are zero.
+
+### Automation Operations
+
+Report actual execution and success for backlog rescoring, Issue triage, documentation deployment, rewards, or other governance automation. Separate intentional skips from failures.
+
+### Release Delivery
+
+Report:
+
+- app Releases in the period;
+- CLI Releases in the period;
+- latest release before or within the period;
+- release gap at period end;
+- post-period Releases, explicitly excluded from weekly totals;
+- whether the “one Release per week” goal was met or skipped with reason.
+
+### Issue Governance
+
+Report:
+
+- created and closed during the period;
+- net change;
+- current open count;
+- priority and triage-label structure;
+- age bands: `<7`, `7—13`, `14—29`, `≥30` days;
+- `needs-info` count and proportion;
+- observable human response coverage.
+
+### PR Governance
+
+Report:
+
+- created, merged, and closed without merge during the period;
+- open-count change;
+- current open count;
+- age bands;
+- stale, superseded, already-implemented, blocked, and ready-to-merge groups;
+- merge Lead Time only with sample size and limitation.
+
+### Community Response
+
+Separate:
+
+1. automatic triage latency;
+2. first maintainer acknowledgement;
+3. first executable disposition or paired PR;
+4. final closure.
+
+Automatic comments do not count as maintainer acknowledgement.
+
+## Promotion Metrics
+
+Track actions and outcomes separately:
+
+| Action fields | Outcome examples |
+|---|---|
+| Type, title, channel/partner, date, URL | Reads, views, interactions, clicks, referred visits, integrations |
+
+Also report weekly forks, npm CLI downloads, and timestamped repository snapshots. Do not infer weekly Star growth without a period-start snapshot. Do not claim an action caused a change without attribution evidence.
+
+## Ecosystem Metrics
+
+Include:
+
+- unique new Issue authors and author association;
+- unique new PR authors;
+- merged community contributors;
+- documentation contributions;
+- Agent integrations or partner projects;
+- recurring demand themes;
+- community-feedback-to-delivery closures;
+- product-boundary risks.
+
+Forks, downloads, Issue authors, PR authors, and merged contributors represent different participation signals. They are not a conversion funnel unless the same cohort is linked across stages.
+
+## Value Ranking
+
+Rank weekly flow and current backlog separately:
+
+- **A**: immediate maintenance value; material user impact with clear evidence or mature implementation.
+- **B**: high value but requires design, security review, decomposition, or a clear gate.
+- **C**: conditional, limited-scope, or appropriate for incremental work.
+- **D**: defer, transfer, supersede, or close.
+
+Use user impact, product fit, security/operational risk, evidence quality, implementation maturity, and maintenance cost. Explain the judgment; do not rank by label alone.

--- a/.agents/skills/generate-skillhub-weekly-report/references/report-structure.md
+++ b/.agents/skills/generate-skillhub-weekly-report/references/report-structure.md
@@ -1,0 +1,101 @@
+# SkillHub Tabbed Weekly Report
+
+## Information Architecture
+
+Use a self-contained HTML report with two required Tabs (`总览`, `数据说明`) and two optional Tabs (`项目健康`, `Issue 与 PR`).
+
+### Shared Header
+
+Use one conclusion sentence and exactly four headline metrics. Put the current Star total and its valid comparison in the first metric. If the period-start Star snapshot is missing, write `周增量未取得`; if only a partial comparison exists, show both timestamps and mark it as non-natural-week data.
+
+### Tab 1：总览
+
+Keep this Tab to about 2–3 desktop screens and 800–1,500 Chinese characters.
+
+#### 一、仓库关键信息（必选）
+
+Use two compact visual blocks:
+
+- **规模快照**：current Stars and Forks plus valid weekly or timestamped changes;
+- **协作流转**：horizontal bars for weekly Issue created/closed and PR created/merged/closed-unmerged.
+
+Mention Actions, Release, and current open Issue/PR counts in one concise judgment under the visuals. End with one risk sentence. Do not expose workflow-by-workflow detail here. Do not draw a Star trend from fewer than two comparable snapshots.
+
+#### 二、功能迭代信息（有内容时）
+
+Show 3–5 important items, ordered by user value:
+
+| Status | Item | Weekly progress | Next step or post-period result |
+|---|---|---|---|
+
+Use statuses such as `已完成`, `推进中`, `期后完成`, `待设计`, and `受阻`. Include related Issue, PR, and Release links.
+
+Do not turn every Issue or PR into a feature item.
+
+#### 三、生态相关进展（有内容时）
+
+Combine:
+
+- unique community participants;
+- merged community contributions;
+- documentation and Agent integration results;
+- weekly Forks and CLI downloads;
+- maintainer-provided articles, talks, sharing, and partner projects.
+
+When verified, begin with three independent signal tiles: contributor participation, weekly Forks, and CLI downloads. State that the signals do not form a funnel. Follow with a short list of delivered integrations, documentation, promotion, and cooperation, with at most five rows.
+
+#### 下周关注
+
+Use no more than three actions. Each action needs a concrete object and observable result.
+
+### Tab 2：项目健康（有模块时）
+
+Include concise evidence for:
+
+- health cards for engineering stability, security, automation, Release, Issue governance, and PR governance;
+- an Actions segmented bar for success, failure, authorization wait, skipped, and cancelled outcomes;
+- security pipeline execution and authorization gaps;
+- release delivery and post-period releases;
+- horizontal age bars for open Issue and PR;
+- a donut only when a meaningful numerator and denominator exist, such as `needs-info / open Issue`;
+- automatic versus maintainer response.
+
+Keep workflow breakdowns in one table. Successful security workflows mean pipeline stability, not zero vulnerabilities.
+
+### Tab 3：Issue 与 PR（有模块时）
+
+Show:
+
+1. weekly created/closed/merged flow;
+2. weekly new Issues and PRs ordered by value;
+3. current A and B priority queues;
+4. one collapsed cleanup block for superseded or already-implemented PRs.
+
+Only include the complete A—D backlog when full governance mode is explicitly requested.
+
+### Tab 4：数据说明（必选）
+
+Keep timezone, snapshot, source coverage, missing permissions, formulas, and the meaning of post-period data here. Do not repeat methodology in other Tabs.
+
+## Editorial Rules
+
+- Use short, formal Chinese sentences.
+- Keep the overview around 800–1,500 Chinese characters.
+- Limit headline metrics to four.
+- Limit feature and ecosystem rows to five each.
+- Do not add a separate execution summary, promotion chapter, or appendix to the overview.
+- Label `未取得`, `无法计算`, and `期后` precisely.
+- Do not repeat the same fact in multiple sections.
+
+## HTML Rules
+
+- Use the bundled Notion-light theme: white canvas, warm-gray bands, near-black text, light borders, and one blue interaction accent.
+- Use one paper-like content column. Reserve cards for headline metrics, health judgments, and evidence charts.
+- Use tables for linked iteration and queue details; use charts only for composition or distribution questions.
+- Give `.bars`, `.segbar`, `.donut`, and `.ecosystem-signals` `role="img"`, a complete numeric `aria-label`, and adjacent visible values.
+- Wrap each optional chart in its own `data-module`; omit the complete chart when source values are missing.
+- Keep one HTML file with inline CSS and no external assets.
+- Implement Tabs with buttons, ARIA relationships, arrow keys, and URL hashes.
+- Mark each optional block with `data-module`; omit empty modules and omit empty detail Tabs with their panels.
+- Show every panel without JavaScript and when printing.
+- Support keyboard focus, horizontal Tab scrolling, narrow screens, reduced motion, and A4 print.

--- a/.agents/skills/generate-skillhub-weekly-report/scripts/validate_report.py
+++ b/.agents/skills/generate-skillhub-weekly-report/scripts/validate_report.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Validate the structure and self-contained nature of a SkillHub weekly report."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+OVERVIEW_ORDER = (
+    "仓库关键信息",
+    "功能迭代信息",
+    "生态相关进展",
+)
+HARD_PLACEHOLDERS = ("{{", "}}", "[TODO", "TODO:")
+CHART_CLASSES = {"bars", "segbar", "donut", "ecosystem-signals"}
+VOID_ELEMENTS = {
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+}
+NON_CONTENT_ELEMENTS = {"caption", "h1", "h2", "h3", "h4", "h5", "h6", "th"}
+
+
+class ReportHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.ids: set[str] = set()
+        self.duplicate_ids: set[str] = set()
+        self.h1_count = 0
+        self.h2_count = 0
+        self.table_count = 0
+        self.caption_count = 0
+        self.tablist_count = 0
+        self.tabs: list[tuple[str, str, str, str]] = []
+        self.panels: list[tuple[str, str]] = []
+        self.noscript_count = 0
+        self.external_assets: list[str] = []
+        self.text_parts: list[str] = []
+        self.panel_text_parts: dict[str, list[str]] = {}
+        self.panel_modules: dict[str, int] = {}
+        self.current_panel: str | None = None
+        self.panel_depth = 0
+        self.module_stack: list[dict[str, object]] = []
+        self.module_counts: dict[str, int] = {}
+        self.module_panels: dict[str, set[str]] = {}
+        self.module_names: set[str] = set()
+        self.empty_modules: set[str] = set()
+        self.table_stack: list[dict[str, int]] = []
+        self.empty_table_count = 0
+        self.chart_issues: list[str] = []
+        self.ignored_depth = 0
+        self.non_content_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        is_void = tag in VOID_ELEMENTS
+        if self.current_panel is not None and not is_void:
+            self.panel_depth += 1
+        if not is_void:
+            for module in self.module_stack:
+                module["depth"] = int(module["depth"]) + 1
+            for table in self.table_stack:
+                table["depth"] += 1
+        if tag in {"style", "script"}:
+            self.ignored_depth += 1
+        if tag in NON_CONTENT_ELEMENTS:
+            self.non_content_depth += 1
+        values = dict(attrs)
+        class_names = set((values.get("class") or "").split())
+        chart_names = sorted(class_names & CHART_CLASSES)
+        if chart_names:
+            chart_name = "/".join(chart_names)
+            if values.get("role") != "img":
+                self.chart_issues.append(f".{chart_name} is missing role=img")
+            if not (values.get("aria-label") or "").strip():
+                self.chart_issues.append(f".{chart_name} is missing a numeric aria-label")
+            if not values.get("data-module") and not self.module_stack:
+                self.chart_issues.append(f".{chart_name} is not inside a data-module")
+        element_id = values.get("id")
+        if element_id:
+            if element_id in self.ids:
+                self.duplicate_ids.add(element_id)
+            self.ids.add(element_id)
+
+        if tag == "h1":
+            self.h1_count += 1
+        elif tag == "h2":
+            self.h2_count += 1
+        elif tag == "table":
+            self.table_count += 1
+            self.table_stack.append({"depth": 1, "data_cells": 0})
+        elif tag == "td":
+            for table in self.table_stack:
+                table["data_cells"] += 1
+        elif tag == "caption":
+            self.caption_count += 1
+        elif tag == "noscript":
+            self.noscript_count += 1
+
+        role = values.get("role")
+        if role == "tablist":
+            self.tablist_count += 1
+        elif role == "tab":
+            self.tabs.append(
+                (
+                    tag,
+                    values.get("id") or "",
+                    values.get("aria-controls") or "",
+                    values.get("aria-selected") or "",
+                )
+            )
+        elif role == "tabpanel":
+            panel_id = values.get("id") or ""
+            self.panels.append((panel_id, values.get("aria-labelledby") or ""))
+            self.current_panel = panel_id
+            self.panel_depth = 1
+            self.panel_text_parts.setdefault(panel_id, [])
+            self.panel_modules.setdefault(panel_id, 0)
+
+        module_name = values.get("data-module")
+        if module_name:
+            self.module_names.add(module_name)
+            self.module_counts[module_name] = self.module_counts.get(module_name, 0) + 1
+            if self.current_panel:
+                self.module_panels.setdefault(module_name, set()).add(self.current_panel)
+            if is_void:
+                self.empty_modules.add(module_name)
+            else:
+                self.module_stack.append(
+                    {"depth": 1, "name": module_name, "has_meaningful_content": False}
+                )
+            if self.current_panel:
+                self.panel_modules[self.current_panel] = self.panel_modules.get(self.current_panel, 0) + 1
+
+        if tag == "script" and values.get("src"):
+            self.external_assets.append(f"script src={values['src']}")
+        elif tag == "link" and "stylesheet" in (values.get("rel") or ""):
+            self.external_assets.append(f"stylesheet href={values.get('href', '')}")
+        elif tag in {"img", "source"}:
+            source = values.get("src") or values.get("srcset")
+            if source and not source.startswith("data:"):
+                self.external_assets.append(f"{tag} src={source}")
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.handle_starttag(tag, attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"style", "script"} and self.ignored_depth:
+            self.ignored_depth -= 1
+        if tag in NON_CONTENT_ELEMENTS and self.non_content_depth:
+            self.non_content_depth -= 1
+        for module in self.module_stack:
+            module["depth"] = int(module["depth"]) - 1
+        while self.module_stack and int(self.module_stack[-1]["depth"]) == 0:
+            module = self.module_stack.pop()
+            if not module["has_meaningful_content"]:
+                self.empty_modules.add(str(module["name"]))
+        for table in self.table_stack:
+            table["depth"] -= 1
+        while self.table_stack and self.table_stack[-1]["depth"] == 0:
+            table = self.table_stack.pop()
+            if table["data_cells"] == 0:
+                self.empty_table_count += 1
+        if self.current_panel is not None:
+            self.panel_depth -= 1
+            if self.panel_depth == 0:
+                self.current_panel = None
+
+    def handle_data(self, data: str) -> None:
+        if not self.ignored_depth and data.strip():
+            text = data.strip()
+            self.text_parts.append(text)
+            if not self.non_content_depth:
+                for module in self.module_stack:
+                    module["has_meaningful_content"] = True
+            if self.current_panel is not None:
+                self.panel_text_parts[self.current_panel].append(text)
+
+    @property
+    def text(self) -> str:
+        return " ".join(self.text_parts)
+
+    def panel_text(self, panel_id: str) -> str:
+        return " ".join(self.panel_text_parts.get(panel_id, []))
+
+
+def check_order(text: str, errors: list[str]) -> None:
+    repository_index = text.find(OVERVIEW_ORDER[0])
+    if repository_index < 0:
+        errors.append(f"missing required chapter: {OVERVIEW_ORDER[0]}")
+        return
+    cursor = repository_index
+    for heading in OVERVIEW_ORDER[1:]:
+        index = text.find(heading)
+        if index >= 0 and index < cursor:
+            errors.append(f"overview chapter is out of order: {heading}")
+        if index >= 0:
+            cursor = index
+
+
+def check_placeholders(text: str, errors: list[str], warnings: list[str]) -> None:
+    for token in HARD_PLACEHOLDERS:
+        if token in text:
+            errors.append(f"unresolved template token: {token}")
+    if "待补充" in text:
+        warnings.append("report still contains 待补充; acceptable only for maintainer promotion input")
+
+
+def validate_html(path: Path, strict: bool) -> int:
+    source = path.read_text(encoding="utf-8")
+    parser = ReportHTMLParser()
+    parser.feed(source)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    overview_text = parser.panel_text("panel-overview")
+    check_order(overview_text or parser.text, errors)
+    check_placeholders(source, errors, warnings)
+
+    if parser.h1_count != 1:
+        errors.append(f"expected exactly one h1, found {parser.h1_count}")
+    if parser.h2_count < 1:
+        errors.append("expected at least one h2 heading")
+    if parser.tablist_count != 1:
+        errors.append(f"expected exactly one tablist, found {parser.tablist_count}")
+    if not 2 <= len(parser.tabs) <= 4 or len(parser.tabs) != len(parser.panels):
+        errors.append(
+            f"expected two to four matching tabs and panels, found {len(parser.tabs)} tab(s) "
+            f"and {len(parser.panels)} panel(s)"
+        )
+    tab_ids = {tab_id for _, tab_id, _, _ in parser.tabs}
+    panel_ids = {panel_id for panel_id, _ in parser.panels}
+    controlled_panels = {controls for _, _, controls, _ in parser.tabs}
+    labelled_tabs = {labelled_by for _, labelled_by in parser.panels}
+    if any(tag != "button" for tag, _, _, _ in parser.tabs):
+        errors.append("every role=tab element must be a button")
+    if any(not tab_id or not controls for _, tab_id, controls, _ in parser.tabs):
+        errors.append("every tab must define id and aria-controls")
+    if any(not panel_id or not labelled_by for panel_id, labelled_by in parser.panels):
+        errors.append("every tabpanel must define id and aria-labelledby")
+    if controlled_panels != panel_ids:
+        errors.append("tab aria-controls values do not match tabpanel ids")
+    if labelled_tabs != tab_ids:
+        errors.append("tabpanel aria-labelledby values do not match tab ids")
+    if sum(selected == "true" for _, _, _, selected in parser.tabs) != 1:
+        errors.append("exactly one tab must have aria-selected=true")
+    if not {"panel-overview", "panel-method"}.issubset(panel_ids):
+        errors.append("overview and data panels are required")
+    if "repository-summary" not in parser.module_names:
+        errors.append("missing required repository-summary module")
+    elif parser.module_panels.get("repository-summary") != {"panel-overview"}:
+        errors.append("repository-summary must appear in panel-overview")
+    duplicate_modules = sorted(
+        name for name, count in parser.module_counts.items() if count > 1
+    )
+    if duplicate_modules:
+        errors.append(f"duplicate module names: {', '.join(duplicate_modules)}")
+    if parser.empty_modules:
+        errors.append(
+            "modules without meaningful content: "
+            f"{', '.join(sorted(parser.empty_modules))}"
+        )
+    if parser.empty_table_count:
+        errors.append(f"empty tables without data cells: {parser.empty_table_count}")
+    if parser.module_stack:
+        errors.append("unclosed data-module element")
+    if parser.table_stack:
+        errors.append("unclosed table element")
+    empty_panels = sorted(
+        panel_id for panel_id, module_count in parser.panel_modules.items() if module_count == 0
+    )
+    if empty_panels:
+        errors.append(f"panels without modules: {', '.join(empty_panels)}")
+    if parser.noscript_count < 1:
+        errors.append("expected a no-JavaScript fallback")
+    if "location.hash" not in source:
+        errors.append("expected direct-hash tab activation")
+    if parser.duplicate_ids:
+        errors.append(f"duplicate ids: {', '.join(sorted(parser.duplicate_ids))}")
+    if parser.external_assets:
+        errors.append("external file dependencies: " + "; ".join(parser.external_assets))
+    if parser.chart_issues:
+        errors.extend(parser.chart_issues)
+    if parser.caption_count < parser.table_count:
+        warnings.append(
+            f"{parser.table_count - parser.caption_count} table(s) have no caption; "
+            "a nearby heading may be sufficient, but verify accessibility"
+        )
+    if "期后进展" in parser.text and "不计入" not in parser.text:
+        errors.append("post-period progress is present without an explicit exclusion from weekly totals")
+    if "下周关注" not in parser.text:
+        warnings.append("report has no 下周关注 block")
+    overview_characters = len(re.findall(r"[\u4e00-\u9fff]", overview_text))
+    if overview_characters > 1800:
+        warnings.append(
+            f"overview contains about {overview_characters} Chinese characters; "
+            "compact overviews should usually stay under 1800"
+        )
+
+    return emit(path, errors, warnings, strict)
+
+
+def validate_markdown(path: Path, strict: bool) -> int:
+    source = path.read_text(encoding="utf-8")
+    text = re.sub(r"[`*_>#|]", "", source)
+    errors: list[str] = []
+    warnings: list[str] = []
+    check_order(text, errors)
+    check_placeholders(source, errors, warnings)
+
+    if len(re.findall(r"^# ", source, flags=re.MULTILINE)) != 1:
+        errors.append("expected exactly one level-one heading")
+    if "期后" in source and "不计入" not in source:
+        errors.append("post-period progress is present without an explicit exclusion from weekly totals")
+    if "下周关注" not in source:
+        warnings.append("report has no 下周关注 block")
+    chinese_characters = len(re.findall(r"[\u4e00-\u9fff]", source))
+    if chinese_characters > 2500:
+        warnings.append(
+            f"report contains about {chinese_characters} Chinese characters; "
+            "compact reports should usually stay under 2500"
+        )
+
+    return emit(path, errors, warnings, strict)
+
+
+def emit(path: Path, errors: list[str], warnings: list[str], strict: bool) -> int:
+    print(f"Validating {path}")
+    for warning in warnings:
+        print(f"WARN: {warning}")
+    for error in errors:
+        print(f"ERROR: {error}")
+    if errors or (strict and warnings):
+        print(f"FAIL: {len(errors)} error(s), {len(warnings)} warning(s)")
+        return 1
+    print(f"PASS: 0 errors, {len(warnings)} warning(s)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--strict", action="store_true", help="treat warnings as failures")
+    args = parser.parse_args()
+
+    if not args.report.is_file():
+        parser.error(f"report not found: {args.report}")
+    suffix = args.report.suffix.lower()
+    if suffix in {".html", ".htm"}:
+        return validate_html(args.report, args.strict)
+    if suffix in {".md", ".markdown"}:
+        return validate_markdown(args.report, args.strict)
+    parser.error("report must be Markdown or HTML")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'docs/skillhub/**'
+      - 'weekly/**'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -34,8 +36,17 @@ jobs:
         uses: actions/configure-pages@v4
       - name: Install dependencies
         run: cd docs/skillhub && npm ci
+      - name: Build and validate weekly reports
+        run: |
+          cd weekly
+          python3 scripts/build_site.py
+          python3 scripts/validate_site.py _site
       - name: Build with VitePress
         run: cd docs/skillhub && npm run build
+      - name: Add weekly reports to Pages artifact
+        run: |
+          mkdir -p docs/skillhub/.vitepress/dist/weekly
+          cp -R weekly/_site/. docs/skillhub/.vitepress/dist/weekly/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -88,7 +88,10 @@ jobs:
           filters: |
             docs:
               - 'docs/skillhub/**'
+              - 'weekly/**'
+              - '.agents/skills/generate-skillhub-weekly-report/**'
               - '.github/workflows/pr-tests.yml'
+              - '.github/workflows/deploy-docs.yml'
 
       - name: Set up Node.js
         if: steps.changed.outputs.docs == 'true'
@@ -105,3 +108,18 @@ jobs:
       - name: Build VitePress site
         if: steps.changed.outputs.docs == 'true'
         run: cd docs/skillhub && npm run build
+
+      - name: Build and validate weekly reports
+        if: steps.changed.outputs.docs == 'true'
+        run: |
+          cd weekly
+          python3 scripts/build_site.py
+          python3 scripts/validate_site.py _site
+
+      - name: Assemble Pages artifact layout
+        if: steps.changed.outputs.docs == 'true'
+        run: |
+          mkdir -p docs/skillhub/.vitepress/dist/weekly
+          cp -R weekly/_site/. docs/skillhub/.vitepress/dist/weekly/
+          test -f docs/skillhub/.vitepress/dist/weekly/index.html
+          test -f docs/skillhub/.vitepress/dist/weekly/archive.html

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ package-lock.json
 .tmp/
 tmp/
 __pycache__/
+weekly/_site/
 
 # Git worktrees
 .worktrees/

--- a/docs/skillhub/.vitepress/config.ts
+++ b/docs/skillhub/.vitepress/config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
           { text: '首页', link: '/' },
           { text: '快速开始', link: '/quickstart' },
           { text: '功能指南', link: '/guide/skill-publish' },
+          { text: '开源周报', link: 'https://iflytek.github.io/skillhub/weekly/' },
           { text: 'FAQ', link: '/faq' },
         ],
         sidebar: [
@@ -69,6 +70,7 @@ export default defineConfig({
           { text: 'Home', link: '/en/' },
           { text: 'Quick Start', link: '/en/quickstart' },
           { text: 'Guide', link: '/en/guide/skill-publish' },
+          { text: 'Weekly Reports', link: 'https://iflytek.github.io/skillhub/weekly/' },
           { text: 'FAQ', link: '/en/faq' },
         ],
         sidebar: [

--- a/weekly/README.md
+++ b/weekly/README.md
@@ -1,0 +1,26 @@
+# SkillHub Weekly Mirror
+
+This directory is the reviewed mirror of the public
+[`XiaoSeS/skillhub-weekly`](https://github.com/XiaoSeS/skillhub-weekly) site.
+The standalone repository remains the authoritative content source.
+
+The SkillHub documentation workflow builds this directory and places the result
+under the existing VitePress Pages artifact:
+
+- Latest report: `https://iflytek.github.io/skillhub/weekly/`
+- Archive: `https://iflytek.github.io/skillhub/weekly/archive.html`
+- Report: `https://iflytek.github.io/skillhub/weekly/reports/<week>/`
+
+## Local validation
+
+```bash
+cd weekly
+python3 scripts/sync_report_theme.py site/reports/*/index.html
+python3 scripts/build_site.py
+python3 scripts/validate_site.py _site
+```
+
+Do not edit `_site/`; it is ignored and rebuilt by CI. Update reports in the
+standalone repository first, then copy `site/`, `assets/`, and `scripts/`
+byte-for-byte into this directory so both published sites keep the same report
+HTML, Notion-light theme, charts, and Tab behavior.

--- a/weekly/assets/notion-light.css
+++ b/weekly/assets/notion-light.css
@@ -1,0 +1,1176 @@
+:root {
+  color-scheme: light;
+  --page: #ffffff;
+  --paper: #ffffff;
+  --warm: #f6f5f4;
+  --ink: #0d0d0d;
+  --ink-soft: #31302e;
+  --muted: #615d59;
+  --faint: #76716c;
+  --line: #e5e3e1;
+  --line-soft: #efeeec;
+  --blue: #0075de;
+  --blue-active: #005bab;
+  --blue-soft: #f2f9ff;
+  --green: #147a33;
+  --green-soft: #e9f7ec;
+  --orange: #b84d00;
+  --orange-soft: #fdf0e3;
+  --red: #b52d25;
+  --red-soft: #fdecea;
+  --neutral-soft: #f1f0ef;
+  --focus: #097fe8;
+  --radius-sm: 8px;
+  --radius: 12px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 4%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 15px/1.65 Inter, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--blue-active);
+  text-decoration: underline;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--neutral-soft);
+  color: var(--ink-soft);
+  font-size: .92em;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 30;
+  top: 8px;
+  left: -999px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background: var(--ink-soft);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: 8px;
+}
+
+.report {
+  width: min(1200px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.masthead {
+  padding: 44px 28px 36px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 26px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: var(--ink-soft);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.brand-name {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+}
+
+.brand-tag {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--neutral-soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.utility-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 820px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(32px, 4vw, 44px);
+  line-height: 1.15;
+  letter-spacing: -.025em;
+}
+
+.report-sub {
+  margin: 8px 0 24px;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: 1.15fr .85fr;
+  gap: 16px;
+}
+
+.meta-card,
+.headline {
+  border-radius: var(--radius-sm);
+  padding: 20px 22px;
+}
+
+.meta-card {
+  background: var(--warm);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.meta-item .key,
+.headline-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--faint);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: .01em;
+}
+
+.meta-item .value {
+  color: var(--ink-soft);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.period {
+  margin: 0;
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  border: 0;
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.headline-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 7px;
+}
+
+.headline-status strong {
+  color: var(--orange);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.headline p {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 18px;
+  border: 0;
+}
+
+.metric {
+  min-width: 0;
+  padding: 16px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.metric strong {
+  display: block;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.tabs-wrap {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+  background: rgb(255 255 255 / 97%);
+  backdrop-filter: saturate(1.1) blur(5px);
+}
+
+.tabs {
+  display: flex;
+  min-width: max-content;
+  padding: 0 28px;
+}
+
+.tab {
+  position: relative;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.tab::after {
+  position: absolute;
+  right: 14px;
+  bottom: -1px;
+  left: 14px;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.tab:hover,
+.tab[aria-selected="true"] {
+  color: var(--ink);
+}
+
+.tab[aria-selected="true"] {
+  font-weight: 600;
+}
+
+.tab[aria-selected="true"]::after {
+  background: var(--ink-soft);
+}
+
+main {
+  padding: 0 28px 48px;
+}
+
+.tab-panel {
+  padding-top: 4px;
+}
+
+.js .tab-panel[hidden] {
+  display: none;
+}
+
+.panel-intro {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.panel-intro p {
+  margin: 0;
+}
+
+section.report-section {
+  margin: 0;
+  padding: 48px 0;
+  border: 0;
+}
+
+.tab-panel > section.report-section:nth-of-type(even) {
+  background: var(--warm);
+  box-shadow: 0 0 0 100vmax var(--warm);
+  clip-path: inset(0 -100vmax);
+}
+
+section.report-section:first-of-type {
+  padding-top: 42px;
+}
+
+h2 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+h3 {
+  margin: 30px 0 12px;
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.35;
+  letter-spacing: -.01em;
+}
+
+p {
+  max-width: 75ch;
+  text-wrap: pretty;
+}
+
+.section-lead {
+  margin: -7px 0 18px;
+  color: var(--muted);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+}
+
+table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+caption {
+  padding: 10px 14px;
+  background: var(--warm);
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: #faf9f8;
+}
+
+.number {
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.status,
+.value-level {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 25px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.status::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.status.ok {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status.warn {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.status.risk {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-a {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-b {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.value-c {
+  background: var(--blue-soft);
+  color: var(--blue-active);
+}
+
+.value-d {
+  background: var(--neutral-soft);
+  color: var(--muted);
+}
+
+.risk-note {
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.repo-visuals {
+  display: grid;
+  grid-template-columns: minmax(280px, .85fr) minmax(0, 1.15fr);
+  gap: 18px;
+}
+
+.snapshot-list {
+  display: grid;
+  gap: 0;
+}
+
+.snapshot-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto;
+  gap: 4px 16px;
+  align-items: center;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.snapshot-row:first-child {
+  padding-top: 0;
+}
+
+.snapshot-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.snapshot-row .snapshot-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.snapshot-row strong {
+  color: var(--ink);
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.snapshot-row .snapshot-change {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.snapshot-row .snapshot-change.positive {
+  color: var(--green);
+}
+
+.snapshot-row .snapshot-change.missing {
+  color: var(--orange);
+}
+
+.chart-note {
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.ecosystem-signal {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.ecosystem-signal strong {
+  display: block;
+  color: var(--ink);
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecosystem-signal span {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signal-note {
+  grid-column: 1 / -1;
+  margin: -3px 0 0;
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.ecosystem-list,
+.method-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.ecosystem-list li,
+.method-list li {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.method-list li {
+  grid-template-columns: 180px 1fr;
+}
+
+.ecosystem-list strong,
+.method-list strong {
+  color: var(--ink);
+}
+
+.next-actions {
+  margin: 4px 0 30px;
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.next-actions h2 {
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.next-actions ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.next-actions li {
+  margin: 7px 0;
+}
+
+.health-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.health-card,
+.chart-box,
+.health-note {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.health-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 20px 22px;
+}
+
+.health-card .top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.health-card .name {
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.health-card .health-metric {
+  color: var(--ink);
+  font-size: 27px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.health-card .health-metric small {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.health-card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.health-card .detail {
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.segbar {
+  display: flex;
+  height: 24px;
+  overflow: hidden;
+  margin: 15px 0 10px;
+  border-radius: 6px;
+  background: var(--neutral-soft);
+}
+
+.segbar > span {
+  min-width: 2px;
+  height: 100%;
+}
+
+.seg-success {
+  background: #1aae39;
+}
+
+.seg-failure {
+  background: #e16259;
+}
+
+.seg-auth {
+  background: #e8a94b;
+}
+
+.seg-skipped {
+  background: #d6d2cd;
+}
+
+.seg-cancelled {
+  background: #8e8984;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chart-legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.chart-legend b {
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.chart-box {
+  padding: 20px 22px;
+}
+
+.chart-box h3 {
+  margin: 0 0 14px;
+  font-size: 15px;
+}
+
+.bars {
+  display: grid;
+  gap: 11px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 42px;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.repo-visuals .bar-row {
+  grid-template-columns: 112px 1fr 36px;
+}
+
+.bar-label {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 16px;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--neutral-soft);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 5px;
+  background: var(--blue);
+}
+
+.bar-fill.hot {
+  background: var(--orange);
+}
+
+.bar-value {
+  color: var(--ink-soft);
+  font-weight: 700;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.donut-layout {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 22px;
+  align-items: center;
+}
+
+.donut {
+  position: relative;
+  width: 142px;
+  height: 142px;
+  border-radius: 50%;
+  background: conic-gradient(var(--orange) 0 var(--value), #d6d2cd var(--value) 100%);
+}
+
+.donut::after {
+  position: absolute;
+  inset: 24px;
+  border-radius: 50%;
+  background: var(--paper);
+  content: "";
+}
+
+.donut-center {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.donut-center strong {
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+.donut-center span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.donut-copy p {
+  margin: 0 0 9px;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.donut-copy p:last-child {
+  margin-bottom: 0;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chart-box + .table-wrap {
+  margin-top: 18px;
+}
+
+.health-note {
+  padding: 18px;
+}
+
+.health-note h3 {
+  margin: 0 0 7px;
+  font-size: 15px;
+}
+
+.health-note p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.flow-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0 24px;
+}
+
+.flow-item {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.flow-item strong {
+  display: block;
+  color: var(--ink);
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-item span {
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+details {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+summary {
+  padding: 14px 18px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.details-body {
+  padding: 0 18px 16px;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 28px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .masthead,
+  main,
+  footer {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .topline,
+  footer,
+  .panel-intro {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .header-grid,
+  .meta-grid,
+  .repo-visuals,
+  .chart-grid,
+  .health-grid,
+  .flow-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .header-grid > *,
+  .meta-item {
+    min-width: 0;
+  }
+
+  .meta-item .value {
+    overflow-wrap: anywhere;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tabs {
+    padding: 0 6px;
+  }
+
+  section.report-section {
+    padding: 38px 0;
+  }
+
+  .ecosystem-list li,
+  .method-list li {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+
+  .ecosystem-signals {
+    grid-template-columns: 1fr;
+  }
+
+  .ecosystem-signal-note {
+    grid-column: auto;
+  }
+
+  .donut-layout {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .donut-copy {
+    text-align: center;
+  }
+}
+
+@media (max-width: 430px) {
+  h1 {
+    font-size: 30px;
+    overflow-wrap: anywhere;
+  }
+
+  .bar-row {
+    grid-template-columns: 76px 1fr 32px;
+    gap: 7px;
+  }
+
+  .repo-visuals .bar-row {
+    grid-template-columns: 98px 1fr 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media print {
+  @page {
+    size: A4;
+    margin: 13mm;
+  }
+
+  body {
+    background: #fff;
+    font-size: 10px;
+  }
+
+  .report {
+    width: 100%;
+  }
+
+  .masthead,
+  main,
+  footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .tabs-wrap,
+  .skip-link,
+  .utility-links {
+    display: none !important;
+  }
+
+  .tab-panel[hidden] {
+    display: block !important;
+  }
+
+  .tab-panel {
+    break-before: page;
+  }
+
+  .tab-panel:first-child {
+    break-before: auto;
+  }
+
+  .tab-panel > section.report-section:nth-of-type(even) {
+    background: #fff;
+    box-shadow: none;
+    clip-path: none;
+  }
+
+  section.report-section {
+    padding: 16px 0;
+  }
+
+  h1 {
+    font-size: 27px;
+  }
+
+  h2,
+  h3,
+  tr,
+  .health-card,
+  .health-note,
+  .chart-box,
+  .next-actions {
+    break-inside: avoid;
+  }
+
+  table {
+    min-width: 0;
+    font-size: 8px;
+  }
+
+  th,
+  td {
+    padding: 5px 6px;
+  }
+
+  .health-card,
+  .health-note,
+  .chart-box {
+    box-shadow: none;
+  }
+
+  .segbar,
+  .bar-fill,
+  .donut,
+  .status,
+  .value-level,
+  .metric,
+  .headline {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}

--- a/weekly/scripts/build_site.py
+++ b/weekly/scripts/build_site.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Build the SkillHub weekly report site from self-contained report files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from html import escape
+from pathlib import Path
+
+
+def load_manifest(source: Path) -> tuple[str, list[dict[str, str]]]:
+    manifest_path = source / "reports.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    latest = payload.get("latest")
+    reports = payload.get("reports")
+    if not isinstance(latest, str) or not latest:
+        raise ValueError("reports.json must define a non-empty latest week")
+    if not isinstance(reports, list) or not reports:
+        raise ValueError("reports.json must contain at least one report")
+
+    required = {"week", "title", "period", "snapshot", "path"}
+    normalized: list[dict[str, str]] = []
+    for index, report in enumerate(reports):
+        if not isinstance(report, dict) or not required.issubset(report):
+            missing = required - set(report) if isinstance(report, dict) else required
+            raise ValueError(f"report #{index + 1} is missing fields: {sorted(missing)}")
+        normalized.append({key: str(report[key]) for key in required})
+
+    weeks = {report["week"] for report in normalized}
+    if latest not in weeks:
+        raise ValueError(f"latest week {latest!r} is not present in reports")
+    return latest, sorted(normalized, key=lambda item: item["week"], reverse=True)
+
+
+def render_archive(latest: str, reports: list[dict[str, str]]) -> str:
+    rows = "\n".join(
+        f"""        <li>
+          <a class="report-link" href="./{escape(report['path'], quote=True)}">
+            <span class="report-copy">
+              <span class="report-kicker">
+                <span>{escape(report['week'])}</span>
+                {'<span class="latest">最新</span>' if report['week'] == latest else ''}
+              </span>
+              <strong>{escape(report['title'])}</strong>
+              <span class="report-meta">{escape(report['period'])} · 快照 {escape(report['snapshot'])}</span>
+            </span>
+            <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </li>"""
+        for report in reports
+    )
+    return f"""<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>SkillHub 开源周报归档</title>
+  <style data-site-theme="notion-light">
+    :root {{
+      color-scheme: light;
+      --page:#fff;
+      --warm:#f6f5f4;
+      --ink:#0d0d0d;
+      --ink-soft:#31302e;
+      --muted:#615d59;
+      --faint:#76716c;
+      --line:#e5e3e1;
+      --blue:#0075de;
+      --blue-active:#005bab;
+      --green:#147a33;
+      --green-soft:#e9f7ec;
+      --focus:#097fe8;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin:0;
+      background:var(--page);
+      color:var(--ink);
+      font:15px/1.65 Inter,-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;
+      -webkit-font-smoothing:antialiased;
+    }}
+    a {{ color:var(--blue); text-decoration:none; text-underline-offset:3px; }}
+    a:hover {{ color:var(--blue-active); }}
+    :focus-visible {{ outline:2px solid var(--focus); outline-offset:3px; }}
+    main {{ width:min(920px,100%); min-height:100vh; margin:0 auto; padding:44px 28px 56px; }}
+    .topline {{ display:flex; align-items:center; justify-content:space-between; gap:18px; margin-bottom:44px; }}
+    .brand {{ display:flex; align-items:center; gap:10px; color:var(--ink); }}
+    .brand-mark {{
+      display:inline-flex;
+      width:34px;
+      height:34px;
+      align-items:center;
+      justify-content:center;
+      border-radius:6px;
+      background:var(--ink-soft);
+      color:#fff;
+      font-size:14px;
+      font-weight:700;
+      letter-spacing:.04em;
+    }}
+    .brand-name {{ font-size:17px; font-weight:700; letter-spacing:-.01em; }}
+    .brand-tag {{ padding:4px 10px; border-radius:999px; background:#f1f0ef; color:var(--muted); font-size:12px; font-weight:600; }}
+    .utility {{ display:flex; flex-wrap:wrap; gap:16px; font-size:13px; }}
+    h1 {{ margin:0; font-size:clamp(32px,5vw,44px); line-height:1.15; letter-spacing:-.025em; }}
+    .intro {{ margin:9px 0 30px; color:var(--muted); }}
+    .archive-summary {{ margin-bottom:18px; padding:18px 20px; border-radius:8px; background:var(--warm); color:var(--ink-soft); }}
+    .archive-summary strong {{ color:var(--ink); }}
+    ul {{ margin:0; padding:0; overflow:hidden; border:1px solid var(--line); border-radius:12px; list-style:none; }}
+    li + li {{ border-top:1px solid var(--line); }}
+    .report-link {{ display:flex; align-items:center; justify-content:space-between; gap:24px; padding:20px 22px; color:var(--ink); }}
+    .report-link:hover {{ background:#faf9f8; text-decoration:none; }}
+    .report-copy {{ display:flex; min-width:0; flex-direction:column; gap:4px; }}
+    .report-kicker {{ display:flex; align-items:center; gap:8px; color:var(--faint); font-size:12px; font-weight:600; }}
+    .report-copy strong {{ color:var(--ink); font-size:17px; line-height:1.4; }}
+    .report-meta {{ color:var(--muted); font-size:12.5px; }}
+    .latest {{ padding:2px 8px; border-radius:999px; background:var(--green-soft); color:var(--green); font-size:11px; font-weight:700; }}
+    .arrow {{ flex:0 0 auto; color:var(--faint); font-size:20px; transition:transform .15s ease; }}
+    .report-link:hover .arrow {{ transform:translateX(3px); color:var(--ink); }}
+    .back {{ display:inline-block; margin-top:24px; font-size:13px; font-weight:600; }}
+    @media (max-width:600px) {{
+      main {{ padding:28px 18px 40px; }}
+      .topline {{ align-items:flex-start; flex-direction:column; gap:12px; margin-bottom:34px; }}
+      .report-link {{ align-items:flex-start; padding:18px; }}
+      .report-copy strong {{ font-size:15px; }}
+    }}
+    @media (prefers-reduced-motion:reduce) {{ .arrow {{ transition:none; }} }}
+  </style>
+</head>
+<body>
+  <main>
+    <div class="topline">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">SH</span>
+        <span class="brand-name">SkillHub</span>
+        <span class="brand-tag">开源周报</span>
+      </div>
+      <nav class="utility" aria-label="站点链接">
+        <a href="https://iflytek.github.io/skillhub/">项目文档</a>
+        <a href="https://github.com/iflytek/skillhub">GitHub 仓库</a>
+      </nav>
+    </div>
+    <h1>SkillHub 开源周报归档</h1>
+    <p class="intro">按统计周期倒序查看历期开源周报。</p>
+    <div class="archive-summary">当前共收录 <strong>{len(reports)} 期</strong>，最新一期为 <strong>{escape(latest)}</strong>。</div>
+    <ul>
+{rows}
+    </ul>
+    <a class="back" href="./">返回最新周报</a>
+  </main>
+</body>
+</html>
+"""
+
+
+def build(source: Path, output: Path) -> None:
+    latest, reports = load_manifest(source)
+    latest_report = next(report for report in reports if report["week"] == latest)
+    latest_source = source / latest_report["path"] / "index.html"
+    if not latest_source.is_file():
+        raise FileNotFoundError(f"latest report not found: {latest_source}")
+
+    for report in reports:
+        report_file = source / report["path"] / "index.html"
+        if not report_file.is_file():
+            raise FileNotFoundError(f"report not found: {report_file}")
+
+    if output.exists():
+        shutil.rmtree(output)
+    shutil.copytree(source, output)
+
+    latest_html = latest_source.read_text(encoding="utf-8")
+    latest_html = latest_html.replace('href="../../archive.html"', 'href="./archive.html"')
+    (output / "index.html").write_text(latest_html, encoding="utf-8")
+    (output / "archive.html").write_text(
+        render_archive(latest, reports),
+        encoding="utf-8",
+    )
+    (output / ".nojekyll").write_text("", encoding="utf-8")
+    print(f"Built {len(reports)} report(s); latest={latest}; output={output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=Path("site"))
+    parser.add_argument("--output", type=Path, default=Path("_site"))
+    args = parser.parse_args()
+    build(args.source.resolve(), args.output.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/weekly/scripts/sync_report_theme.py
+++ b/weekly/scripts/sync_report_theme.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Inline the canonical Notion-light theme into self-contained weekly reports."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+THEME_PATTERN = re.compile(
+    r'(?P<open><style data-report-theme="notion-light">\n)'
+    r".*?"
+    r"(?P<close>\n[ \t]*</style>)",
+    flags=re.DOTALL,
+)
+
+
+def sync_theme(theme_path: Path, report_paths: list[Path]) -> None:
+    theme = theme_path.read_text(encoding="utf-8").rstrip()
+    for report_path in report_paths:
+        source = report_path.read_text(encoding="utf-8")
+        updated, replacements = THEME_PATTERN.subn(
+            lambda match: f"{match.group('open')}{theme}{match.group('close')}",
+            source,
+        )
+        if replacements != 1:
+            raise ValueError(
+                f"{report_path}: expected one notion-light theme block, "
+                f"found {replacements}"
+            )
+        report_path.write_text(updated, encoding="utf-8")
+        print(f"Synced theme: {report_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "reports",
+        type=Path,
+        nargs="+",
+        help="HTML report files containing a notion-light theme block",
+    )
+    parser.add_argument(
+        "--theme",
+        type=Path,
+        default=Path("assets/notion-light.css"),
+        help="canonical CSS file",
+    )
+    args = parser.parse_args()
+    sync_theme(args.theme.resolve(), [path.resolve() for path in args.reports])
+
+
+if __name__ == "__main__":
+    main()

--- a/weekly/scripts/validate_site.py
+++ b/weekly/scripts/validate_site.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Validate built routes and basic accessibility hooks for the weekly site."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+VOID_ELEMENTS = {
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+}
+NON_CONTENT_ELEMENTS = {"caption", "h1", "h2", "h3", "h4", "h5", "h6", "th"}
+ALLOWED_PANELS = {"panel-overview", "panel-health", "panel-flow", "panel-method"}
+
+
+class PageParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.h1_count = 0
+        self.tabs = 0
+        self.panels = 0
+        self.tab_controls: set[str] = set()
+        self.panel_ids: set[str] = set()
+        self.panel_modules: dict[str, int] = {}
+        self.current_panel: str | None = None
+        self.panel_depth = 0
+        self.module_stack: list[dict[str, object]] = []
+        self.module_counts: dict[str, int] = {}
+        self.module_panels: dict[str, set[str]] = {}
+        self.module_names: set[str] = set()
+        self.empty_modules: set[str] = set()
+        self.table_stack: list[dict[str, int]] = []
+        self.empty_table_count = 0
+        self.ids: set[str] = set()
+        self.duplicate_ids: set[str] = set()
+        self.external_assets: list[str] = []
+        self.non_content_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        is_void = tag in VOID_ELEMENTS
+        if self.current_panel is not None and not is_void:
+            self.panel_depth += 1
+        if not is_void:
+            for module in self.module_stack:
+                module["depth"] = int(module["depth"]) + 1
+            for table in self.table_stack:
+                table["depth"] += 1
+        if tag in NON_CONTENT_ELEMENTS:
+            self.non_content_depth += 1
+        values = dict(attrs)
+        element_id = values.get("id")
+        if element_id:
+            if element_id in self.ids:
+                self.duplicate_ids.add(element_id)
+            self.ids.add(element_id)
+        if tag == "h1":
+            self.h1_count += 1
+        if values.get("role") == "tab":
+            self.tabs += 1
+            controls = values.get("aria-controls")
+            if controls:
+                self.tab_controls.add(controls)
+        if values.get("role") == "tabpanel":
+            self.panels += 1
+            panel_id = values.get("id") or ""
+            if panel_id:
+                self.panel_ids.add(panel_id)
+                self.panel_modules.setdefault(panel_id, 0)
+            self.current_panel = panel_id
+            self.panel_depth = 1
+        if tag == "table":
+            self.table_stack.append({"depth": 1, "data_cells": 0})
+        elif tag == "td":
+            for table in self.table_stack:
+                table["data_cells"] += 1
+        module_name = values.get("data-module")
+        if module_name:
+            self.module_names.add(module_name)
+            self.module_counts[module_name] = self.module_counts.get(module_name, 0) + 1
+            if self.current_panel:
+                self.module_panels.setdefault(module_name, set()).add(self.current_panel)
+            if is_void:
+                self.empty_modules.add(module_name)
+            else:
+                self.module_stack.append(
+                    {"depth": 1, "name": module_name, "has_meaningful_content": False}
+                )
+            if self.current_panel:
+                self.panel_modules[self.current_panel] = self.panel_modules.get(self.current_panel, 0) + 1
+        if tag == "script" and values.get("src"):
+            self.external_assets.append(values["src"] or "")
+        if tag == "link" and "stylesheet" in (values.get("rel") or ""):
+            self.external_assets.append(values.get("href") or "")
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.handle_starttag(tag, attrs)
+
+    def handle_data(self, data: str) -> None:
+        if data.strip() and not self.non_content_depth:
+            for module in self.module_stack:
+                module["has_meaningful_content"] = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in NON_CONTENT_ELEMENTS and self.non_content_depth:
+            self.non_content_depth -= 1
+        for module in self.module_stack:
+            module["depth"] = int(module["depth"]) - 1
+        while self.module_stack and int(self.module_stack[-1]["depth"]) == 0:
+            module = self.module_stack.pop()
+            if not module["has_meaningful_content"]:
+                self.empty_modules.add(str(module["name"]))
+        for table in self.table_stack:
+            table["depth"] -= 1
+        while self.table_stack and self.table_stack[-1]["depth"] == 0:
+            table = self.table_stack.pop()
+            if table["data_cells"] == 0:
+                self.empty_table_count += 1
+        if self.current_panel is not None:
+            self.panel_depth -= 1
+            if self.panel_depth == 0:
+                self.current_panel = None
+
+
+def validate(root: Path) -> list[str]:
+    errors: list[str] = []
+    required = (root / "index.html", root / "archive.html", root / ".nojekyll")
+    for path in required:
+        if not path.exists():
+            errors.append(f"missing built route: {path}")
+
+    manifest_path = root / "reports.json"
+    if not manifest_path.is_file():
+        errors.append(f"missing manifest: {manifest_path}")
+        return errors
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    latest = payload.get("latest")
+    report_paths: list[Path] = []
+    for report in payload.get("reports", []):
+        report_file = root / str(report.get("path", "")) / "index.html"
+        if not report_file.is_file():
+            errors.append(f"missing report: {report_file}")
+        else:
+            report_paths.append(report_file)
+    if not latest:
+        errors.append("manifest latest is empty")
+
+    archive_path = root / "archive.html"
+    if archive_path.is_file():
+        archive_source = archive_path.read_text(encoding="utf-8")
+        archive_parser = PageParser()
+        archive_parser.feed(archive_source)
+        if archive_parser.h1_count != 1:
+            errors.append(
+                f"{archive_path}: expected one h1, found {archive_parser.h1_count}"
+            )
+        if 'data-site-theme="notion-light"' not in archive_source:
+            errors.append(f"{archive_path}: missing notion-light theme marker")
+        report_link_count = archive_source.count('class="report-link"')
+        if report_link_count != len(payload.get("reports", [])):
+            errors.append(
+                f"{archive_path}: expected one archive link per report, "
+                f"found {report_link_count}"
+            )
+        if archive_parser.external_assets:
+            errors.append(
+                f"{archive_path}: external assets are not allowed: "
+                f"{archive_parser.external_assets}"
+            )
+
+    pages_to_validate = [root / "index.html", *report_paths]
+    for index_path in pages_to_validate:
+        if not index_path.is_file():
+            continue
+        parser = PageParser()
+        parser.feed(index_path.read_text(encoding="utf-8"))
+        if parser.h1_count != 1:
+            errors.append(f"{index_path}: expected one h1, found {parser.h1_count}")
+        if not 2 <= parser.tabs <= 4 or parser.tabs != parser.panels:
+            errors.append(
+                f"{index_path}: expected two to four matching report tabs/panels, "
+                f"found {parser.tabs}/{parser.panels}"
+            )
+        if parser.tab_controls != parser.panel_ids:
+            errors.append(f"{index_path}: tab aria-controls values do not match panel ids")
+        if not {"panel-overview", "panel-method"}.issubset(parser.panel_ids):
+            errors.append(f"{index_path}: overview and data panels are required")
+        unexpected_panels = sorted(parser.panel_ids - ALLOWED_PANELS)
+        if unexpected_panels:
+            errors.append(f"{index_path}: unexpected panels: {unexpected_panels}")
+        if "repository-summary" not in parser.module_names:
+            errors.append(f"{index_path}: missing required repository-summary module")
+        elif parser.module_panels.get("repository-summary") != {"panel-overview"}:
+            errors.append(
+                f"{index_path}: repository-summary must appear in panel-overview"
+            )
+        duplicate_modules = sorted(
+            name for name, count in parser.module_counts.items() if count > 1
+        )
+        if duplicate_modules:
+            errors.append(f"{index_path}: duplicate module names: {duplicate_modules}")
+        if parser.empty_modules:
+            errors.append(
+                f"{index_path}: modules without meaningful content: "
+                f"{sorted(parser.empty_modules)}"
+            )
+        if parser.empty_table_count:
+            errors.append(
+                f"{index_path}: empty tables without data cells: "
+                f"{parser.empty_table_count}"
+            )
+        if parser.module_stack:
+            errors.append(f"{index_path}: unclosed data-module element")
+        if parser.table_stack:
+            errors.append(f"{index_path}: unclosed table element")
+        empty_panels = sorted(
+            panel_id for panel_id, module_count in parser.panel_modules.items() if module_count == 0
+        )
+        if empty_panels:
+            errors.append(f"{index_path}: panels without modules: {empty_panels}")
+        if parser.duplicate_ids:
+            errors.append(f"{index_path}: duplicate ids: {sorted(parser.duplicate_ids)}")
+        if parser.external_assets:
+            errors.append(f"{index_path}: external assets are not allowed: {parser.external_assets}")
+        if "{{" in index_path.read_text(encoding="utf-8"):
+            errors.append(f"{index_path}: unresolved template placeholder")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("site", type=Path, nargs="?", default=Path("_site"))
+    args = parser.parse_args()
+    errors = validate(args.site.resolve())
+    for error in errors:
+        print(f"ERROR: {error}")
+    if errors:
+        print(f"FAIL: {len(errors)} error(s)")
+        return 1
+    print(f"PASS: {args.site.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/weekly/site/reports.json
+++ b/weekly/site/reports.json
@@ -1,0 +1,26 @@
+{
+  "latest": "2026-W31",
+  "reports": [
+    {
+      "week": "2026-W31",
+      "title": "SkillHub 开源周报｜2026 年第 31 周",
+      "period": "2026-07-23—2026-07-30",
+      "snapshot": "2026-07-30 16:36 Asia/Shanghai",
+      "path": "reports/2026-W31/"
+    },
+    {
+      "week": "2026-W30",
+      "title": "SkillHub 开源周报｜2026 年第 30 周",
+      "period": "2026-07-16—2026-07-23",
+      "snapshot": "2026-07-23 22:00 Asia/Shanghai",
+      "path": "reports/2026-W30/"
+    },
+    {
+      "week": "2026-W29",
+      "title": "SkillHub 开源周报｜2026 年第 29 周",
+      "period": "2026-07-09—2026-07-16",
+      "snapshot": "2026-07-23 22:00 Asia/Shanghai",
+      "path": "reports/2026-W29/"
+    }
+  ]
+}

--- a/weekly/site/reports/2026-W29/index.html
+++ b/weekly/site/reports/2026-W29/index.html
@@ -1,0 +1,1719 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="SkillHub 2026 年第 29 周开源周报：仓库状态、功能迭代、生态进展及项目健康明细。">
+  <title>SkillHub 开源周报｜2026 年第 29 周</title>
+  <script>document.documentElement.classList.add('js')</script>
+  <style data-report-theme="notion-light">
+:root {
+  color-scheme: light;
+  --page: #ffffff;
+  --paper: #ffffff;
+  --warm: #f6f5f4;
+  --ink: #0d0d0d;
+  --ink-soft: #31302e;
+  --muted: #615d59;
+  --faint: #76716c;
+  --line: #e5e3e1;
+  --line-soft: #efeeec;
+  --blue: #0075de;
+  --blue-active: #005bab;
+  --blue-soft: #f2f9ff;
+  --green: #147a33;
+  --green-soft: #e9f7ec;
+  --orange: #b84d00;
+  --orange-soft: #fdf0e3;
+  --red: #b52d25;
+  --red-soft: #fdecea;
+  --neutral-soft: #f1f0ef;
+  --focus: #097fe8;
+  --radius-sm: 8px;
+  --radius: 12px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 4%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 15px/1.65 Inter, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--blue-active);
+  text-decoration: underline;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--neutral-soft);
+  color: var(--ink-soft);
+  font-size: .92em;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 30;
+  top: 8px;
+  left: -999px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background: var(--ink-soft);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: 8px;
+}
+
+.report {
+  width: min(1200px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.masthead {
+  padding: 44px 28px 36px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 26px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: var(--ink-soft);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.brand-name {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+}
+
+.brand-tag {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--neutral-soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.utility-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 820px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(32px, 4vw, 44px);
+  line-height: 1.15;
+  letter-spacing: -.025em;
+}
+
+.report-sub {
+  margin: 8px 0 24px;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: 1.15fr .85fr;
+  gap: 16px;
+}
+
+.meta-card,
+.headline {
+  border-radius: var(--radius-sm);
+  padding: 20px 22px;
+}
+
+.meta-card {
+  background: var(--warm);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.meta-item .key,
+.headline-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--faint);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: .01em;
+}
+
+.meta-item .value {
+  color: var(--ink-soft);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.period {
+  margin: 0;
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  border: 0;
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.headline-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 7px;
+}
+
+.headline-status strong {
+  color: var(--orange);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.headline p {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 18px;
+  border: 0;
+}
+
+.metric {
+  min-width: 0;
+  padding: 16px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.metric strong {
+  display: block;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.tabs-wrap {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+  background: rgb(255 255 255 / 97%);
+  backdrop-filter: saturate(1.1) blur(5px);
+}
+
+.tabs {
+  display: flex;
+  min-width: max-content;
+  padding: 0 28px;
+}
+
+.tab {
+  position: relative;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.tab::after {
+  position: absolute;
+  right: 14px;
+  bottom: -1px;
+  left: 14px;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.tab:hover,
+.tab[aria-selected="true"] {
+  color: var(--ink);
+}
+
+.tab[aria-selected="true"] {
+  font-weight: 600;
+}
+
+.tab[aria-selected="true"]::after {
+  background: var(--ink-soft);
+}
+
+main {
+  padding: 0 28px 48px;
+}
+
+.tab-panel {
+  padding-top: 4px;
+}
+
+.js .tab-panel[hidden] {
+  display: none;
+}
+
+.panel-intro {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.panel-intro p {
+  margin: 0;
+}
+
+section.report-section {
+  margin: 0;
+  padding: 48px 0;
+  border: 0;
+}
+
+.tab-panel > section.report-section:nth-of-type(even) {
+  background: var(--warm);
+  box-shadow: 0 0 0 100vmax var(--warm);
+  clip-path: inset(0 -100vmax);
+}
+
+section.report-section:first-of-type {
+  padding-top: 42px;
+}
+
+h2 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+h3 {
+  margin: 30px 0 12px;
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.35;
+  letter-spacing: -.01em;
+}
+
+p {
+  max-width: 75ch;
+  text-wrap: pretty;
+}
+
+.section-lead {
+  margin: -7px 0 18px;
+  color: var(--muted);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+}
+
+table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+caption {
+  padding: 10px 14px;
+  background: var(--warm);
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: #faf9f8;
+}
+
+.number {
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.status,
+.value-level {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 25px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.status::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.status.ok {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status.warn {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.status.risk {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-a {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-b {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.value-c {
+  background: var(--blue-soft);
+  color: var(--blue-active);
+}
+
+.value-d {
+  background: var(--neutral-soft);
+  color: var(--muted);
+}
+
+.risk-note {
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.repo-visuals {
+  display: grid;
+  grid-template-columns: minmax(280px, .85fr) minmax(0, 1.15fr);
+  gap: 18px;
+}
+
+.snapshot-list {
+  display: grid;
+  gap: 0;
+}
+
+.snapshot-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto;
+  gap: 4px 16px;
+  align-items: center;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.snapshot-row:first-child {
+  padding-top: 0;
+}
+
+.snapshot-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.snapshot-row .snapshot-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.snapshot-row strong {
+  color: var(--ink);
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.snapshot-row .snapshot-change {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.snapshot-row .snapshot-change.positive {
+  color: var(--green);
+}
+
+.snapshot-row .snapshot-change.missing {
+  color: var(--orange);
+}
+
+.chart-note {
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.ecosystem-signal {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.ecosystem-signal strong {
+  display: block;
+  color: var(--ink);
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecosystem-signal span {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signal-note {
+  grid-column: 1 / -1;
+  margin: -3px 0 0;
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.ecosystem-list,
+.method-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.ecosystem-list li,
+.method-list li {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.method-list li {
+  grid-template-columns: 180px 1fr;
+}
+
+.ecosystem-list strong,
+.method-list strong {
+  color: var(--ink);
+}
+
+.next-actions {
+  margin: 4px 0 30px;
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.next-actions h2 {
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.next-actions ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.next-actions li {
+  margin: 7px 0;
+}
+
+.health-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.health-card,
+.chart-box,
+.health-note {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.health-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 20px 22px;
+}
+
+.health-card .top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.health-card .name {
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.health-card .health-metric {
+  color: var(--ink);
+  font-size: 27px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.health-card .health-metric small {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.health-card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.health-card .detail {
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.segbar {
+  display: flex;
+  height: 24px;
+  overflow: hidden;
+  margin: 15px 0 10px;
+  border-radius: 6px;
+  background: var(--neutral-soft);
+}
+
+.segbar > span {
+  min-width: 2px;
+  height: 100%;
+}
+
+.seg-success {
+  background: #1aae39;
+}
+
+.seg-failure {
+  background: #e16259;
+}
+
+.seg-auth {
+  background: #e8a94b;
+}
+
+.seg-skipped {
+  background: #d6d2cd;
+}
+
+.seg-cancelled {
+  background: #8e8984;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chart-legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.chart-legend b {
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.chart-box {
+  padding: 20px 22px;
+}
+
+.chart-box h3 {
+  margin: 0 0 14px;
+  font-size: 15px;
+}
+
+.bars {
+  display: grid;
+  gap: 11px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 42px;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.repo-visuals .bar-row {
+  grid-template-columns: 112px 1fr 36px;
+}
+
+.bar-label {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 16px;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--neutral-soft);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 5px;
+  background: var(--blue);
+}
+
+.bar-fill.hot {
+  background: var(--orange);
+}
+
+.bar-value {
+  color: var(--ink-soft);
+  font-weight: 700;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.donut-layout {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 22px;
+  align-items: center;
+}
+
+.donut {
+  position: relative;
+  width: 142px;
+  height: 142px;
+  border-radius: 50%;
+  background: conic-gradient(var(--orange) 0 var(--value), #d6d2cd var(--value) 100%);
+}
+
+.donut::after {
+  position: absolute;
+  inset: 24px;
+  border-radius: 50%;
+  background: var(--paper);
+  content: "";
+}
+
+.donut-center {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.donut-center strong {
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+.donut-center span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.donut-copy p {
+  margin: 0 0 9px;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.donut-copy p:last-child {
+  margin-bottom: 0;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chart-box + .table-wrap {
+  margin-top: 18px;
+}
+
+.health-note {
+  padding: 18px;
+}
+
+.health-note h3 {
+  margin: 0 0 7px;
+  font-size: 15px;
+}
+
+.health-note p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.flow-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0 24px;
+}
+
+.flow-item {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.flow-item strong {
+  display: block;
+  color: var(--ink);
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-item span {
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+details {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+summary {
+  padding: 14px 18px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.details-body {
+  padding: 0 18px 16px;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 28px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .masthead,
+  main,
+  footer {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .topline,
+  footer,
+  .panel-intro {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .header-grid,
+  .meta-grid,
+  .repo-visuals,
+  .chart-grid,
+  .health-grid,
+  .flow-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .header-grid > *,
+  .meta-item {
+    min-width: 0;
+  }
+
+  .meta-item .value {
+    overflow-wrap: anywhere;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tabs {
+    padding: 0 6px;
+  }
+
+  section.report-section {
+    padding: 38px 0;
+  }
+
+  .ecosystem-list li,
+  .method-list li {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+
+  .ecosystem-signals {
+    grid-template-columns: 1fr;
+  }
+
+  .ecosystem-signal-note {
+    grid-column: auto;
+  }
+
+  .donut-layout {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .donut-copy {
+    text-align: center;
+  }
+}
+
+@media (max-width: 430px) {
+  h1 {
+    font-size: 30px;
+    overflow-wrap: anywhere;
+  }
+
+  .bar-row {
+    grid-template-columns: 76px 1fr 32px;
+    gap: 7px;
+  }
+
+  .repo-visuals .bar-row {
+    grid-template-columns: 98px 1fr 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media print {
+  @page {
+    size: A4;
+    margin: 13mm;
+  }
+
+  body {
+    background: #fff;
+    font-size: 10px;
+  }
+
+  .report {
+    width: 100%;
+  }
+
+  .masthead,
+  main,
+  footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .tabs-wrap,
+  .skip-link,
+  .utility-links {
+    display: none !important;
+  }
+
+  .tab-panel[hidden] {
+    display: block !important;
+  }
+
+  .tab-panel {
+    break-before: page;
+  }
+
+  .tab-panel:first-child {
+    break-before: auto;
+  }
+
+  .tab-panel > section.report-section:nth-of-type(even) {
+    background: #fff;
+    box-shadow: none;
+    clip-path: none;
+  }
+
+  section.report-section {
+    padding: 16px 0;
+  }
+
+  h1 {
+    font-size: 27px;
+  }
+
+  h2,
+  h3,
+  tr,
+  .health-card,
+  .health-note,
+  .chart-box,
+  .next-actions {
+    break-inside: avoid;
+  }
+
+  table {
+    min-width: 0;
+    font-size: 8px;
+  }
+
+  th,
+  td {
+    padding: 5px 6px;
+  }
+
+  .health-card,
+  .health-note,
+  .chart-box {
+    box-shadow: none;
+  }
+
+  .segbar,
+  .bar-fill,
+  .donut,
+  .status,
+  .value-level,
+  .metric,
+  .headline {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}
+  </style>
+  <noscript>
+    <style>
+      .tabs-wrap { display: none !important; }
+      .tab-panel[hidden] { display: block !important; }
+    </style>
+  </noscript>
+</head>
+<body>
+  <a class="skip-link" href="#report-content">跳到报告正文</a>
+  <article class="report">
+    <header class="masthead">
+      <div class="topline">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">SH</span>
+          <span class="brand-name">SkillHub</span>
+          <span class="brand-tag">开源周报</span>
+        </div>
+        <nav class="utility-links" aria-label="站点链接">
+          <a href="../../archive.html">历史周报</a>
+          <a href="https://iflytek.github.io/skillhub/">项目文档</a>
+          <a href="https://github.com/iflytek/skillhub">GitHub 仓库</a>
+        </nav>
+      </div>
+      <h1>2026 年第 29 周</h1>
+      <p class="report-sub">项目健康 · 版本交付 · 开源生态 · Issue/PR 流转与价值队列</p>
+      <div class="header-grid">
+        <div class="meta-card">
+          <div class="meta-grid">
+            <div class="meta-item">
+              <span class="key">统计周期</span>
+              <span class="value">2026-07-09 00:00—2026-07-16 23:59（Asia/Shanghai）</span>
+            </div>
+            <div class="meta-item">
+              <span class="key">当前状态快照</span>
+              <span class="value">2026-07-23 22:00（Asia/Shanghai）</span>
+            </div>
+            <div class="meta-item">
+              <span class="key">项目仓库</span>
+              <span class="value"><a href="https://github.com/iflytek/skillhub">iflytek/skillhub</a></span>
+            </div>
+            <div class="meta-item">
+              <span class="key">数据来源</span>
+              <span class="value">GitHub REST API · Actions · Git · npm Downloads API</span>
+            </div>
+          </div>
+        </div>
+        <div class="headline">
+          <span class="headline-label">总体状态</span>
+          <div class="headline-status">
+            <strong>需关注</strong>
+            <span class="status warn">Attention</span>
+          </div>
+          <p>安全流水线稳定，但 Actions 有 5 次失败且周度 Release 未完成；长期 Issue/PR 积压仍是主要治理风险。</p>
+        </div>
+      </div>
+      <div class="metrics" aria-label="四项核心指标">
+        <div class="metric"><strong>4,823</strong><span>Stars · 周增量未取得</span></div>
+        <div class="metric"><strong>652</strong><span>Forks · 本期新增 189</span></div>
+        <div class="metric"><strong>92.6%</strong><span>Actions 有效成功率 · 63/68</span></div>
+        <div class="metric"><strong>0 / 0</strong><span>应用 / CLI Release · W29</span></div>
+      </div>
+    </header>
+
+    <div class="tabs-wrap">
+      <nav class="tabs" role="tablist" aria-label="周报视图">
+        <button class="tab" id="tab-overview" type="button" role="tab" aria-selected="true"
+          aria-controls="panel-overview" tabindex="0" data-tab="overview">总览</button>
+        <button class="tab" id="tab-health" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-health" tabindex="-1" data-tab="health">项目健康</button>
+        <button class="tab" id="tab-flow" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-flow" tabindex="-1" data-tab="flow">Issue 与 PR</button>
+        <button class="tab" id="tab-method" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-method" tabindex="-1" data-tab="method">数据说明</button>
+      </nav>
+    </div>
+
+    <main id="report-content">
+      <div class="tab-panel" id="panel-overview" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-overview" data-panel="overview">
+        <div class="panel-intro">
+          <p>三分钟总览：只保留仓库、迭代和生态三类决策信息。</p>
+          <p>详细健康和维护队列请使用上方 Tab。</p>
+        </div>
+
+        <section class="report-section" data-module="repository-summary" aria-labelledby="repository-title">
+          <h2 id="repository-title">一、仓库关键信息</h2>
+          <div class="repo-visuals">
+            <div class="chart-box" data-module="repository-scale">
+              <h3>规模快照</h3>
+              <div class="snapshot-list">
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Stars</span>
+                  <strong>4,823</strong>
+                  <span class="snapshot-change missing">周初快照未取得，不能计算自然周增量</span>
+                </div>
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Forks</span>
+                  <strong>652</strong>
+                  <span class="snapshot-change positive">本期新增 189</span>
+                </div>
+              </div>
+              <p class="chart-note">规模数据截至 7 月 23 日 22:00；缺失值没有用 0 代替。</p>
+            </div>
+            <div class="chart-box" data-module="weekly-collaboration-chart">
+              <h3>本周协作流转</h3>
+              <div class="bars" role="img" aria-label="W29 协作流转：Issue 新增 6 个、关闭 3 个；PR 新增 4 个、合并 0 个、关闭未合并 0 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">6</span></div>
+                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:50%"></span></span><span class="bar-value">3</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:66.7%"></span></span><span class="bar-value">4</span></div>
+                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:0%"></span></span><span class="bar-value">0</span></div>
+                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:0%"></span></span><span class="bar-value">0</span></div>
+              </div>
+              <p class="chart-note">Issue 净增 3、PR 净增 4；7 月 23 日快照开放 Issue 21 个、PR 19 个。主分支新增 3 个提交，本期未形成 Merge Commit。</p>
+            </div>
+          </div>
+          <p class="risk-note"><strong>主要风险：</strong>开放 Issue 和 PR 中分别有 52.4% 与 52.6% 已超过 30 天，存量治理弱于新增需求识别。</p>
+        </section>
+
+        <section class="report-section" data-module="feature-iterations" aria-labelledby="feature-title">
+          <h2 id="feature-title">二、功能迭代信息</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>按用户价值排序的重要事项</caption>
+              <thead>
+                <tr><th>状态</th><th>事项</th><th>进展与下一步</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><span class="status ok">期后完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/529">PR #529 双语社区 FAQ</a></td>
+                  <td>7 月 17 日合并并部署，沉淀常见部署与使用问题；不计入 W29 合并量。</td>
+                </tr>
+                <tr>
+                  <td><span class="status warn">推进中</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/issues/580">#580</a> / <a href="https://github.com/iflytek/skillhub/pull/581">PR #581 namespace 可见性</a></td>
+                  <td>修复 SUPER_ADMIN 读取边界；需收敛范围并完成门禁。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">期后完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/issues/582">#582</a> / <a href="https://github.com/iflytek/skillhub/pull/584">PR #584 Hermes 集成</a></td>
+                  <td>7 月 22 日合并并关闭 Issue，不计入 W29 交付量。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">期后完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/585">PR #585 CLI 通用安装目标</a></td>
+                  <td>随 <a href="https://github.com/iflytek/skillhub/releases/tag/cli-v0.1.9">cli-v0.1.9</a> 发布，不计入 W29 交付量。</td>
+                </tr>
+                <tr>
+                  <td><span class="status warn">待设计</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/issues/579">#579 来源证明、签名与 SBOM</a></td>
+                  <td>方向符合企业 Registry 定位；建议拆为 fingerprint、签名和 SBOM 三阶段。</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
+          <h2 id="ecosystem-title">三、生态相关进展</h2>
+          <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
+            aria-label="W29 开源生态参与信号：6 位新 Issue 作者、3 位新 PR 作者、0 位合并贡献者；本期新增 189 个 Fork；SkillHub CLI npm 下载 644 次">
+            <div class="ecosystem-signal"><strong>6 / 3 / 0</strong><span>新 Issue 作者 / 新 PR 作者 / 合并贡献者</span></div>
+            <div class="ecosystem-signal"><strong>+189</strong><span>本期新增 Fork</span></div>
+            <div class="ecosystem-signal"><strong>644</strong><span>SkillHub CLI npm 下载</span></div>
+            <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
+          </div>
+          <ul class="ecosystem-list">
+            <li><strong>社区输入</strong><span>6 位作者提交部署、namespace、OAuth、Hermes 与供应链议题，需求分布覆盖核心治理和生态接入。</span></li>
+            <li><strong>本地化与部署</strong><span><a href="https://github.com/iflytek/skillhub/pull/578">韩语本地化</a>、<a href="https://github.com/iflytek/skillhub/pull/576">可配置 Base Path</a>与 <a href="https://github.com/iflytek/skillhub/pull/575">部署 Cookie 配置</a>进入 Review。</span></li>
+            <li><strong>期后生态进展</strong><span>双语 FAQ、Hermes 指南和 CLI 通用安装目标在 7 月 17—22 日完成，不计入本期交付量。</span></li>
+            <li><strong>推广与合作</strong><span>本期尚未收到文章、直播、社区分享或合作项目清单；缺失数据不记为 0。</span></li>
+          </ul>
+        </section>
+
+        <aside class="next-actions" data-module="next-actions" aria-labelledby="next-title">
+          <h2 id="next-title">下周关注</h2>
+          <ol>
+            <li>收敛并完成 <a href="https://github.com/iflytek/skillhub/pull/581">PR #581</a> 的 Review 与完整门禁。</li>
+            <li>恢复固定 Release 窗口；若跳过发布，记录明确原因。</li>
+            <li>批量处理 14 个 <code>needs-info</code> Issue，并清理已实现或被替代的长期 PR。</li>
+          </ol>
+        </aside>
+      </div>
+
+      <div class="tab-panel" id="panel-health" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-health" data-panel="health" hidden>
+        <div class="panel-intro">
+          <p>项目健康详情：用于维护者判断工程、交付和治理风险。</p>
+          <p>成功流水线不等同于“无漏洞”。</p>
+        </div>
+
+        <section class="report-section" data-module="health-summary" aria-labelledby="health-summary-title">
+          <h2 id="health-summary-title">项目健康状态</h2>
+          <div class="health-cards">
+            <article class="health-card">
+              <div class="top"><span class="name">工程稳定性</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">92.6% <small>63/68</small></div>
+              <p>5 次失败中有 4 次来自 PR E2E。</p>
+              <div class="detail">有效成功率只统计实际成功与失败。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
+              <div class="health-metric">10 / 10 <small>执行成功</small></div>
+              <p>本期没有等待授权或失败记录。</p>
+              <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">31 / 32 <small>Backlog Rescore</small></div>
+              <p>Issue Triage 实际执行 6 次并全部成功。</p>
+              <div class="detail">Rescore 有 1 次失败，另有 12 次条件跳过。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Release 交付</span><span class="status risk">风险</span></div>
+              <div class="health-metric">0 / 0 <small>应用 / CLI</small></div>
+              <p>W29 未完成周度 Release 目标。</p>
+              <div class="detail">应用发布空窗在期末超过 13 天。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Issue 治理</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">52.4% <small>11/21 超 30 天</small></div>
+              <p>14 个开放 Issue 仍带有 <code>needs-info</code>。</p>
+              <div class="detail">长期积压与信息补充队列需要并行清理。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">PR 治理</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">52.6% <small>10/19 超 30 天</small></div>
+              <p>Review 与关闭决策仍是主要瓶颈。</p>
+              <div class="detail">已实现或被替代的 PR 应优先形成明确处置。</div>
+            </article>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
+          <h2 id="ci-title">CI 与自动化执行</h2>
+          <p class="section-lead">统计期内有 84 条 Actions 记录，其中 63 次成功、5 次失败、15 次跳过、1 次取消。</p>
+          <div class="chart-box" data-module="actions-outcome-chart">
+            <h3>Actions 结果构成</h3>
+            <div class="segbar" role="img" aria-label="W29 Actions 共 84 条记录：成功 63，失败 5，条件跳过 15，取消 1">
+              <span class="seg-success" style="width:75%"></span>
+              <span class="seg-failure" style="width:5.95%"></span>
+              <span class="seg-skipped" style="width:17.86%"></span>
+              <span class="seg-cancelled" style="width:1.19%"></span>
+            </div>
+            <div class="chart-legend" aria-hidden="true">
+              <span><i class="seg-success"></i>成功 <b>63</b></span>
+              <span><i class="seg-failure"></i>失败 <b>5</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>15</b></span>
+              <span><i class="seg-cancelled"></i>取消 <b>1</b></span>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <caption>工作流执行明细</caption>
+              <thead>
+                <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>PR Tests</td><td class="number">9</td><td class="number">9</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">9</td><td class="number">4</td><td class="number">4</td><td class="number">0</td><td class="number">1</td></tr>
+                <tr><td>PR Scripts</td><td class="number">3</td><td class="number">3</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Security</td><td class="number">10</td><td class="number">10</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Issue Backlog Rescore</td><td class="number">32</td><td class="number">31</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Issue Triage</td><td class="number">18</td><td class="number">6</td><td class="number">0</td><td class="number">0</td><td class="number">12</td></tr>
+                <tr><td>Claim Issue Reward</td><td class="number">3</td><td class="number">0</td><td class="number">0</td><td class="number">0</td><td class="number">3</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>本期薄弱点：</strong>PR E2E 8 次实际形成结论，其中 4 次失败；Backlog Rescore 另有 1 次失败。</p>
+        </section>
+
+        <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
+          <h2 id="delivery-title">安全、Release 与存量健康</h2>
+          <div class="health-grid">
+            <article class="health-note">
+              <h3>安全与供应链</h3>
+              <p>Security 实际执行 10 次并全部成功。仓库保留 CodeQL 定时扫描和 dependency review；公开数据无法确认未修复告警数量。</p>
+            </article>
+            <article class="health-note">
+              <h3>Release 交付</h3>
+              <p>W29 应用与 CLI 均未发布。<a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.14">v0.2.14</a> 和 <a href="https://github.com/iflytek/skillhub/releases/tag/cli-v0.1.9">cli-v0.1.9</a> 于 7 月 22 日期后补发，不计入 W29。</p>
+            </article>
+          </div>
+          <h3>Issue 健康</h3>
+          <div class="chart-grid">
+            <div class="chart-box" data-module="issue-age-chart">
+              <h3>开放 Issue 年龄结构</h3>
+              <div class="bars" role="img" aria-label="W29 当前开放 Issue 21 个：不足 7 天 5 个，7 到 13 天 3 个，14 到 29 天 2 个，30 天以上 11 个">
+                <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:45.5%"></span></span><span class="bar-value">5</span></div>
+                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:27.3%"></span></span><span class="bar-value">3</span></div>
+                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:18.2%"></span></span><span class="bar-value">2</span></div>
+                <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:100%"></span></span><span class="bar-value">11</span></div>
+              </div>
+              <p class="chart-note">52.4% 已超过 30 天，年龄结构明显偏向长期存量。</p>
+            </div>
+            <div class="chart-box" data-module="issue-needs-info-chart">
+              <h3><code>needs-info</code> 占比</h3>
+              <div class="donut-layout">
+                <div class="donut" style="--value:66.7%" role="img" aria-label="W29 当前开放 Issue 中，14 个带 needs-info 标签，占 21 个开放 Issue 的 66.7%">
+                  <div class="donut-center"><strong>66.7%</strong><span>14 / 21</span></div>
+                </div>
+                <div class="donut-copy">
+                  <p><strong>14 个</strong>开放 Issue 仍需补充信息。</p>
+                  <p>信息补充队列规模大于本周新增量，应集中确认、降级或关闭。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <h3>PR 健康</h3>
+          <div class="chart-box" data-module="pr-age-chart">
+            <h3>开放 PR 年龄结构</h3>
+            <div class="bars" role="img" aria-label="W29 当前开放 PR 19 个：不足 7 天 5 个，7 到 13 天 1 个，14 到 29 天 3 个，30 天以上 10 个">
+              <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:50%"></span></span><span class="bar-value">5</span></div>
+              <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:10%"></span></span><span class="bar-value">1</span></div>
+              <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:30%"></span></span><span class="bar-value">3</span></div>
+              <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:100%"></span></span><span class="bar-value">10</span></div>
+            </div>
+            <p class="chart-note">52.6% 已超过 30 天；Review 和关闭决策是主要治理瓶颈。</p>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
+          <h2 id="response-title">社区响应</h2>
+          <p>6 个新增 Issue 中，部署阻断问题 <a href="https://github.com/iflytek/skillhub/issues/574">#574</a> 和 CLI 可见性问题 <a href="https://github.com/iflytek/skillhub/issues/577">#577</a> 在本期关闭；namespace 问题 <a href="https://github.com/iflytek/skillhub/issues/580">#580</a> 形成配对 PR #581。按“关闭或形成配对实现”统计，可观察处置覆盖为 3/6。</p>
+          <div class="table-wrap">
+            <table>
+              <caption>新增 Issue 的首次可观察处置</caption>
+              <thead><tr><th>Issue</th><th>首次处置</th><th>耗时</th><th>状态</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/574">#574</a></td><td>形成部署修复 PR #575</td><td>约 4 小时</td><td>本期关闭</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/577">#577</a></td><td>确认 ClawHub CLI 兼容边界</td><td>未取得</td><td>本期关闭</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/580">#580</a></td><td>形成配对 PR #581</td><td>约 13 小时</td><td>推进中</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/582">#582</a></td><td>期后形成 Hermes 指南 PR #584</td><td>期后</td><td>期后完成</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/579">#579</a>、<a href="https://github.com/iflytek/skillhub/issues/583">#583</a></td><td>本期未观察到明确执行结论</td><td>未取得</td><td>待确认</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-flow" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-flow" data-panel="flow" hidden>
+        <div class="panel-intro">
+          <p>先看本周流转，再看当前高价值维护队列。</p>
+          <p>价值级别是人工治理判断，不替代仓库标签。</p>
+        </div>
+
+        <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
+          <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
+          <div class="flow-summary">
+            <div class="flow-item"><strong>Issue +6 / -3</strong><span>净增 3 · 7 月 23 日快照开放 21</span></div>
+            <div class="flow-item"><strong>PR +4 / 合并 0</strong><span>关闭未合并 0 · 净增 4 · 7 月 23 日快照开放 19</span></div>
+          </div>
+
+          <h3>新增 Issue（按价值排序）</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W29 新增 Issue 价值排序</caption>
+              <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前进展</th></tr></thead>
+              <tbody>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/574">#574 Release Compose 启动失败</a></td><td>直接阻断生产部署。</td><td>形成 PR #575，并在本期关闭。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/580">#580 SUPER_ADMIN namespace 可见性</a></td><td>企业治理核心体验问题。</td><td>配对 PR #581 仍开放。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/583">#583 DingTalk OAuth</a></td><td>身份接入价值高，安全风险也高。</td><td>与 PR #467 配对，待安全审查。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/579">#579 来源证明、签名与 SBOM</a></td><td>战略价值高，当前范围过大。</td><td>待拆分设计。</td></tr>
+                <tr><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/issues/582">#582 Hermes Skill 集成</a></td><td>边界清晰的生态文档需求。</td><td>期后合并并关闭。</td></tr>
+                <tr><td><span class="value-level value-d">D</span></td><td><a href="https://github.com/iflytek/skillhub/issues/577">#577 ClawHub visibility 参数</a></td><td>上游 CLI 能力边界问题。</td><td>本期关闭，不进入 SkillHub 实现队列。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>新增、合并与关闭 PR</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W29 PR 流转</caption>
+              <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
+              <tbody>
+                <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/581">#581 namespace 可见性</a></td><td>价值高、范围较大，需收敛并重跑门禁。</td></tr>
+                <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/575">#575 部署 Cookie 配置</a></td><td>回应启动阻断问题 #574；期后关闭未合并。</td></tr>
+                <tr><td>新增</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/576">#576 可配置 Base Path</a></td><td>支持子路径部署，期末仍开放。</td></tr>
+                <tr><td>新增</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/578">#578 韩语本地化</a></td><td>扩大本地化覆盖，期后关闭未合并。</td></tr>
+                <tr><td>本期结果</td><td>—</td><td>合并 0 / 关闭未合并 0</td><td>4 个新增 PR 均在期末保持开放。</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="priority-queue" aria-labelledby="priority-title">
+          <h2 id="priority-title">当前高价值维护队列</h2>
+          <p class="section-lead">以下为 2026-07-23 22:00 快照，只列需要明确决策的 A/B 项；其余队列按主题合并，避免把周报变成全量工单导出。</p>
+
+          <h3>Issue：A 级优先处理</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">A 级开放 Issue</caption>
+              <thead><tr><th>Issue</th><th>价值判断</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/596">#596 驳回版本同版本号重传返回 500</a></td><td>发布核心流程确定性错误。</td><td>优先审查配对 PR #601，并回归版本指针。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/580">#580 namespace 可见性</a></td><td>企业治理核心体验，已有成熟实现。</td><td>收敛 PR #581 范围并完成完整门禁。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/516">#516 多 Skill 仓库导入与同步</a></td><td>与 Registry 增长定位高度一致。</td><td>先形成一期验收标准，再做扫描与批量发布。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/518">#518 SemVer 与预发布版本</a></td><td>Registry 基础协议，文档与实现需统一。</td><td>先统一兼容、排序、latest 和 prerelease 规则。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Issue：B 级需设计或严格审查</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">B 级开放 Issue</caption>
+              <thead><tr><th>Issue</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/597">#597 异步索引可观察性</a></td><td>先补失败指标与 MDC，再决定有界重试。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/583">#583 DingTalk OAuth</a></td><td>围绕 Issue 对 PR #467 做集中安全评审。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/579">#579 来源证明、签名与 SBOM</a></td><td>拆分 fingerprint、签名验证和 SBOM。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/556">#556 合规元数据与审计</a></td><td>审查领域模型、迁移、查询性能和 API 生成。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/452">#452 Skill Evaluation</a></td><td>先做外部执行、SkillHub 接收并展示结果的窄版本。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>PR：A 级优先推进</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">A 级开放 PR</caption>
+              <thead><tr><th>PR</th><th>价值判断</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/601">#601 修复驳回版本重传 500</a></td><td>直接修复发布核心流程。</td><td>完成 CI 与 Review 后优先合并。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/581">#581 namespace 可见性</a></td><td>用户价值高，但范围继续扩大。</td><td>核对无关变更，rebase 后重跑完整门禁。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/592">#592 标签变更后重建搜索索引</a></td><td>修复真实索引一致性错误。</td><td>确认完整 CI；稳健性问题由 #597 跟踪。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/593">#593 部署与运维 FAQ</a></td><td>低风险，可降低社区支持成本。</td><td>事实校对后合并。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <details data-module="cleanup-queue">
+            <summary>展开：需要清理的长期 PR</summary>
+            <div class="details-body">
+              <p><a href="https://github.com/iflytek/skillhub/pull/460">#460</a>、<a href="https://github.com/iflytek/skillhub/pull/457">#457</a>、<a href="https://github.com/iflytek/skillhub/pull/442">#442</a> 已被主干实现或替代；<a href="https://github.com/iflytek/skillhub/pull/437">#437</a> 依赖未推进的父 PR。建议在确认无剩余差异后关闭，减少队列噪音。</p>
+            </div>
+          </details>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-method" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-method" data-panel="method" hidden>
+        <div class="panel-intro">
+          <p>这里说明时间边界、数据来源与缺失项。</p>
+          <p>缺失数据均标为“未取得”，不替换为 0。</p>
+        </div>
+
+        <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
+          <h2 id="method-title">统计口径</h2>
+          <ul class="method-list">
+            <li><strong>统计周期</strong><span>2026-07-09 00:00—2026-07-16 23:59，Asia/Shanghai；按“上周四到本周四”回溯统计。</span></li>
+            <li><strong>当前快照</strong><span>2026-07-23 22:00；开放 Issue/PR、Stars、Forks 和 Watchers 是期后快照，不回填为 W29 流量。</span></li>
+            <li><strong>期后进展</strong><span>7 月 17 日以后发生的合并、关闭和 Release 仅说明后续结果，明确不计入 W29。</span></li>
+            <li><strong>历史衔接</strong><span>本报告由原周一—周日口径回溯调整；7 月 16 日作为周四边界日期，也会出现在相邻 W30 的展示周期中。</span></li>
+            <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权和条件性跳过不进入分母。</span></li>
+            <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告将两者分开统计；价值 A—D 为人工治理判断。</span></li>
+            <li><strong>推广数据</strong><span>推广动作由维护者补录；Fork、下载、Issue 作者和 PR 作者是不同信号，不作为转化漏斗。</span></li>
+          </ul>
+        </section>
+
+        <section class="report-section" data-module="source-coverage" aria-labelledby="source-title">
+          <h2 id="source-title">数据来源与限制</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>来源覆盖</caption>
+              <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
+              <tbody>
+                <tr><td>GitHub 公共 REST API</td><td>仓库、Issue、PR、Release、Actions、Fork</td><td>Traffic 与私有安全告警不可见。</td></tr>
+                <tr><td>GitHub Actions 与本地 Git</td><td>流水线运行、恢复证据和变更核对</td><td>外部 PR 等待授权时无实际执行样本。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 本期下载</td><td>644 次下载不等同于独立用户。</td></tr>
+                <tr><td>维护者人工底稿</td><td>价值排序、推广动作和期后确认</td><td>推广动作尚未提供。</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、周初 Stargazer 快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
+        </section>
+      </div>
+    </main>
+
+    <footer>
+      <span>SkillHub Open Source Weekly · 2026-W29</span>
+      <span>公开报告 · 维护者治理视图</span>
+    </footer>
+  </article>
+
+  <script>
+    (function () {
+      var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
+      var panels = Array.prototype.slice.call(document.querySelectorAll('[role="tabpanel"]'));
+
+      function activate(name, moveFocus, updateHash) {
+        var nextTab = tabs.find(function (tab) { return tab.dataset.tab === name; }) || tabs[0];
+        tabs.forEach(function (tab) {
+          var selected = tab === nextTab;
+          tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+          tab.tabIndex = selected ? 0 : -1;
+        });
+        panels.forEach(function (panel) {
+          panel.hidden = panel.dataset.panel !== nextTab.dataset.tab;
+        });
+        if (moveFocus) nextTab.focus();
+        if (updateHash && history.replaceState) {
+          history.replaceState(null, '', '#' + nextTab.dataset.tab);
+        }
+      }
+
+      tabs.forEach(function (tab, index) {
+        tab.addEventListener('click', function () {
+          activate(tab.dataset.tab, false, true);
+        });
+        tab.addEventListener('keydown', function (event) {
+          var nextIndex = index;
+          if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+          else if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+          else if (event.key === 'Home') nextIndex = 0;
+          else if (event.key === 'End') nextIndex = tabs.length - 1;
+          else return;
+          event.preventDefault();
+          activate(tabs[nextIndex].dataset.tab, true, true);
+        });
+      });
+
+      window.addEventListener('hashchange', function () {
+        activate(location.hash.replace('#', ''), false, false);
+      });
+      var initial = location.hash.replace('#', '');
+      activate(initial, false, false);
+    }());
+  </script>
+</body>
+</html>

--- a/weekly/site/reports/2026-W30/index.html
+++ b/weekly/site/reports/2026-W30/index.html
@@ -1,0 +1,1713 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="SkillHub 2026 年第 30 周开源周报：仓库状态、功能迭代、生态进展及项目健康明细。">
+  <title>SkillHub 开源周报｜2026 年第 30 周</title>
+  <script>document.documentElement.classList.add('js')</script>
+  <style data-report-theme="notion-light">
+:root {
+  color-scheme: light;
+  --page: #ffffff;
+  --paper: #ffffff;
+  --warm: #f6f5f4;
+  --ink: #0d0d0d;
+  --ink-soft: #31302e;
+  --muted: #615d59;
+  --faint: #76716c;
+  --line: #e5e3e1;
+  --line-soft: #efeeec;
+  --blue: #0075de;
+  --blue-active: #005bab;
+  --blue-soft: #f2f9ff;
+  --green: #147a33;
+  --green-soft: #e9f7ec;
+  --orange: #b84d00;
+  --orange-soft: #fdf0e3;
+  --red: #b52d25;
+  --red-soft: #fdecea;
+  --neutral-soft: #f1f0ef;
+  --focus: #097fe8;
+  --radius-sm: 8px;
+  --radius: 12px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 4%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 15px/1.65 Inter, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--blue-active);
+  text-decoration: underline;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--neutral-soft);
+  color: var(--ink-soft);
+  font-size: .92em;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 30;
+  top: 8px;
+  left: -999px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background: var(--ink-soft);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: 8px;
+}
+
+.report {
+  width: min(1200px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.masthead {
+  padding: 44px 28px 36px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 26px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: var(--ink-soft);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.brand-name {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+}
+
+.brand-tag {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--neutral-soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.utility-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 820px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(32px, 4vw, 44px);
+  line-height: 1.15;
+  letter-spacing: -.025em;
+}
+
+.report-sub {
+  margin: 8px 0 24px;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: 1.15fr .85fr;
+  gap: 16px;
+}
+
+.meta-card,
+.headline {
+  border-radius: var(--radius-sm);
+  padding: 20px 22px;
+}
+
+.meta-card {
+  background: var(--warm);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.meta-item .key,
+.headline-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--faint);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: .01em;
+}
+
+.meta-item .value {
+  color: var(--ink-soft);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.period {
+  margin: 0;
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  border: 0;
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.headline-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 7px;
+}
+
+.headline-status strong {
+  color: var(--orange);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.headline p {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 18px;
+  border: 0;
+}
+
+.metric {
+  min-width: 0;
+  padding: 16px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.metric strong {
+  display: block;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.tabs-wrap {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+  background: rgb(255 255 255 / 97%);
+  backdrop-filter: saturate(1.1) blur(5px);
+}
+
+.tabs {
+  display: flex;
+  min-width: max-content;
+  padding: 0 28px;
+}
+
+.tab {
+  position: relative;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.tab::after {
+  position: absolute;
+  right: 14px;
+  bottom: -1px;
+  left: 14px;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.tab:hover,
+.tab[aria-selected="true"] {
+  color: var(--ink);
+}
+
+.tab[aria-selected="true"] {
+  font-weight: 600;
+}
+
+.tab[aria-selected="true"]::after {
+  background: var(--ink-soft);
+}
+
+main {
+  padding: 0 28px 48px;
+}
+
+.tab-panel {
+  padding-top: 4px;
+}
+
+.js .tab-panel[hidden] {
+  display: none;
+}
+
+.panel-intro {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.panel-intro p {
+  margin: 0;
+}
+
+section.report-section {
+  margin: 0;
+  padding: 48px 0;
+  border: 0;
+}
+
+.tab-panel > section.report-section:nth-of-type(even) {
+  background: var(--warm);
+  box-shadow: 0 0 0 100vmax var(--warm);
+  clip-path: inset(0 -100vmax);
+}
+
+section.report-section:first-of-type {
+  padding-top: 42px;
+}
+
+h2 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+h3 {
+  margin: 30px 0 12px;
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.35;
+  letter-spacing: -.01em;
+}
+
+p {
+  max-width: 75ch;
+  text-wrap: pretty;
+}
+
+.section-lead {
+  margin: -7px 0 18px;
+  color: var(--muted);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+}
+
+table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+caption {
+  padding: 10px 14px;
+  background: var(--warm);
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: #faf9f8;
+}
+
+.number {
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.status,
+.value-level {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 25px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.status::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.status.ok {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status.warn {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.status.risk {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-a {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-b {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.value-c {
+  background: var(--blue-soft);
+  color: var(--blue-active);
+}
+
+.value-d {
+  background: var(--neutral-soft);
+  color: var(--muted);
+}
+
+.risk-note {
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.repo-visuals {
+  display: grid;
+  grid-template-columns: minmax(280px, .85fr) minmax(0, 1.15fr);
+  gap: 18px;
+}
+
+.snapshot-list {
+  display: grid;
+  gap: 0;
+}
+
+.snapshot-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto;
+  gap: 4px 16px;
+  align-items: center;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.snapshot-row:first-child {
+  padding-top: 0;
+}
+
+.snapshot-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.snapshot-row .snapshot-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.snapshot-row strong {
+  color: var(--ink);
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.snapshot-row .snapshot-change {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.snapshot-row .snapshot-change.positive {
+  color: var(--green);
+}
+
+.snapshot-row .snapshot-change.missing {
+  color: var(--orange);
+}
+
+.chart-note {
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.ecosystem-signal {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.ecosystem-signal strong {
+  display: block;
+  color: var(--ink);
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecosystem-signal span {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signal-note {
+  grid-column: 1 / -1;
+  margin: -3px 0 0;
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.ecosystem-list,
+.method-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.ecosystem-list li,
+.method-list li {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.method-list li {
+  grid-template-columns: 180px 1fr;
+}
+
+.ecosystem-list strong,
+.method-list strong {
+  color: var(--ink);
+}
+
+.next-actions {
+  margin: 4px 0 30px;
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.next-actions h2 {
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.next-actions ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.next-actions li {
+  margin: 7px 0;
+}
+
+.health-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.health-card,
+.chart-box,
+.health-note {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.health-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 20px 22px;
+}
+
+.health-card .top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.health-card .name {
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.health-card .health-metric {
+  color: var(--ink);
+  font-size: 27px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.health-card .health-metric small {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.health-card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.health-card .detail {
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.segbar {
+  display: flex;
+  height: 24px;
+  overflow: hidden;
+  margin: 15px 0 10px;
+  border-radius: 6px;
+  background: var(--neutral-soft);
+}
+
+.segbar > span {
+  min-width: 2px;
+  height: 100%;
+}
+
+.seg-success {
+  background: #1aae39;
+}
+
+.seg-failure {
+  background: #e16259;
+}
+
+.seg-auth {
+  background: #e8a94b;
+}
+
+.seg-skipped {
+  background: #d6d2cd;
+}
+
+.seg-cancelled {
+  background: #8e8984;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chart-legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.chart-legend b {
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.chart-box {
+  padding: 20px 22px;
+}
+
+.chart-box h3 {
+  margin: 0 0 14px;
+  font-size: 15px;
+}
+
+.bars {
+  display: grid;
+  gap: 11px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 42px;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.repo-visuals .bar-row {
+  grid-template-columns: 112px 1fr 36px;
+}
+
+.bar-label {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 16px;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--neutral-soft);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 5px;
+  background: var(--blue);
+}
+
+.bar-fill.hot {
+  background: var(--orange);
+}
+
+.bar-value {
+  color: var(--ink-soft);
+  font-weight: 700;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.donut-layout {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 22px;
+  align-items: center;
+}
+
+.donut {
+  position: relative;
+  width: 142px;
+  height: 142px;
+  border-radius: 50%;
+  background: conic-gradient(var(--orange) 0 var(--value), #d6d2cd var(--value) 100%);
+}
+
+.donut::after {
+  position: absolute;
+  inset: 24px;
+  border-radius: 50%;
+  background: var(--paper);
+  content: "";
+}
+
+.donut-center {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.donut-center strong {
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+.donut-center span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.donut-copy p {
+  margin: 0 0 9px;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.donut-copy p:last-child {
+  margin-bottom: 0;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chart-box + .table-wrap {
+  margin-top: 18px;
+}
+
+.health-note {
+  padding: 18px;
+}
+
+.health-note h3 {
+  margin: 0 0 7px;
+  font-size: 15px;
+}
+
+.health-note p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.flow-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0 24px;
+}
+
+.flow-item {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.flow-item strong {
+  display: block;
+  color: var(--ink);
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-item span {
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+details {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+summary {
+  padding: 14px 18px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.details-body {
+  padding: 0 18px 16px;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 28px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .masthead,
+  main,
+  footer {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .topline,
+  footer,
+  .panel-intro {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .header-grid,
+  .meta-grid,
+  .repo-visuals,
+  .chart-grid,
+  .health-grid,
+  .flow-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .header-grid > *,
+  .meta-item {
+    min-width: 0;
+  }
+
+  .meta-item .value {
+    overflow-wrap: anywhere;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tabs {
+    padding: 0 6px;
+  }
+
+  section.report-section {
+    padding: 38px 0;
+  }
+
+  .ecosystem-list li,
+  .method-list li {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+
+  .ecosystem-signals {
+    grid-template-columns: 1fr;
+  }
+
+  .ecosystem-signal-note {
+    grid-column: auto;
+  }
+
+  .donut-layout {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .donut-copy {
+    text-align: center;
+  }
+}
+
+@media (max-width: 430px) {
+  h1 {
+    font-size: 30px;
+    overflow-wrap: anywhere;
+  }
+
+  .bar-row {
+    grid-template-columns: 76px 1fr 32px;
+    gap: 7px;
+  }
+
+  .repo-visuals .bar-row {
+    grid-template-columns: 98px 1fr 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media print {
+  @page {
+    size: A4;
+    margin: 13mm;
+  }
+
+  body {
+    background: #fff;
+    font-size: 10px;
+  }
+
+  .report {
+    width: 100%;
+  }
+
+  .masthead,
+  main,
+  footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .tabs-wrap,
+  .skip-link,
+  .utility-links {
+    display: none !important;
+  }
+
+  .tab-panel[hidden] {
+    display: block !important;
+  }
+
+  .tab-panel {
+    break-before: page;
+  }
+
+  .tab-panel:first-child {
+    break-before: auto;
+  }
+
+  .tab-panel > section.report-section:nth-of-type(even) {
+    background: #fff;
+    box-shadow: none;
+    clip-path: none;
+  }
+
+  section.report-section {
+    padding: 16px 0;
+  }
+
+  h1 {
+    font-size: 27px;
+  }
+
+  h2,
+  h3,
+  tr,
+  .health-card,
+  .health-note,
+  .chart-box,
+  .next-actions {
+    break-inside: avoid;
+  }
+
+  table {
+    min-width: 0;
+    font-size: 8px;
+  }
+
+  th,
+  td {
+    padding: 5px 6px;
+  }
+
+  .health-card,
+  .health-note,
+  .chart-box {
+    box-shadow: none;
+  }
+
+  .segbar,
+  .bar-fill,
+  .donut,
+  .status,
+  .value-level,
+  .metric,
+  .headline {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}
+  </style>
+  <noscript>
+    <style>
+      .tabs-wrap { display: none !important; }
+      .tab-panel[hidden] { display: block !important; }
+    </style>
+  </noscript>
+</head>
+<body>
+  <a class="skip-link" href="#report-content">跳到报告正文</a>
+  <article class="report">
+    <header class="masthead">
+      <div class="topline">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">SH</span>
+          <span class="brand-name">SkillHub</span>
+          <span class="brand-tag">开源周报</span>
+        </div>
+        <nav class="utility-links" aria-label="站点链接">
+          <a href="../../archive.html">历史周报</a>
+          <a href="https://iflytek.github.io/skillhub/">项目文档</a>
+          <a href="https://github.com/iflytek/skillhub">GitHub 仓库</a>
+        </nav>
+      </div>
+      <h1>2026 年第 30 周</h1>
+      <p class="report-sub">项目健康 · 版本交付 · 开源生态 · Issue/PR 流转与价值队列</p>
+      <div class="header-grid">
+        <div class="meta-card">
+          <div class="meta-grid">
+            <div class="meta-item">
+              <span class="key">统计周期</span>
+              <span class="value">2026-07-16 00:00—2026-07-23 22:00（Asia/Shanghai）</span>
+            </div>
+            <div class="meta-item">
+              <span class="key">当前状态快照</span>
+              <span class="value">2026-07-23 22:00（Asia/Shanghai）</span>
+            </div>
+            <div class="meta-item">
+              <span class="key">项目仓库</span>
+              <span class="value"><a href="https://github.com/iflytek/skillhub">iflytek/skillhub</a></span>
+            </div>
+            <div class="meta-item">
+              <span class="key">数据来源</span>
+              <span class="value">GitHub REST API · Actions · Git · npm Downloads API</span>
+            </div>
+          </div>
+        </div>
+        <div class="headline">
+          <span class="headline-label">总体状态</span>
+          <div class="headline-status">
+            <strong>需关注</strong>
+            <span class="status warn">Attention</span>
+          </div>
+          <p>应用与 CLI 均完成 Release，安全流水线稳定；PR E2E 失败集中、长期 Issue/PR 占比仍高，需要优先治理。</p>
+        </div>
+      </div>
+      <div class="metrics" aria-label="四项核心指标">
+        <div class="metric"><strong>4,823</strong><span>Stars · 统计期增量未取得</span></div>
+        <div class="metric"><strong>652</strong><span>Forks · 本期新增 27</span></div>
+        <div class="metric"><strong>91.3%</strong><span>Actions 有效成功率 · 126/138</span></div>
+        <div class="metric"><strong>1 / 1</strong><span>应用 / CLI Release · W30</span></div>
+      </div>
+    </header>
+
+    <div class="tabs-wrap">
+      <nav class="tabs" role="tablist" aria-label="周报视图">
+        <button class="tab" id="tab-overview" type="button" role="tab" aria-selected="true"
+          aria-controls="panel-overview" tabindex="0" data-tab="overview">总览</button>
+        <button class="tab" id="tab-health" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-health" tabindex="-1" data-tab="health">项目健康</button>
+        <button class="tab" id="tab-flow" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-flow" tabindex="-1" data-tab="flow">Issue 与 PR</button>
+        <button class="tab" id="tab-method" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-method" tabindex="-1" data-tab="method">数据说明</button>
+      </nav>
+    </div>
+
+    <main id="report-content">
+      <div class="tab-panel" id="panel-overview" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-overview" data-panel="overview">
+        <div class="panel-intro">
+          <p>三分钟总览：只保留仓库、迭代和生态三类决策信息。</p>
+          <p>详细健康和维护队列请使用上方 Tab。</p>
+        </div>
+
+        <section class="report-section" data-module="repository-summary" aria-labelledby="repository-title">
+          <h2 id="repository-title">一、仓库关键信息</h2>
+          <div class="repo-visuals">
+            <div class="chart-box" data-module="repository-scale">
+              <h3>规模快照</h3>
+              <div class="snapshot-list">
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Stars</span>
+                  <strong>4,823</strong>
+                  <span class="snapshot-change missing">期初快照未取得，不能计算净增量</span>
+                </div>
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Forks</span>
+                  <strong>652</strong>
+                  <span class="snapshot-change positive">本期新增 27</span>
+                </div>
+              </div>
+              <p class="chart-note">规模快照截至 7 月 23 日 22:00；Fork 新增按创建时间统计，Star 期初净快照未取得。</p>
+            </div>
+            <div class="chart-box" data-module="weekly-collaboration-chart">
+              <h3>本周协作流转</h3>
+              <div class="bars" role="img" aria-label="W30 协作流转：Issue 新增 8 个、关闭 3 个；PR 新增 12 个、合并 5 个、关闭未合并 9 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:66.7%"></span></span><span class="bar-value">8</span></div>
+                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:25%"></span></span><span class="bar-value">3</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">12</span></div>
+                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:41.7%"></span></span><span class="bar-value">5</span></div>
+                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:75%"></span></span><span class="bar-value">9</span></div>
+              </div>
+              <p class="chart-note">Issue 净增 5、当前开放 21；PR 净减 2、当前开放 19。主分支新增 19 个提交，其中 5 个 Merge Commit。</p>
+            </div>
+          </div>
+          <p class="risk-note"><strong>主要风险：</strong>发布目标已经恢复，但开放 Issue 和 PR 中分别有 52.4% 与 52.6% 超过 30 天，且 PR E2E 本期有 8 次失败。</p>
+        </section>
+
+        <section class="report-section" data-module="feature-iterations" aria-labelledby="feature-title">
+          <h2 id="feature-title">二、功能迭代信息</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>按用户价值排序的重要事项</caption>
+              <thead><tr><th>状态</th><th>事项</th><th>进展与下一步</th></tr></thead>
+              <tbody>
+                <tr>
+                  <td><span class="status ok">已完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.14">应用 v0.2.14</a></td>
+                  <td>集成 Hermes 指南、Scanner 依赖修复、通用安装目标及社区 FAQ。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">已完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/releases/tag/cli-v0.1.9">CLI 0.1.9</a></td>
+                  <td>发布通用用户级 Agent 安装目标，降低跨 Agent 使用门槛。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">已完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/584">PR #584 Hermes Agent 集成指南</a></td>
+                  <td>本周合并并关闭 #582，形成新的 Agent 生态接入路径。</td>
+                </tr>
+                <tr>
+                  <td><span class="status warn">推进中</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/issues/596">#596</a> / <a href="https://github.com/iflytek/skillhub/pull/601">PR #601 驳回版本重传 500</a></td>
+                  <td>发布核心流程修复已提交；需解决本周 CI/E2E 失败并完成回归。</td>
+                </tr>
+                <tr>
+                  <td><span class="status warn">推进中</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/592">PR #592 标签变更后异步重建搜索索引</a></td>
+                  <td>修复搜索一致性；可观察性增强由 #597 跟踪。</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
+          <h2 id="ecosystem-title">三、生态相关进展</h2>
+          <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
+            aria-label="W30 开源生态参与信号：8 位新 Issue 作者、5 位新 PR 作者、3 位合并作者；本期新增 27 个 Fork；SkillHub CLI npm 下载 856 次">
+            <div class="ecosystem-signal"><strong>8 / 5 / 3</strong><span>新 Issue 作者 / 新 PR 作者 / 合并作者</span></div>
+            <div class="ecosystem-signal"><strong>+27</strong><span>本期新增 Fork</span></div>
+            <div class="ecosystem-signal"><strong>856</strong><span>SkillHub CLI npm 下载</span></div>
+            <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
+          </div>
+          <ul class="ecosystem-list">
+            <li><strong>Agent 集成</strong><span>Hermes 指南已合并；<a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw Engine 指南 PR #598</a> 继续推进。</span></li>
+            <li><strong>文档沉淀</strong><span>v0.2.14 纳入社区 FAQ；<a href="https://github.com/iflytek/skillhub/pull/593">PR #593</a> 继续补充部署与运维问答。</span></li>
+            <li><strong>推广与合作</strong><span>本周尚未收到文章、直播、社区分享或合作项目清单；缺失数据不记为 0。</span></li>
+          </ul>
+        </section>
+
+        <aside class="next-actions" data-module="next-actions" aria-labelledby="next-title">
+          <h2 id="next-title">下周关注</h2>
+          <ol>
+            <li>处理 PR E2E 的集中失败，优先使 <a href="https://github.com/iflytek/skillhub/pull/601">#601</a>、<a href="https://github.com/iflytek/skillhub/pull/581">#581</a> 获得完整门禁结论。</li>
+            <li>保持固定 Release 窗口；无可发布内容时记录跳过原因。</li>
+            <li>批量处理 14 个 <code>needs-info</code> Issue，并清理已实现或被替代的长期 PR。</li>
+          </ol>
+        </aside>
+      </div>
+
+      <div class="tab-panel" id="panel-health" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-health" data-panel="health" hidden>
+        <div class="panel-intro">
+          <p>项目健康详情：用于维护者判断工程、交付和治理风险。</p>
+          <p>成功流水线不等同于“无漏洞”。</p>
+        </div>
+
+        <section class="report-section" data-module="health-summary" aria-labelledby="health-summary-title">
+          <h2 id="health-summary-title">项目健康状态</h2>
+          <div class="health-cards">
+            <article class="health-card">
+              <div class="top"><span class="name">工程稳定性</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">91.3% <small>126/138</small></div>
+              <p>12 次失败中有 8 次来自 PR E2E。</p>
+              <div class="detail">失败覆盖多个开发分支，需要区分回归与环境问题。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
+              <div class="health-metric">32 / 32 <small>执行成功</small></div>
+              <p>另有 9 次等待授权、1 次条件跳过。</p>
+              <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">31 / 32 <small>Backlog Rescore</small></div>
+              <p>DeepWiki 1 次失败；镜像发布 2 成功、1 失败。</p>
+              <div class="detail">治理自动化整体可用，但存在分散失败点。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Release 交付</span><span class="status ok">达成</span></div>
+              <div class="health-metric">1 / 1 <small>应用 / CLI</small></div>
+              <p>v0.2.14 与 cli-v0.1.9 均在本周发布。</p>
+              <div class="detail">周度 Release 目标恢复。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Issue 治理</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">52.4% <small>11/21 超 30 天</small></div>
+              <p>14 个开放 Issue 仍带有 <code>needs-info</code>。</p>
+              <div class="detail">长期积压与信息补充队列需要并行清理。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">PR 治理</span><span class="status risk">风险</span></div>
+              <div class="health-metric">52.6% <small>10/19 超 30 天</small></div>
+              <p>Review 与关闭决策不足。</p>
+              <div class="detail">长期存量占比已成为本周最明显治理风险。</div>
+            </article>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
+          <h2 id="ci-title">CI 与自动化执行</h2>
+          <p class="section-lead">统计期内有 213 条 Actions 记录，其中 126 次成功、12 次失败、32 次等待授权、42 次跳过、1 次取消。</p>
+          <div class="chart-box" data-module="actions-outcome-chart">
+            <h3>Actions 结果构成</h3>
+            <div class="segbar" role="img" aria-label="W30 Actions 共 213 条记录：成功 126，失败 12，等待授权 32，条件跳过 42，取消 1">
+              <span class="seg-success" style="width:59.15%"></span>
+              <span class="seg-failure" style="width:5.63%"></span>
+              <span class="seg-auth" style="width:15.02%"></span>
+              <span class="seg-skipped" style="width:19.72%"></span>
+              <span class="seg-cancelled" style="width:.47%"></span>
+            </div>
+            <div class="chart-legend" aria-hidden="true">
+              <span><i class="seg-success"></i>成功 <b>126</b></span>
+              <span><i class="seg-failure"></i>失败 <b>12</b></span>
+              <span><i class="seg-auth"></i>等待授权 <b>32</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>42</b></span>
+              <span><i class="seg-cancelled"></i>取消 <b>1</b></span>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <caption>工作流执行明细</caption>
+              <thead>
+                <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>PR Tests</td><td class="number">36</td><td class="number">24</td><td class="number">1</td><td class="number">9</td><td class="number">2</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">22</td><td class="number">6</td><td class="number">8</td><td class="number">8</td><td class="number">0</td></tr>
+                <tr><td>PR CLI</td><td class="number">6</td><td class="number">5</td><td class="number">0</td><td class="number">1</td><td class="number">0</td></tr>
+                <tr><td>PR Scripts</td><td class="number">12</td><td class="number">7</td><td class="number">0</td><td class="number">5</td><td class="number">0</td></tr>
+                <tr><td>PR Helm Chart</td><td class="number">1</td><td class="number">1</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Security</td><td class="number">42</td><td class="number">32</td><td class="number">0</td><td class="number">9</td><td class="number">1</td></tr>
+                <tr><td>Issue Backlog Rescore</td><td class="number">32</td><td class="number">31</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Issue Triage</td><td class="number">50</td><td class="number">13</td><td class="number">0</td><td class="number">0</td><td class="number">37</td></tr>
+                <tr><td>Publish Images</td><td class="number">3</td><td class="number">2</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Release CLI</td><td class="number">1</td><td class="number">1</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>其他自动化</td><td class="number">8</td><td class="number">4</td><td class="number">1</td><td class="number">0</td><td class="number">3</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>本期薄弱点：</strong>PR E2E 实际形成结论的 14 次运行中有 8 次失败；需区分真实回归、环境不稳定和分支早期失败，不能只看最终合并结果。</p>
+        </section>
+
+        <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
+          <h2 id="delivery-title">安全、Release 与存量健康</h2>
+          <div class="health-grid">
+            <article class="health-note">
+              <h3>安全与供应链</h3>
+              <p>Security 32 次实际执行全部成功。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
+            </article>
+            <article class="health-note">
+              <h3>Release 交付</h3>
+              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.14">v0.2.14</a> 与 <a href="https://github.com/iflytek/skillhub/releases/tag/cli-v0.1.9">cli-v0.1.9</a> 均在 7 月 22 日发布，本周目标达成。</p>
+            </article>
+          </div>
+          <h3>Issue 健康</h3>
+          <div class="chart-grid">
+            <div class="chart-box" data-module="issue-age-chart">
+              <h3>开放 Issue 年龄结构</h3>
+              <div class="bars" role="img" aria-label="W30 当前开放 Issue 21 个：不足 7 天 5 个，7 到 13 天 3 个，14 到 29 天 2 个，30 天以上 11 个">
+                <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:45.5%"></span></span><span class="bar-value">5</span></div>
+                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:27.3%"></span></span><span class="bar-value">3</span></div>
+                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:18.2%"></span></span><span class="bar-value">2</span></div>
+                <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:100%"></span></span><span class="bar-value">11</span></div>
+              </div>
+              <p class="chart-note">52.4% 已超过 30 天；长期存量与信息补充队列仍需并行治理。</p>
+            </div>
+            <div class="chart-box" data-module="issue-needs-info-chart">
+              <h3><code>needs-info</code> 占比</h3>
+              <div class="donut-layout">
+                <div class="donut" style="--value:66.7%" role="img" aria-label="W30 当前开放 Issue 中，14 个带 needs-info 标签，占 21 个开放 Issue 的 66.7%">
+                  <div class="donut-center"><strong>66.7%</strong><span>14 / 21</span></div>
+                </div>
+                <div class="donut-copy">
+                  <p><strong>14 个</strong>开放 Issue 仍需补充信息。</p>
+                  <p>数量与 W29 持平，尚未形成可观察的清理进展。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <h3>PR 健康</h3>
+          <div class="chart-box" data-module="pr-age-chart">
+            <h3>开放 PR 年龄结构</h3>
+            <div class="bars" role="img" aria-label="W30 当前开放 PR 19 个：不足 7 天 5 个，7 到 13 天 1 个，14 到 29 天 3 个，30 天以上 10 个">
+              <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:50%"></span></span><span class="bar-value">5</span></div>
+              <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:10%"></span></span><span class="bar-value">1</span></div>
+              <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:30%"></span></span><span class="bar-value">3</span></div>
+              <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:100%"></span></span><span class="bar-value">10</span></div>
+            </div>
+            <p class="chart-note">52.6% 已超过 30 天；Review 与关闭决策仍是主要治理瓶颈。</p>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
+          <h2 id="response-title">社区响应</h2>
+          <p>本期 8 个新增 Issue 中，#582、#586、#594 已关闭，#596 在约 23 小时后形成配对 PR #601，#597 由 PR #592 继续跟踪。按“关闭或形成明确配对实现”统计，可观察处置覆盖为 5/8；该口径不等同于首次维护者响应 SLA。</p>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-flow" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-flow" data-panel="flow" hidden>
+        <div class="panel-intro">
+          <p>先看本周流转，再看当前高价值维护队列。</p>
+          <p>价值级别是人工治理判断，不替代仓库标签。</p>
+        </div>
+
+        <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
+          <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
+          <div class="flow-summary">
+            <div class="flow-item"><strong>Issue +8 / -3</strong><span>净增 5 · 当前快照开放 21</span></div>
+            <div class="flow-item"><strong>PR +12 / 合并 5</strong><span>关闭未合并 9 · 净减 2 · 当前快照开放 19</span></div>
+          </div>
+
+          <h3>新增 Issue（按价值排序）</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W30 新增 Issue 价值排序</caption>
+              <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前进展</th></tr></thead>
+              <tbody>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/596">#596 驳回版本同版本号重传返回 500</a></td><td>直接阻断发布核心流程。</td><td>配对 PR #601 已提交，CI/E2E 待修复。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/586">#586 启动脚本缺少 Cookie Secret</a></td><td>阻断依赖 OSS 脚本部署的用户。</td><td>本期完成同步并关闭。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/594">#594 GitLab OAuth Base URI 不生效</a></td><td>影响企业身份接入，官方标记 high risk。</td><td>本周约 4 小时内关闭；需保留关闭依据。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/583">#583 DingTalk OAuth</a></td><td>身份接入价值高，安全边界也需要严格审查。</td><td>与 PR #467 配对，期末仍开放。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/597">#597 搜索异步重建缺少 MDC、重试与指标</a></td><td>关系到索引长期一致性和可运维性。</td><td>作为 PR #592 的稳健性后续。</td></tr>
+                <tr><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/issues/587">#587 Skill Health Score</a></td><td>治理价值存在，但需先定义外部遥测契约。</td><td>当前信息不足，需明确遥测来源与责任边界。</td></tr>
+                <tr><td><span class="value-level value-d">D</span></td><td><a href="https://github.com/iflytek/skillhub/issues/589">#589 Skill 工作台</a></td><td>可能把 Registry 扩展为创作 IDE。</td><td>已标记 deferred，建议独立验证。</td></tr>
+                <tr><td><span class="value-level value-d">D</span></td><td><a href="https://github.com/iflytek/skillhub/issues/602">#602 MCP 广场和专家包</a></td><td>涉及产品边界扩张。</td><td>已标记 deferred，先澄清定位。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>新增、合并与关闭 PR</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W30 关键 PR 流转</caption>
+              <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
+              <tbody>
+                <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传修复</a></td><td>发布核心修复；本周 PR Tests 与 E2E 失败。</td></tr>
+                <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/592">#592 搜索索引异步重建</a></td><td>修复标签变化后的搜索一致性，当前仍开放。</td></tr>
+                <tr><td>合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/529">#529 双语 FAQ</a> / <a href="https://github.com/iflytek/skillhub/pull/591">#591 Scanner 依赖固定</a> / <a href="https://github.com/iflytek/skillhub/pull/595">#595 CLI 0.1.9</a></td><td>完成社区文档、镜像构建和 CLI 发版闭环。</td></tr>
+                <tr><td>合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/584">#584 Hermes 指南</a> / <a href="https://github.com/iflytek/skillhub/pull/585">#585 通用安装目标</a></td><td>完成 Agent 集成和跨 Agent 安装路径。</td></tr>
+                <tr><td>新增</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/593">#593 运维 FAQ</a> / <a href="https://github.com/iflytek/skillhub/pull/598">#598 HarnessClaw 指南</a></td><td>文档型贡献，完成事实核对后可小步合并。</td></tr>
+                <tr><td>其他新增</td><td>—</td><td>#588 / #590 / #599 / #600</td><td>覆盖俄语本地化、安全修复、README 传播与站点文档；#588、#590、#600 在本期关闭未合并。</td></tr>
+                <tr><td>关闭未合并</td><td>—</td><td>#317 / #459 / #569 / #572 / #575 / #578</td><td>配合新增后关闭的 #588、#590、#600，本期共完成 9 个未合并关闭决策。</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="priority-queue" aria-labelledby="priority-title">
+          <h2 id="priority-title">当前高价值维护队列</h2>
+          <p class="section-lead">以下为 2026-07-23 22:00 快照，只列需要明确决策的 A/B 项；价值分级不替代仓库标签。</p>
+
+          <h3>Issue：A 级优先处理</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">A 级开放 Issue</caption>
+              <thead><tr><th>Issue</th><th>价值判断</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/596">#596 驳回版本重传 500</a></td><td>发布核心流程确定性错误。</td><td>修复 #601 门禁后优先合并并回归版本指针。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/580">#580 namespace 可见性</a></td><td>企业治理核心体验，已有配对实现。</td><td>收敛 PR #581 范围并完成完整门禁。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/516">#516 多 Skill 仓库导入与同步</a></td><td>与 Registry 增长定位高度一致。</td><td>先形成一期验收标准，再做扫描与批量发布。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/518">#518 SemVer 与预发布版本</a></td><td>Registry 基础协议，文档与实现需统一。</td><td>先统一兼容、排序、latest 与 prerelease 规则。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Issue：B 级需设计或严格审查</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">B 级开放 Issue</caption>
+              <thead><tr><th>Issue</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/597">#597 搜索异步路径可观察性</a></td><td>先补失败指标与 MDC，再决定有界重试。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/583">#583 DingTalk OAuth</a></td><td>围绕 Issue 对 PR #467 做集中安全评审。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/579">#579 来源证明、签名与 SBOM</a></td><td>拆分 fingerprint、签名验证和 SBOM。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/556">#556 合规元数据与审计</a></td><td>审查领域模型、迁移、查询性能与 API 生成。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/452">#452 Skill Evaluation</a></td><td>先做外部执行、SkillHub 接收并展示结果的窄版本。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>PR：A 级优先推进</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">A 级开放 PR</caption>
+              <thead><tr><th>PR</th><th>价值判断</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/601">#601 修复驳回版本重传 500</a></td><td>直接修复发布核心流程。</td><td>定位 PR Tests/E2E 失败，完整通过后优先合并。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/581">#581 namespace 可见性</a></td><td>用户价值高，但范围较大。</td><td>核对无关变更，rebase 后重跑完整门禁。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/592">#592 搜索索引异步重建</a></td><td>修复真实索引一致性错误。</td><td>确认完整 CI；稳健性问题由 #597 跟踪。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/593">#593 部署与运维 FAQ</a></td><td>低风险，可降低社区支持成本。</td><td>完成事实校对后合并。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <details data-module="cleanup-queue">
+            <summary>展开：需要清理的长期 PR</summary>
+            <div class="details-body">
+              <p><a href="https://github.com/iflytek/skillhub/pull/460">#460</a>、<a href="https://github.com/iflytek/skillhub/pull/457">#457</a>、<a href="https://github.com/iflytek/skillhub/pull/442">#442</a> 已被主干实现或替代；<a href="https://github.com/iflytek/skillhub/pull/437">#437</a> 依赖未推进的父 PR。建议确认无剩余差异后关闭。</p>
+            </div>
+          </details>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-method" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-method" data-panel="method" hidden>
+        <div class="panel-intro">
+          <p>这里说明时间边界、数据来源与缺失项。</p>
+          <p>缺失数据均标为“未取得”，不替换为 0。</p>
+        </div>
+
+        <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
+          <h2 id="method-title">统计口径</h2>
+          <ul class="method-list">
+            <li><strong>统计周期</strong><span>2026-07-16 00:00—2026-07-23 22:00，Asia/Shanghai；按“上周四到本周四”回溯统计。</span></li>
+            <li><strong>当前快照</strong><span>2026-07-23 22:00；开放队列与仓库累计数均取该时点。</span></li>
+            <li><strong>Star 比较</strong><span>期初净 Star 快照未取得，因此只展示期末 4,823，不推断统计期净增长。</span></li>
+            <li><strong>历史衔接</strong><span>本报告由原周一—周日口径回溯调整；7 月 16 日和 7 月 23 日是周四边界日期，也会出现在相邻报告的展示周期中。</span></li>
+            <li><strong>期后进展</strong><span>7 月 23 日 22:00 以后发生的合并、关闭和 Release 只作为后续状态，不计入 W30。</span></li>
+            <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权、条件跳过和取消不进入分母。</span></li>
+            <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告分开统计；价值 A—D 为人工治理判断。</span></li>
+            <li><strong>推广数据</strong><span>推广动作由维护者补录；Fork、下载、Issue 作者和 PR 作者不组成转化漏斗。</span></li>
+          </ul>
+        </section>
+
+        <section class="report-section" data-module="source-coverage" aria-labelledby="source-title">
+          <h2 id="source-title">数据来源与限制</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>来源覆盖</caption>
+              <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
+              <tbody>
+                <tr><td>GitHub REST API</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer</td><td>Traffic 与私有安全告警不可见。</td></tr>
+                <tr><td>Git 标签与提交历史</td><td>核对 v0.2.14 交付内容</td><td>只用于补充公开 Release 信息。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 本期下载</td><td>856 次下载不等同于独立用户。</td></tr>
+                <tr><td>维护者人工判断</td><td>价值排序、推广动作和产品边界</td><td>推广动作尚未提供。</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、期初净 Star 快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
+        </section>
+      </div>
+    </main>
+
+    <footer>
+      <span>SkillHub Open Source Weekly · 2026-W30</span>
+      <span>公开报告 · 维护者治理视图</span>
+    </footer>
+  </article>
+
+  <script>
+    (function () {
+      var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
+      var panels = Array.prototype.slice.call(document.querySelectorAll('[role="tabpanel"]'));
+
+      function activate(name, moveFocus, updateHash) {
+        var nextTab = tabs.find(function (tab) { return tab.dataset.tab === name; }) || tabs[0];
+        tabs.forEach(function (tab) {
+          var selected = tab === nextTab;
+          tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+          tab.tabIndex = selected ? 0 : -1;
+        });
+        panels.forEach(function (panel) {
+          panel.hidden = panel.dataset.panel !== nextTab.dataset.tab;
+        });
+        if (moveFocus) nextTab.focus();
+        if (updateHash && history.replaceState) {
+          history.replaceState(null, '', '#' + nextTab.dataset.tab);
+        }
+      }
+
+      tabs.forEach(function (tab, index) {
+        tab.addEventListener('click', function () {
+          activate(tab.dataset.tab, false, true);
+        });
+        tab.addEventListener('keydown', function (event) {
+          var nextIndex = index;
+          if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+          else if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+          else if (event.key === 'Home') nextIndex = 0;
+          else if (event.key === 'End') nextIndex = tabs.length - 1;
+          else return;
+          event.preventDefault();
+          activate(tabs[nextIndex].dataset.tab, true, true);
+        });
+      });
+
+      window.addEventListener('hashchange', function () {
+        activate(location.hash.replace('#', ''), false, false);
+      });
+      activate(location.hash.replace('#', ''), false, false);
+    }());
+  </script>
+</body>
+</html>

--- a/weekly/site/reports/2026-W31/index.html
+++ b/weekly/site/reports/2026-W31/index.html
@@ -1,0 +1,1723 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="SkillHub 2026 年第 31 周开源周报：仓库状态、功能迭代、生态进展及项目健康明细。">
+  <title>SkillHub 开源周报｜2026 年第 31 周</title>
+  <script>document.documentElement.classList.add('js')</script>
+  <style data-report-theme="notion-light">
+:root {
+  color-scheme: light;
+  --page: #ffffff;
+  --paper: #ffffff;
+  --warm: #f6f5f4;
+  --ink: #0d0d0d;
+  --ink-soft: #31302e;
+  --muted: #615d59;
+  --faint: #76716c;
+  --line: #e5e3e1;
+  --line-soft: #efeeec;
+  --blue: #0075de;
+  --blue-active: #005bab;
+  --blue-soft: #f2f9ff;
+  --green: #147a33;
+  --green-soft: #e9f7ec;
+  --orange: #b84d00;
+  --orange-soft: #fdf0e3;
+  --red: #b52d25;
+  --red-soft: #fdecea;
+  --neutral-soft: #f1f0ef;
+  --focus: #097fe8;
+  --radius-sm: 8px;
+  --radius: 12px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 4%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 15px/1.65 Inter, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--blue-active);
+  text-decoration: underline;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--neutral-soft);
+  color: var(--ink-soft);
+  font-size: .92em;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 30;
+  top: 8px;
+  left: -999px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background: var(--ink-soft);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: 8px;
+}
+
+.report {
+  width: min(1200px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.masthead {
+  padding: 44px 28px 36px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 26px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: var(--ink-soft);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.brand-name {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+}
+
+.brand-tag {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--neutral-soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.utility-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 820px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(32px, 4vw, 44px);
+  line-height: 1.15;
+  letter-spacing: -.025em;
+}
+
+.report-sub {
+  margin: 8px 0 24px;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: 1.15fr .85fr;
+  gap: 16px;
+}
+
+.meta-card,
+.headline {
+  border-radius: var(--radius-sm);
+  padding: 20px 22px;
+}
+
+.meta-card {
+  background: var(--warm);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.meta-item .key,
+.headline-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--faint);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: .01em;
+}
+
+.meta-item .value {
+  color: var(--ink-soft);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.period {
+  margin: 0;
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  border: 0;
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.headline-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 7px;
+}
+
+.headline-status strong {
+  color: var(--orange);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.headline p {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 18px;
+  border: 0;
+}
+
+.metric {
+  min-width: 0;
+  padding: 16px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.metric strong {
+  display: block;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.tabs-wrap {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+  background: rgb(255 255 255 / 97%);
+  backdrop-filter: saturate(1.1) blur(5px);
+}
+
+.tabs {
+  display: flex;
+  min-width: max-content;
+  padding: 0 28px;
+}
+
+.tab {
+  position: relative;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.tab::after {
+  position: absolute;
+  right: 14px;
+  bottom: -1px;
+  left: 14px;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.tab:hover,
+.tab[aria-selected="true"] {
+  color: var(--ink);
+}
+
+.tab[aria-selected="true"] {
+  font-weight: 600;
+}
+
+.tab[aria-selected="true"]::after {
+  background: var(--ink-soft);
+}
+
+main {
+  padding: 0 28px 48px;
+}
+
+.tab-panel {
+  padding-top: 4px;
+}
+
+.js .tab-panel[hidden] {
+  display: none;
+}
+
+.panel-intro {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.panel-intro p {
+  margin: 0;
+}
+
+section.report-section {
+  margin: 0;
+  padding: 48px 0;
+  border: 0;
+}
+
+.tab-panel > section.report-section:nth-of-type(even) {
+  background: var(--warm);
+  box-shadow: 0 0 0 100vmax var(--warm);
+  clip-path: inset(0 -100vmax);
+}
+
+section.report-section:first-of-type {
+  padding-top: 42px;
+}
+
+h2 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+h3 {
+  margin: 30px 0 12px;
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.35;
+  letter-spacing: -.01em;
+}
+
+p {
+  max-width: 75ch;
+  text-wrap: pretty;
+}
+
+.section-lead {
+  margin: -7px 0 18px;
+  color: var(--muted);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+}
+
+table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+caption {
+  padding: 10px 14px;
+  background: var(--warm);
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: #faf9f8;
+}
+
+.number {
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.status,
+.value-level {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 25px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.status::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.status.ok {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status.warn {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.status.risk {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-a {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-b {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.value-c {
+  background: var(--blue-soft);
+  color: var(--blue-active);
+}
+
+.value-d {
+  background: var(--neutral-soft);
+  color: var(--muted);
+}
+
+.risk-note {
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.repo-visuals {
+  display: grid;
+  grid-template-columns: minmax(280px, .85fr) minmax(0, 1.15fr);
+  gap: 18px;
+}
+
+.snapshot-list {
+  display: grid;
+  gap: 0;
+}
+
+.snapshot-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto;
+  gap: 4px 16px;
+  align-items: center;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.snapshot-row:first-child {
+  padding-top: 0;
+}
+
+.snapshot-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.snapshot-row .snapshot-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.snapshot-row strong {
+  color: var(--ink);
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.snapshot-row .snapshot-change {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.snapshot-row .snapshot-change.positive {
+  color: var(--green);
+}
+
+.snapshot-row .snapshot-change.missing {
+  color: var(--orange);
+}
+
+.chart-note {
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.ecosystem-signal {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.ecosystem-signal strong {
+  display: block;
+  color: var(--ink);
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecosystem-signal span {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signal-note {
+  grid-column: 1 / -1;
+  margin: -3px 0 0;
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.ecosystem-list,
+.method-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.ecosystem-list li,
+.method-list li {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.method-list li {
+  grid-template-columns: 180px 1fr;
+}
+
+.ecosystem-list strong,
+.method-list strong {
+  color: var(--ink);
+}
+
+.next-actions {
+  margin: 4px 0 30px;
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.next-actions h2 {
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.next-actions ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.next-actions li {
+  margin: 7px 0;
+}
+
+.health-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.health-card,
+.chart-box,
+.health-note {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.health-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 20px 22px;
+}
+
+.health-card .top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.health-card .name {
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.health-card .health-metric {
+  color: var(--ink);
+  font-size: 27px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.health-card .health-metric small {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.health-card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.health-card .detail {
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.segbar {
+  display: flex;
+  height: 24px;
+  overflow: hidden;
+  margin: 15px 0 10px;
+  border-radius: 6px;
+  background: var(--neutral-soft);
+}
+
+.segbar > span {
+  min-width: 2px;
+  height: 100%;
+}
+
+.seg-success {
+  background: #1aae39;
+}
+
+.seg-failure {
+  background: #e16259;
+}
+
+.seg-auth {
+  background: #e8a94b;
+}
+
+.seg-skipped {
+  background: #d6d2cd;
+}
+
+.seg-cancelled {
+  background: #8e8984;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chart-legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.chart-legend b {
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.chart-box {
+  padding: 20px 22px;
+}
+
+.chart-box h3 {
+  margin: 0 0 14px;
+  font-size: 15px;
+}
+
+.bars {
+  display: grid;
+  gap: 11px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 42px;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.repo-visuals .bar-row {
+  grid-template-columns: 112px 1fr 36px;
+}
+
+.bar-label {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 16px;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--neutral-soft);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 5px;
+  background: var(--blue);
+}
+
+.bar-fill.hot {
+  background: var(--orange);
+}
+
+.bar-value {
+  color: var(--ink-soft);
+  font-weight: 700;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.donut-layout {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 22px;
+  align-items: center;
+}
+
+.donut {
+  position: relative;
+  width: 142px;
+  height: 142px;
+  border-radius: 50%;
+  background: conic-gradient(var(--orange) 0 var(--value), #d6d2cd var(--value) 100%);
+}
+
+.donut::after {
+  position: absolute;
+  inset: 24px;
+  border-radius: 50%;
+  background: var(--paper);
+  content: "";
+}
+
+.donut-center {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.donut-center strong {
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+.donut-center span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.donut-copy p {
+  margin: 0 0 9px;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.donut-copy p:last-child {
+  margin-bottom: 0;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chart-box + .table-wrap {
+  margin-top: 18px;
+}
+
+.health-note {
+  padding: 18px;
+}
+
+.health-note h3 {
+  margin: 0 0 7px;
+  font-size: 15px;
+}
+
+.health-note p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.flow-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0 24px;
+}
+
+.flow-item {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.flow-item strong {
+  display: block;
+  color: var(--ink);
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-item span {
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+details {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+summary {
+  padding: 14px 18px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.details-body {
+  padding: 0 18px 16px;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 28px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .masthead,
+  main,
+  footer {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .topline,
+  footer,
+  .panel-intro {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .header-grid,
+  .meta-grid,
+  .repo-visuals,
+  .chart-grid,
+  .health-grid,
+  .flow-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .header-grid > *,
+  .meta-item {
+    min-width: 0;
+  }
+
+  .meta-item .value {
+    overflow-wrap: anywhere;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tabs {
+    padding: 0 6px;
+  }
+
+  section.report-section {
+    padding: 38px 0;
+  }
+
+  .ecosystem-list li,
+  .method-list li {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+
+  .ecosystem-signals {
+    grid-template-columns: 1fr;
+  }
+
+  .ecosystem-signal-note {
+    grid-column: auto;
+  }
+
+  .donut-layout {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .donut-copy {
+    text-align: center;
+  }
+}
+
+@media (max-width: 430px) {
+  h1 {
+    font-size: 30px;
+    overflow-wrap: anywhere;
+  }
+
+  .bar-row {
+    grid-template-columns: 76px 1fr 32px;
+    gap: 7px;
+  }
+
+  .repo-visuals .bar-row {
+    grid-template-columns: 98px 1fr 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media print {
+  @page {
+    size: A4;
+    margin: 13mm;
+  }
+
+  body {
+    background: #fff;
+    font-size: 10px;
+  }
+
+  .report {
+    width: 100%;
+  }
+
+  .masthead,
+  main,
+  footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .tabs-wrap,
+  .skip-link,
+  .utility-links {
+    display: none !important;
+  }
+
+  .tab-panel[hidden] {
+    display: block !important;
+  }
+
+  .tab-panel {
+    break-before: page;
+  }
+
+  .tab-panel:first-child {
+    break-before: auto;
+  }
+
+  .tab-panel > section.report-section:nth-of-type(even) {
+    background: #fff;
+    box-shadow: none;
+    clip-path: none;
+  }
+
+  section.report-section {
+    padding: 16px 0;
+  }
+
+  h1 {
+    font-size: 27px;
+  }
+
+  h2,
+  h3,
+  tr,
+  .health-card,
+  .health-note,
+  .chart-box,
+  .next-actions {
+    break-inside: avoid;
+  }
+
+  table {
+    min-width: 0;
+    font-size: 8px;
+  }
+
+  th,
+  td {
+    padding: 5px 6px;
+  }
+
+  .health-card,
+  .health-note,
+  .chart-box {
+    box-shadow: none;
+  }
+
+  .segbar,
+  .bar-fill,
+  .donut,
+  .status,
+  .value-level,
+  .metric,
+  .headline {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}
+  </style>
+  <noscript>
+    <style>
+      .tabs-wrap { display: none !important; }
+      .tab-panel[hidden] { display: block !important; }
+    </style>
+  </noscript>
+</head>
+<body>
+  <a class="skip-link" href="#report-content">跳到报告正文</a>
+  <article class="report">
+    <header class="masthead">
+      <div class="topline">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">SH</span>
+          <span class="brand-name">SkillHub</span>
+          <span class="brand-tag">开源周报</span>
+        </div>
+        <nav class="utility-links" aria-label="站点链接">
+          <a href="../../archive.html">历史周报</a>
+          <a href="https://iflytek.github.io/skillhub/">项目文档</a>
+          <a href="https://github.com/iflytek/skillhub">GitHub 仓库</a>
+        </nav>
+      </div>
+      <h1>2026 年第 31 周</h1>
+      <p class="report-sub">项目健康 · 版本交付 · 开源生态 · Issue/PR 流转与价值队列</p>
+      <div class="header-grid">
+        <div class="meta-card">
+          <div class="meta-grid">
+            <div class="meta-item">
+              <span class="key">统计周期</span>
+              <span class="value">2026-07-23 00:00—2026-07-30 16:36（Asia/Shanghai）</span>
+            </div>
+            <div class="meta-item">
+              <span class="key">当前状态快照</span>
+              <span class="value">2026-07-30 16:36（Asia/Shanghai）</span>
+            </div>
+            <div class="meta-item">
+              <span class="key">项目仓库</span>
+              <span class="value"><a href="https://github.com/iflytek/skillhub">iflytek/skillhub</a></span>
+            </div>
+            <div class="meta-item">
+              <span class="key">数据来源</span>
+              <span class="value">GitHub REST API · Actions · Git · npm Downloads API</span>
+            </div>
+          </div>
+        </div>
+        <div class="headline">
+          <span class="headline-label">总体状态</span>
+          <div class="headline-status">
+            <strong>需关注</strong>
+            <span class="status warn">Attention</span>
+          </div>
+          <p>应用 v0.2.15、镜像及 Helm Chart 已完成发布，Actions 保持稳定；Issue 净增 20、开放 P1 达 19 个，是当前主要风险。</p>
+        </div>
+      </div>
+      <div class="metrics" aria-label="四项核心指标">
+        <div class="metric"><strong>4,945</strong><span>Stars · 较 7 月 23 日 +122*</span></div>
+        <div class="metric"><strong>702</strong><span>Forks · 本期新增 60</span></div>
+        <div class="metric"><strong>97.6%</strong><span>Actions 有效成功率 · 240/246</span></div>
+        <div class="metric"><strong>1 / 0</strong><span>应用 / CLI Release · 本期</span></div>
+      </div>
+    </header>
+
+    <div class="tabs-wrap">
+      <nav class="tabs" role="tablist" aria-label="周报视图">
+        <button class="tab" id="tab-overview" type="button" role="tab" aria-selected="true"
+          aria-controls="panel-overview" tabindex="0" data-tab="overview">总览</button>
+        <button class="tab" id="tab-health" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-health" tabindex="-1" data-tab="health">项目健康</button>
+        <button class="tab" id="tab-flow" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-flow" tabindex="-1" data-tab="flow">Issue 与 PR</button>
+        <button class="tab" id="tab-method" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-method" tabindex="-1" data-tab="method">数据说明</button>
+      </nav>
+    </div>
+
+    <main id="report-content">
+      <div class="tab-panel" id="panel-overview" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-overview" data-panel="overview">
+        <div class="panel-intro">
+          <p>三分钟总览：只保留仓库、迭代和生态三类决策信息。</p>
+          <p>详细健康和维护队列请使用上方 Tab。</p>
+        </div>
+
+        <section class="report-section" data-module="repository-summary" aria-labelledby="repository-title">
+          <h2 id="repository-title">一、仓库关键信息</h2>
+          <div class="repo-visuals">
+            <div class="chart-box" data-module="repository-scale">
+              <h3>规模快照</h3>
+              <div class="snapshot-list">
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Stars</span>
+                  <strong>4,945</strong>
+                  <span class="snapshot-change positive">较 7 月 23 日 22:00 快照 +122（4,823 → 4,945）</span>
+                </div>
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Forks</span>
+                  <strong>702</strong>
+                  <span class="snapshot-change positive">7 月 23 日以来新增 60</span>
+                </div>
+              </div>
+              <p class="chart-note">Star 变化覆盖 7 月 23 日 22:00 至 7 月 30 日 16:36，未覆盖本期最初 22 小时；Fork 新增按创建时间统计。</p>
+            </div>
+            <div class="chart-box" data-module="weekly-collaboration-chart">
+              <h3>本期协作流转</h3>
+              <div class="bars" role="img" aria-label="W31 协作流转：Issue 新增 22 个、关闭 2 个；PR 新增 20 个、合并 16 个、关闭未合并 6 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">22</span></div>
+                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:9.1%"></span></span><span class="bar-value">2</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:90.9%"></span></span><span class="bar-value">20</span></div>
+                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:72.7%"></span></span><span class="bar-value">16</span></div>
+                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:27.3%"></span></span><span class="bar-value">6</span></div>
+              </div>
+              <p class="chart-note">Issue 净增 20，当前开放 40；PR 净减 2，当前开放 15。主分支新增 56 个提交，其中 19 个 Merge Commit。</p>
+            </div>
+          </div>
+          <p class="risk-note"><strong>主要风险：</strong>Issue 输入速度显著高于处置速度，当前开放 P1 19 个、P2 17 个；应用已完成发版，但 CLI 仍需明确本周发布或跳过结论。</p>
+        </section>
+
+        <section class="report-section" data-module="feature-iterations" aria-labelledby="feature-title">
+          <h2 id="feature-title">二、功能迭代信息</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>按用户价值排序的重要事项</caption>
+              <thead><tr><th>状态</th><th>事项</th><th>进展与下一步</th></tr></thead>
+              <tbody>
+                <tr>
+                  <td><span class="status ok">已完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a></td>
+                  <td>已发布 Helm Chart、Redis Cluster/Sentinel、PostgreSQL/Nginx 部署增强，以及认证、发布与搜索修复；镜像和 Helm Chart 发布工作流均成功。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">已完成</span></td>
+                  <td>认证与 CLI 稳定性修复</td>
+                  <td>修复 <a href="https://github.com/iflytek/skillhub/pull/607">Device Auth Redis 反序列化</a>、<a href="https://github.com/iflytek/skillhub/pull/608">Namespace 坐标</a>与 <a href="https://github.com/iflytek/skillhub/pull/610">403 错误语义</a>，并补充 <a href="https://github.com/iflytek/skillhub/pull/609">Token 撤销回归测试</a>。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">已完成</span></td>
+                  <td>发布与搜索一致性</td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/601">驳回版本重传</a>和 <a href="https://github.com/iflytek/skillhub/pull/592">标签变更后重建搜索索引</a>已合并，关闭两条核心流程缺陷。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">已完成</span></td>
+                  <td>生态与文档补全</td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/593">社区 FAQ</a>、<a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw 指南</a>、<a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>与 <a href="https://github.com/iflytek/skillhub/pull/603">生态入口</a>已合并。</td>
+                </tr>
+                <tr>
+                  <td><span class="status warn">推进中</span></td>
+                  <td>统一身份联邦</td>
+                  <td><a href="https://github.com/iflytek/skillhub/issues/628">架构议题 #628</a>、<a href="https://github.com/iflytek/skillhub/pull/630">设计文档 #630</a>、<a href="https://github.com/iflytek/skillhub/pull/631">可信属性 #631</a>与 <a href="https://github.com/iflytek/skillhub/pull/633">全局成员配置 #633</a>仍在审查，尚未合并。</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
+          <h2 id="ecosystem-title">三、生态相关进展</h2>
+          <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
+            aria-label="W31 开源生态参与信号：新增 Issue 22 个、新增 PR 20 个、合并作者 10 位；新增 60 个 Fork；SkillHub CLI npm 下载 1041 次">
+            <div class="ecosystem-signal"><strong>22 / 20 / 10</strong><span>新增 Issue / 新增 PR / 合并作者</span></div>
+            <div class="ecosystem-signal"><strong>+60</strong><span>本期新增 Fork</span></div>
+            <div class="ecosystem-signal"><strong>1,041</strong><span>SkillHub CLI npm 下载</span></div>
+            <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
+          </div>
+          <ul class="ecosystem-list">
+            <li><strong>社区贡献</strong><span>16 个 PR 由 10 位作者完成合并，其中 9 位为社区 Contributor，贡献覆盖部署、认证、CLI、核心流程与文档。</span></li>
+            <li><strong>Agent 集成</strong><span><a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw Engine 指南</a> 已合并，新增一条 Agent 生态接入路径。</span></li>
+            <li><strong>项目可发现性</strong><span><a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>及 <a href="https://github.com/iflytek/skillhub/pull/603">Trendshift、AAIF 入口</a>已落地。</span></li>
+          </ul>
+        </section>
+
+        <aside class="next-actions" data-module="next-actions" aria-labelledby="next-title">
+          <h2 id="next-title">下周关注</h2>
+          <p>以下动作延续到下一期跟踪。</p>
+          <ol>
+            <li>为 19 个开放 P1 Issue 明确负责人和处置顺序，并批量处理 22 个 <code>triage/needs-info</code> Issue。</li>
+            <li>优先审查 <a href="https://github.com/iflytek/skillhub/pull/623">#623</a>、<a href="https://github.com/iflytek/skillhub/pull/624">#624</a>、<a href="https://github.com/iflytek/skillhub/pull/639">#639</a> 与 <a href="https://github.com/iflytek/skillhub/pull/633">#633</a>，保持 PR 存量下降趋势。</li>
+            <li>明确 CLI 发版窗口；<a href="https://github.com/iflytek/skillhub/pull/608">#608 Namespace 修复</a>已进入源码，但尚未包含在 npm CLI 0.1.9 中。</li>
+          </ol>
+        </aside>
+      </div>
+
+      <div class="tab-panel" id="panel-health" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-health" data-panel="health" hidden>
+        <div class="panel-intro">
+          <p>项目健康详情：用于维护者判断工程、交付和治理风险。</p>
+          <p>成功流水线不等同于“无漏洞”。</p>
+        </div>
+
+        <section class="report-section" data-module="health-summary" aria-labelledby="health-summary-title">
+          <h2 id="health-summary-title">项目健康状态</h2>
+          <div class="health-cards">
+            <article class="health-card">
+              <div class="top"><span class="name">工程稳定性</span><span class="status ok">稳定</span></div>
+              <div class="health-metric">97.6% <small>240/246</small></div>
+              <p>有效运行中有 6 次失败。</p>
+              <div class="detail">PR Tests 2 次、PR E2E 3 次、DeepWiki 1 次。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
+              <div class="health-metric">59 / 59 <small>执行成功</small></div>
+              <p>另有 14 次等待授权、7 次条件跳过。</p>
+              <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">31 / 31 <small>Backlog Rescore</small></div>
+              <p>镜像发布 12/12，文档部署 4/4。</p>
+              <div class="detail">Release 相关发布成功；DeepWiki Crawler 失败 1 次。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Release 交付</span><span class="status ok">应用达成</span></div>
+              <div class="health-metric">1 / 0 <small>应用 / CLI</small></div>
+              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a> 已于 7 月 30 日发布。</p>
+              <div class="detail">CLI 本周尚无新版本；最新 npm 版本仍为 0.1.9。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Issue 治理</span><span class="status risk">风险</span></div>
+              <div class="health-metric">+20 <small>本期净增</small></div>
+              <p>开放 40 个，其中 P1 19 个、<code>triage/needs-info</code> 22 个。</p>
+              <div class="detail">输入速度明显高于关闭速度，是当前首要治理风险。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">PR 治理</span><span class="status ok">改善中</span></div>
+              <div class="health-metric">-2 <small>存量净变化</small></div>
+              <p>合并 16 个、关闭未合并 6 个，当前开放 15 个。</p>
+              <div class="detail">30 天以上 PR 降至 3 个，仍需逐项做关闭或推进决策。</div>
+            </article>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
+          <h2 id="ci-title">CI 与自动化执行</h2>
+          <p class="section-lead">统计期内有 381 条 Actions 记录，其中 240 次成功、6 次失败、49 次等待授权、82 次跳过、4 次取消。</p>
+          <div class="chart-box" data-module="actions-outcome-chart">
+            <h3>Actions 结果构成</h3>
+            <div class="segbar" role="img" aria-label="W31 Actions 共 381 条记录：成功 240，失败 6，等待授权 49，条件跳过 82，取消 4">
+              <span class="seg-success" style="width:63.00%"></span>
+              <span class="seg-failure" style="width:1.57%"></span>
+              <span class="seg-auth" style="width:12.86%"></span>
+              <span class="seg-skipped" style="width:21.52%"></span>
+              <span class="seg-cancelled" style="width:1.05%"></span>
+            </div>
+            <div class="chart-legend" aria-hidden="true">
+              <span><i class="seg-success"></i>成功 <b>240</b></span>
+              <span><i class="seg-failure"></i>失败 <b>6</b></span>
+              <span><i class="seg-auth"></i>等待授权 <b>49</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>82</b></span>
+              <span><i class="seg-cancelled"></i>取消 <b>4</b></span>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <caption>工作流执行明细</caption>
+              <thead>
+                <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>PR Tests</td><td class="number">66</td><td class="number">42</td><td class="number">2</td><td class="number">14</td><td class="number">8</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">53</td><td class="number">27</td><td class="number">3</td><td class="number">14</td><td class="number">9</td></tr>
+                <tr><td>PR Scripts</td><td class="number">24</td><td class="number">18</td><td class="number">0</td><td class="number">6</td><td class="number">0</td></tr>
+                <tr><td>Security</td><td class="number">80</td><td class="number">59</td><td class="number">0</td><td class="number">14</td><td class="number">7</td></tr>
+                <tr><td>Issue Triage</td><td class="number">95</td><td class="number">35</td><td class="number">0</td><td class="number">0</td><td class="number">60</td></tr>
+                <tr><td>Issue Backlog Rescore</td><td class="number">31</td><td class="number">31</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Publish Images</td><td class="number">12</td><td class="number">12</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Deploy Docs</td><td class="number">4</td><td class="number">4</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>其他自动化</td><td class="number">16</td><td class="number">12</td><td class="number">1</td><td class="number">1</td><td class="number">2</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>本期薄弱点：</strong>6 次失败来自 PR Tests 2 次、PR E2E 3 次和 DeepWiki Documentation Crawler 1 次；等待授权共 49 次，不计入有效成功率分母。</p>
+        </section>
+
+        <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
+          <h2 id="delivery-title">安全、Release 与存量健康</h2>
+          <div class="health-grid">
+            <article class="health-note">
+              <h3>安全与供应链</h3>
+              <p>Security 59 次实际执行全部成功。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
+            </article>
+            <article class="health-note">
+              <h3>Release 交付</h3>
+              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a> 已于 7 月 30 日 16:25 发布，Publish Images 与 Publish Helm Chart 均成功。CLI 本周仍为 0；#608 的 Namespace 修复尚未进入 npm CLI 0.1.9。</p>
+            </article>
+          </div>
+          <h3>Issue 健康</h3>
+          <div class="chart-grid">
+            <div class="chart-box" data-module="issue-age-chart">
+              <h3>开放 Issue 年龄结构</h3>
+              <div class="bars" role="img" aria-label="W31 当前开放 Issue 40 个：不足 7 天 21 个，7 到 13 天 4 个，14 到 29 天 3 个，30 天以上 12 个">
+                <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">21</span></div>
+                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:19%"></span></span><span class="bar-value">4</span></div>
+                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:14.3%"></span></span><span class="bar-value">3</span></div>
+                <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:57.1%"></span></span><span class="bar-value">12</span></div>
+              </div>
+              <p class="chart-note">长期存量数量未增长，但 22 个新 Issue 使治理压力转向短期分诊和价值判断。</p>
+            </div>
+            <div class="chart-box" data-module="issue-needs-info-chart">
+              <h3><code>needs-info</code> 占比</h3>
+              <div class="donut-layout">
+                <div class="donut" style="--value:55%" role="img" aria-label="W31 当前开放 Issue 中，22 个带 triage/needs-info 标签，占 40 个开放 Issue 的 55.0%">
+                  <div class="donut-center"><strong>55.0%</strong><span>22 / 40</span></div>
+                </div>
+                <div class="donut-copy">
+                  <p><strong>22 个</strong>开放 Issue 仍需补充信息。</p>
+                  <p>绝对数量较上周快照增加 8 个，需要集中澄清或关闭。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <h3>PR 健康</h3>
+          <div class="chart-box" data-module="pr-age-chart">
+            <h3>开放 PR 年龄结构</h3>
+            <div class="bars" role="img" aria-label="W31 当前开放 PR 15 个：不足 7 天 10 个，7 到 13 天 0 个，14 到 29 天 2 个，30 天以上 3 个">
+              <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">10</span></div>
+              <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:0%"></span></span><span class="bar-value">0</span></div>
+              <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:20%"></span></span><span class="bar-value">2</span></div>
+              <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:30%"></span></span><span class="bar-value">3</span></div>
+            </div>
+            <p class="chart-note">30 天以上 PR 占比为 20.0%；本周合并与关闭决策仍显著降低了长期存量。</p>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
+          <h2 id="response-title">社区响应</h2>
+          <p>22 个新增 Issue 中，<a href="https://github.com/iflytek/skillhub/issues/604">#604</a> 已关闭；#604—#606 及 <a href="https://github.com/iflytek/skillhub/issues/634">#634</a> 已形成对应修复、回归或替代 PR。<a href="https://github.com/iflytek/skillhub/issues/602">#602</a> 提出 MCP 广场和专家包方向，其余新输入仍以 Bug 和身份架构议题为主。该口径不等同于首次维护者响应 SLA。</p>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-flow" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-flow" data-panel="flow" hidden>
+        <div class="panel-intro">
+          <p>先看本周流转，再看当前高价值维护队列。</p>
+          <p>价值级别是人工治理判断，不替代仓库标签。</p>
+        </div>
+
+        <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
+          <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
+          <div class="flow-summary">
+            <div class="flow-item"><strong>Issue +22 / -2</strong><span>净增 20 · 当前快照开放 40</span></div>
+            <div class="flow-item"><strong>PR +20 / 合并 16</strong><span>关闭未合并 6 · 净减 2 · 当前开放 15</span></div>
+          </div>
+
+          <h3>新增 Issue（按价值排序）</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W31 新增 Issue 价值排序</caption>
+              <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前进展</th></tr></thead>
+              <tbody>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/634">#634 禁用不安全的旧账户合并流程</a> / <a href="https://github.com/iflytek/skillhub/issues/640">#640 身份核心与 Provider 权限锁</a></td><td>涉及账户接管防护和统一身份授权边界。</td><td>#634 已形成替代 PR #639；#640 仍待实现方案。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/605">#605 Token 撤销后 whoami/search 仍放行</a></td><td>凭证撤销语义不一致，存在认证风险。</td><td>已合并回归测试 #609，Issue 仍开放，需完成实现修复。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/611">#611 删除版本残留子外键</a> / <a href="https://github.com/iflytek/skillhub/issues/612">#612 扫描任务早于事务提交</a></td><td>直接影响版本删除和发布扫描一致性。</td><td>均开放，需先补可复现测试与事务边界结论。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/615">#615 审核审计失败导致状态已提交但返回 500</a> / <a href="https://github.com/iflytek/skillhub/issues/617">#617 首次发布坐标竞争</a></td><td>可能造成客户端认知与服务端状态不一致。</td><td>均开放，优先处理幂等与事务一致性。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/613">#613 并发 OAuth 绑定 500</a> / <a href="https://github.com/iflytek/skillhub/issues/614">#614 旧 Session 阻断公开 API</a></td><td>影响登录与公开技能访问。</td><td>均开放，需覆盖并发和失效会话回归。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/628">#628 统一身份联邦</a> / <a href="https://github.com/iflytek/skillhub/issues/629">#629 外部身份可信属性</a> / <a href="https://github.com/iflytek/skillhub/issues/632">#632 审批后配置全局成员</a></td><td>决定企业身份接入与授权边界。</td><td>已形成 #630、#631、#633 三个开放 PR，待集中审查。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/620">#620 审核进度</a> / <a href="https://github.com/iflytek/skillhub/issues/621">#621 主题持久化</a> / <a href="https://github.com/iflytek/skillhub/issues/622">#622 通知轮询</a></td><td>均有用户体验价值，但实现范围与优先级不同。</td><td>仍处于议题阶段，应先拆验收标准再排期。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/602">#602 MCP 广场与专家包</a></td><td>有生态扩展价值，但会扩大 SkillHub 的产品与维护边界。</td><td>先确认与 Skill 注册表、集合和 Agent 集成的关系，再决定是否拆分实施。</td></tr>
+                <tr><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/issues/626">#626</a> / <a href="https://github.com/iflytek/skillhub/issues/627">#627 Smoke Test 适配</a></td><td>提升持久环境与受限 Ingress 下的验证可靠性。</td><td>均开放，可在部署链路变更后配套推进。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>新增、合并与关闭 PR</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W31 关键 PR 流转</caption>
+              <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
+              <tbody>
+                <tr><td>新增并合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/607">#607 Device Auth</a> / <a href="https://github.com/iflytek/skillhub/pull/608">#608 CLI Namespace</a> / <a href="https://github.com/iflytek/skillhub/pull/609">#609 Token 回归</a> / <a href="https://github.com/iflytek/skillhub/pull/610">#610 403 语义</a></td><td>4 个新增 PR 均已合并，快速处理认证与 CLI 缺陷。</td></tr>
+                <tr><td>新增并合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/599">#599 README 引导</a> / <a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传</a> / <a href="https://github.com/iflytek/skillhub/pull/603">#603 生态入口</a></td><td>覆盖项目可发现性、发布一致性与生态展示，均在本期创建并合并。</td></tr>
+                <tr><td>新增待审</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/623">#623 OAuth 回跳</a> / <a href="https://github.com/iflytek/skillhub/pull/624">#624 React 19 Portal 崩溃</a></td><td>直接影响登录回跳和 Web 稳定性，建议优先完成回归。</td></tr>
+                <tr><td>新增待审</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/631">#631 外部身份可信属性</a> / <a href="https://github.com/iflytek/skillhub/pull/633">#633 全局成员配置</a></td><td>统一身份联邦的授权边界实现，需结合 #630 设计审查。</td></tr>
+                <tr><td>新增待审</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/619">#619 Web 类型隔离</a> / <a href="https://github.com/iflytek/skillhub/pull/625">#625 标签跳转搜索</a> / <a href="https://github.com/iflytek/skillhub/pull/630">#630 身份联邦设计</a></td><td>覆盖工程隔离、发现体验和架构文档，当前均开放。</td></tr>
+                <tr><td>新增待审</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/639">#639 隔离不安全账户合并流程</a></td><td>替代已关闭的 #637，直接回应高风险认证 Issue #634。</td></tr>
+                <tr><td>新增待审</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/635">#635 内置 Starter Collection</a> / <a href="https://github.com/iflytek/skillhub/pull/636">#636 内置 Skill 构件校验</a></td><td>覆盖开箱内容与供应链校验，需要同步确认维护边界。</td></tr>
+                <tr><td>新增后关闭</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/600">#600 发布项目网站</a> / <a href="https://github.com/iflytek/skillhub/pull/637">#637 账户合并隔离</a> / <a href="https://github.com/iflytek/skillhub/pull/638">#638 Release Skill</a></td><td>均未合并；#637 已由 #639 替代，#600 与 #638 均在本期关闭。</td></tr>
+                <tr><td>本周合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/367">#367</a> / <a href="https://github.com/iflytek/skillhub/pull/443">#443</a> / <a href="https://github.com/iflytek/skillhub/pull/445">#445</a> / <a href="https://github.com/iflytek/skillhub/pull/505">#505</a></td><td>部署与生产化：PostgreSQL、Nginx、Helm、Redis Cluster。</td></tr>
+                <tr><td>本周合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/480">#480</a> / <a href="https://github.com/iflytek/skillhub/pull/560">#560</a> / #607—#610</td><td>认证与 CLI：OAuth Provider、懒加载恢复、Device Auth 与错误语义。</td></tr>
+                <tr><td>本周合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/592">#592</a> / <a href="https://github.com/iflytek/skillhub/pull/601">#601</a></td><td>核心流程：搜索索引重建和驳回版本重传。</td></tr>
+                <tr><td>本周合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/593">#593</a> / <a href="https://github.com/iflytek/skillhub/pull/598">#598</a> / <a href="https://github.com/iflytek/skillhub/pull/599">#599</a> / <a href="https://github.com/iflytek/skillhub/pull/603">#603</a></td><td>生态与文档：FAQ、HarnessClaw、README 与生态入口。</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="priority-queue" aria-labelledby="priority-title">
+          <h2 id="priority-title">当前高价值维护队列</h2>
+          <p class="section-lead">以下为 2026-07-30 16:36 快照，只列需要明确决策的 A/B 项；价值分级是维护治理判断，不替代仓库现有 P1/P2 标签。</p>
+
+          <h3>Issue：A 级优先处理</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">A 级开放 Issue</caption>
+              <thead><tr><th>Issue</th><th>价值判断</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/634">#634 禁用不安全的旧账户合并流程</a></td><td>涉及潜在账户接管风险，已有替代实现 #639。</td><td>完成安全回归和迁移兼容审查后优先合并。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/605">#605 Token 撤销后部分 API 仍放行</a></td><td>认证安全语义不一致，且 Issue 在回归测试合并后仍开放。</td><td>确认失败用例覆盖 whoami/search，完成实现后关闭。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/611">#611 版本删除外键残留</a></td><td>核心删除流程返回 500，可能留下不可治理状态。</td><td>补集成测试并明确级联删除或显式清理策略。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/612">#612 扫描任务与发布事务竞争</a></td><td>可能使合法发布因任务提前执行而失败。</td><td>将异步启动约束到事务提交后，并补稳定回归。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/615">#615 审核状态与审计不一致</a></td><td>服务端已提交状态却向客户端返回失败。</td><td>统一事务边界，避免部分成功和重复操作。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/617">#617 首次发布坐标并发竞争</a></td><td>影响同坐标并发发布的幂等与错误语义。</td><td>增加数据库约束映射与并发回归测试。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Issue：B 级需设计或严格审查</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">B 级开放 Issue</caption>
+              <thead><tr><th>Issue</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/613">#613 并发 OAuth 绑定 500</a></td><td>围绕唯一约束和重试边界设计并发回归。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/614">#614 旧 Session 阻断公开 API</a></td><td>明确 permitAll 路由的失效会话处理语义。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/628">#628 统一身份联邦架构</a></td><td>将 #630、#631、#633 作为一个设计批次集中审查。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/640">#640 身份核心与 Provider 权限锁</a></td><td>先收敛与 #628 的边界，再决定实现拆分与兼容策略。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/620">#620 审核进度与重提历史</a></td><td>先定义作者可见字段与审核隐私边界。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/622">#622 通知由 SSE 改为轮询</a></td><td>先用代理兼容性和资源成本数据验证替换必要性。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>PR：A 级优先推进</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">A 级开放 PR</caption>
+              <thead><tr><th>PR</th><th>价值判断</th><th>建议动作</th></tr></thead>
+              <tbody>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/639">#639 隔离不安全账户合并流程</a></td><td>回应高风险认证 Issue #634，并替代已关闭的 #637。</td><td>优先核对账户接管回归、兼容路径和失败语义。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/623">#623 保留 OAuth 回跳目标</a></td><td>直接影响认证后用户流程连续性。</td><td>验证多 Provider、非法目标和默认回跳后优先合并。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/624">#624 修复 React 19 Portal 崩溃</a></td><td>解决用户可见的 removeChild/insertBefore 崩溃。</td><td>补弹窗开关和路由切换场景 E2E 后合并。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/631">#631 外部身份可信属性</a></td><td>决定外部身份是否可安全触发用户配置。</td><td>与 #630 设计文档同步审查信任来源和降级路径。</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/pull/633">#633 审批后配置 global membership</a></td><td>影响新用户审批后的基础授权可用性。</td><td>验证重试幂等、已有成员和审批回滚场景。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <details data-module="cleanup-queue">
+            <summary>展开：本周关闭未合并的 PR</summary>
+            <div class="details-body">
+              <p>长期 PR <a href="https://github.com/iflytek/skillhub/pull/442">#442</a>、<a href="https://github.com/iflytek/skillhub/pull/457">#457</a>、<a href="https://github.com/iflytek/skillhub/pull/460">#460</a>，以及本期新增的 <a href="https://github.com/iflytek/skillhub/pull/600">#600</a>、<a href="https://github.com/iflytek/skillhub/pull/637">#637</a>、<a href="https://github.com/iflytek/skillhub/pull/638">#638</a> 均已关闭且未合并。配合 16 个合并 PR，开放 PR 从期初 17 个降至 15 个。</p>
+            </div>
+          </details>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-method" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-method" data-panel="method" hidden>
+        <div class="panel-intro">
+          <p>这里说明时间边界、数据来源与缺失项。</p>
+          <p>缺失数据均标为“未取得”，不替换为 0。</p>
+        </div>
+
+        <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
+          <h2 id="method-title">统计口径</h2>
+          <ul class="method-list">
+            <li><strong>统计周期</strong><span>2026-07-23 00:00—2026-07-30 16:36，Asia/Shanghai；按“上周四到本周四”展示和统计。</span></li>
+            <li><strong>当前快照</strong><span>2026-07-30 16:36；开放队列、仓库累计数及年龄结构均取该时点。</span></li>
+            <li><strong>周期衔接</strong><span>本期为首次按周四边界回溯，7 月 23—26 日与旧 W30 周一—周日口径存在重叠；从下一期起使用前一期截止时刻到本期截止时刻，边界事件不重复计数。</span></li>
+            <li><strong>Star 比较</strong><span>4,823 → 4,945（+122）覆盖 7 月 23 日 22:00 至 7 月 30 日 16:36，未覆盖本期最初 22 小时。</span></li>
+            <li><strong>Fork 比较</strong><span>本期新增 60 按 Fork 创建时间统计；总量 652 → 702（+50）覆盖 7 月 23 日 22:00 至 7 月 30 日 16:36，两者时间边界不同。</span></li>
+            <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权、条件跳过和取消不进入分母。</span></li>
+            <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告分开统计；价值 A—D 为人工治理判断。</span></li>
+            <li><strong>Release</strong><span>应用 v0.2.15 于 7 月 30 日 16:25 发布并计入本期；CLI 本周尚无新 Release。</span></li>
+            <li><strong>推广数据</strong><span>文章、直播、社区分享和合作项目由维护者补录；本期未提供，因而不展示推广模块，也不记为 0。</span></li>
+          </ul>
+        </section>
+
+        <section class="report-section" data-module="source-coverage" aria-labelledby="source-title">
+          <h2 id="source-title">数据来源与限制</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>来源覆盖</caption>
+              <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
+              <tbody>
+                <tr><td>GitHub REST API</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer</td><td>Traffic 与私有安全告警不可见。</td></tr>
+                <tr><td>Git 标签与提交历史</td><td>主分支提交、Merge Commit 与 v0.2.15 核对</td><td>CLI 仍以 npm 0.1.9 为最新版本。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 统计期下载</td><td>1,041 次下载不等同于独立用户；7 月 30 日日值尚未结算。</td></tr>
+                <tr><td>维护者人工判断</td><td>价值排序、推广动作和产品边界</td><td>推广动作尚未提供。</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、W31 7 月 23 日 00:00 的 Star/Fork 快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
+        </section>
+      </div>
+    </main>
+
+    <footer>
+      <span>SkillHub Open Source Weekly · 2026-W31</span>
+      <span>公开报告 · 周四结报 · 维护者治理视图</span>
+    </footer>
+  </article>
+
+  <script>
+    (function () {
+      var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
+      var panels = Array.prototype.slice.call(document.querySelectorAll('[role="tabpanel"]'));
+
+      function activate(name, moveFocus, updateHash) {
+        var nextTab = tabs.find(function (tab) { return tab.dataset.tab === name; }) || tabs[0];
+        tabs.forEach(function (tab) {
+          var selected = tab === nextTab;
+          tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+          tab.tabIndex = selected ? 0 : -1;
+        });
+        panels.forEach(function (panel) {
+          panel.hidden = panel.dataset.panel !== nextTab.dataset.tab;
+        });
+        if (moveFocus) nextTab.focus();
+        if (updateHash && history.replaceState) {
+          history.replaceState(null, '', '#' + nextTab.dataset.tab);
+        }
+      }
+
+      tabs.forEach(function (tab, index) {
+        tab.addEventListener('click', function () {
+          activate(tab.dataset.tab, false, true);
+        });
+        tab.addEventListener('keydown', function (event) {
+          var nextIndex = index;
+          if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+          else if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+          else if (event.key === 'Home') nextIndex = 0;
+          else if (event.key === 'End') nextIndex = tabs.length - 1;
+          else return;
+          event.preventDefault();
+          activate(tabs[nextIndex].dataset.tab, true, true);
+        });
+      });
+
+      window.addEventListener('hashchange', function () {
+        activate(location.hash.replace('#', ''), false, false);
+      });
+      activate(location.hash.replace('#', ''), false, false);
+    }());
+  </script>
+</body>
+</html>

--- a/weekly/source.json
+++ b/weekly/source.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/XiaoSeS/skillhub-weekly.git",
+  "commit": "81cabe5ba7a73a938e06bb986d20aaed28fa9695"
+}


### PR DESCRIPTION
## What

- mirror the W29–W31 weekly report sources, Notion-light theme, archive builder, and validators into `weekly/`
- add the updated `generate-skillhub-weekly-report` Skill with the official mirror workflow
- assemble the weekly site under the existing VitePress Pages artifact at `/skillhub/weekly/`
- add Chinese and English documentation navigation links
- validate weekly reports in PR checks without adding a second Pages deployment workflow

## Why

The public weekly report currently has only the standalone `XiaoSeS/skillhub-weekly` source. SkillHub needs a reviewed official mirror while preserving one authoritative content source and the existing report presentation.

Closes #659

## How

The standalone site remains authoritative. Its `site/`, `assets/`, and `scripts/` trees are mirrored byte-for-byte. The existing `Deploy Docs` workflow builds and validates `weekly/`, then copies the generated site into `.vitepress/dist/weekly/` before uploading the single Pages artifact.

## Testing

- `python3 .agents/skills/generate-skillhub-weekly-report/scripts/validate_report.py` for W29, W30, W31: pass
- `python3 weekly/scripts/build_site.py`: pass
- `python3 weekly/scripts/validate_site.py weekly/_site`: pass
- `cd docs/skillhub && npm ci && npm run build`: pass
- assembled `/weekly/`, archive, and all three report routes via local HTTP: HTTP 200
- direct `#health` hash activates the health Tab in headless Chromium
- desktop and 390px narrow render checked in Chromium
- `make typecheck-web`: pass
- `make lint-web`: pass (existing TypeScript compatibility warning only)
- `make test-backend-app`: attempted; blocked locally because the host default is Java 25 while this repository requires Java 21, causing Byte Buddy/Mockito instrumentation errors before app tests. CI runs the supported Java version.

## Impact

Documentation and GitHub Pages only. No backend, frontend API, OpenAPI SDK, database, or runtime behavior changes. Report HTML and inlined theme remain byte-identical to the standalone site.