### PR TITLE
docs(weekly): refresh W31 evidence metadata

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,17 +36,15 @@ jobs:
         uses: actions/configure-pages@v4
       - name: Install dependencies
         run: cd docs/skillhub && npm ci
-      - name: Build and validate weekly reports
-        run: |
-          cd weekly
-          python3 scripts/build_site.py
-          python3 scripts/validate_site.py _site
       - name: Build with VitePress
         run: cd docs/skillhub && npm run build
-      - name: Add weekly reports to Pages artifact
+      - name: Build and validate weekly reports
         run: |
-          mkdir -p docs/skillhub/.vitepress/dist/weekly
-          cp -R weekly/_site/. docs/skillhub/.vitepress/dist/weekly/
+          python3 weekly/scripts/build_site.py \
+            --source weekly/site \
+            --output docs/skillhub/.vitepress/dist/weekly
+          python3 weekly/scripts/validate_site.py \
+            docs/skillhub/.vitepress/dist/weekly
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -111,14 +111,8 @@ jobs:
       - name: Build and validate weekly reports
         if: steps.changed.outputs.docs == 'true'
         run: |
-          cd weekly
-          python3 scripts/build_site.py
-          python3 scripts/validate_site.py _site
-
-      - name: Assemble Pages artifact layout
-        if: steps.changed.outputs.docs == 'true'
-        run: |
-          mkdir -p docs/skillhub/.vitepress/dist/weekly
-          cp -R weekly/_site/. docs/skillhub/.vitepress/dist/weekly/
-          test -f docs/skillhub/.vitepress/dist/weekly/index.html
-          test -f docs/skillhub/.vitepress/dist/weekly/archive.html
+          python3 weekly/scripts/build_site.py \
+            --source weekly/site \
+            --output docs/skillhub/.vitepress/dist/weekly
+          python3 weekly/scripts/validate_site.py \
+            docs/skillhub/.vitepress/dist/weekly

--- a/weekly/site/reports.json
+++ b/weekly/site/reports.json
@@ -5,7 +5,7 @@
       "week": "2026-W31",
       "title": "SkillHub 开源周报｜2026 年第 31 周",
       "period": "2026-07-23—2026-07-30",
-      "snapshot": "2026-07-30 16:36 Asia/Shanghai",
+      "snapshot": "2026-07-31 14:35 Asia/Shanghai",
       "path": "reports/2026-W31/"
     },
     {

--- a/weekly/site/reports/2026-W31/index.html
+++ b/weekly/site/reports/2026-W31/index.html
@@ -1193,7 +1193,14 @@ footer {
 </head>
 <body>
   <a class="skip-link" href="#report-content">跳到报告正文</a>
-  <article class="report">
+  <article class="report"
+    data-period-start="2026-07-23T00:00:00+08:00"
+    data-period-end="2026-07-30T00:00:00+08:00"
+    data-period-boundary="[)"
+    data-snapshot-at="2026-07-31T14:35:33+08:00"
+    data-star-evidence="snapshot-only"
+    data-star-start-at=""
+    data-star-end-at="2026-07-31T14:35:33+08:00">
     <header class="masthead">
       <div class="topline">
         <div class="brand">
@@ -1214,11 +1221,11 @@ footer {
           <div class="meta-grid">
             <div class="meta-item">
               <span class="key">统计周期</span>
-              <span class="value">2026-07-23 00:00—2026-07-30 16:36（Asia/Shanghai）</span>
+              <span class="value">2026-07-23 00:00—2026-07-30 00:00 · Asia/Shanghai · [)</span>
             </div>
             <div class="meta-item">
               <span class="key">当前状态快照</span>
-              <span class="value">2026-07-30 16:36（Asia/Shanghai）</span>
+              <span class="value">2026-07-31 14:35（Asia/Shanghai）</span>
             </div>
             <div class="meta-item">
               <span class="key">项目仓库</span>
@@ -1236,14 +1243,14 @@ footer {
             <strong>需关注</strong>
             <span class="status warn">Attention</span>
           </div>
-          <p>应用 v0.2.15、镜像及 Helm Chart 已完成发布，Actions 保持稳定；Issue 净增 20、开放 P1 达 19 个，是当前主要风险。</p>
+          <p>周期内 Actions 有效成功率为 97.6%，但没有应用或 CLI Release；期后已发布 v0.2.15。Issue 净流入 13 个，当前开放 P1 达 21 个，是主要风险。</p>
         </div>
       </div>
       <div class="metrics" aria-label="四项核心指标">
-        <div class="metric"><strong>4,945</strong><span>Stars · 较 7 月 23 日 +122*</span></div>
-        <div class="metric"><strong>702</strong><span>Forks · 本期新增 60</span></div>
-        <div class="metric"><strong>97.6%</strong><span>Actions 有效成功率 · 240/246</span></div>
-        <div class="metric"><strong>1 / 0</strong><span>应用 / CLI Release · 本期</span></div>
+        <div class="metric"><strong>4,890</strong><span>Stars · 当前快照，周增量未取得</span></div>
+        <div class="metric"><strong>703</strong><span>Forks · 本期当前可见创建 50</span></div>
+        <div class="metric"><strong>97.6%</strong><span>Actions 有效成功率 · 203/208</span></div>
+        <div class="metric"><strong>0 / 0</strong><span>应用 / CLI Release · 本期</span></div>
       </div>
     </header>
 
@@ -1276,30 +1283,30 @@ footer {
               <div class="snapshot-list">
                 <div class="snapshot-row">
                   <span class="snapshot-label">Stars</span>
-                  <strong>4,945</strong>
-                  <span class="snapshot-change positive">较 7 月 23 日 22:00 快照 +122（4,823 → 4,945）</span>
+                  <strong>4,890</strong>
+                  <span class="snapshot-change missing">周增量未取得</span>
                 </div>
                 <div class="snapshot-row">
                   <span class="snapshot-label">Forks</span>
-                  <strong>702</strong>
-                  <span class="snapshot-change positive">7 月 23 日以来新增 60</span>
+                  <strong>703</strong>
+                  <span class="snapshot-change positive">当前可见本期创建 50</span>
                 </div>
               </div>
-              <p class="chart-note">Star 变化覆盖 7 月 23 日 22:00 至 7 月 30 日 16:36，未覆盖本期最初 22 小时；Fork 新增按创建时间统计。</p>
+              <p class="chart-note">Stars 仅有 7 月 31 日快照，不能反推周增量；Fork 为当前列表中创建时间落在半开周期内的可见记录，不代表净增长。</p>
             </div>
             <div class="chart-box" data-module="weekly-collaboration-chart">
               <h3>本期协作流转</h3>
-              <div class="bars" role="img" aria-label="W31 协作流转：Issue 新增 22 个、关闭 2 个；PR 新增 20 个、合并 16 个、关闭未合并 6 个">
-                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">22</span></div>
-                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:9.1%"></span></span><span class="bar-value">2</span></div>
-                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:90.9%"></span></span><span class="bar-value">20</span></div>
-                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:72.7%"></span></span><span class="bar-value">16</span></div>
-                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:27.3%"></span></span><span class="bar-value">6</span></div>
+              <div class="bars" role="img" aria-label="W31 协作流转：Issue 新增 15 个、关闭 2 个；PR 新增 11 个、合并 13 个、关闭未合并 4 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">15</span></div>
+                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:13.3%"></span></span><span class="bar-value">2</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:73.3%"></span></span><span class="bar-value">11</span></div>
+                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:86.7%"></span></span><span class="bar-value">13</span></div>
+                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:26.7%"></span></span><span class="bar-value">4</span></div>
               </div>
-              <p class="chart-note">Issue 净增 20，当前开放 40；PR 净减 2，当前开放 15。主分支新增 56 个提交，其中 19 个 Merge Commit。</p>
+              <p class="chart-note">周期内 Issue 净流入 13，PR 净流出 6；当前快照开放 Issue 46 个、PR 16 个。主分支新增 53 个提交，其中 16 个 Merge Commit。</p>
             </div>
           </div>
-          <p class="risk-note"><strong>主要风险：</strong>Issue 输入速度显著高于处置速度，当前开放 P1 19 个、P2 17 个；应用已完成发版，但 CLI 仍需明确本周发布或跳过结论。</p>
+          <p class="risk-note"><strong>主要风险：</strong>Issue 输入速度显著高于处置速度，当前开放 P1 21 个、<code>triage/needs-info</code> 28 个；周期内应用与 CLI 均未发版，应用 v0.2.15 已在期后补发。</p>
         </section>
 
         <section class="report-section" data-module="feature-iterations" aria-labelledby="feature-title">
@@ -1311,8 +1318,8 @@ footer {
               <tbody>
                 <tr>
                   <td><span class="status ok">已完成</span></td>
-                  <td><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a></td>
-                  <td>已发布 Helm Chart、Redis Cluster/Sentinel、PostgreSQL/Nginx 部署增强，以及认证、发布与搜索修复；镜像和 Helm Chart 发布工作流均成功。</td>
+                  <td>部署与生产化</td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/443">Nginx 代理信任边界</a>与 <a href="https://github.com/iflytek/skillhub/pull/445">Helm Chart 部署方案</a>在周期内合并，补齐反向代理和 Kubernetes 部署能力。</td>
                 </tr>
                 <tr>
                   <td><span class="status ok">已完成</span></td>
@@ -1327,12 +1334,12 @@ footer {
                 <tr>
                   <td><span class="status ok">已完成</span></td>
                   <td>生态与文档补全</td>
-                  <td><a href="https://github.com/iflytek/skillhub/pull/593">社区 FAQ</a>、<a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw 指南</a>、<a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>与 <a href="https://github.com/iflytek/skillhub/pull/603">生态入口</a>已合并。</td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/593">社区 FAQ</a>、<a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw 指南</a>与 <a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>在周期内合并；<a href="https://github.com/iflytek/skillhub/pull/603">生态入口 #603</a>在期后合并。</td>
                 </tr>
                 <tr>
-                  <td><span class="status warn">推进中</span></td>
-                  <td>统一身份联邦</td>
-                  <td><a href="https://github.com/iflytek/skillhub/issues/628">架构议题 #628</a>、<a href="https://github.com/iflytek/skillhub/pull/630">设计文档 #630</a>、<a href="https://github.com/iflytek/skillhub/pull/631">可信属性 #631</a>与 <a href="https://github.com/iflytek/skillhub/pull/633">全局成员配置 #633</a>仍在审查，尚未合并。</td>
+                  <td><span class="status warn">期后完成</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a></td>
+                  <td>7 月 30 日 16:25 发布，包含本期已合并的部署、认证、发布与搜索改动；该 Release 位于周期结束后，不计入本期 Release 总数。</td>
                 </tr>
               </tbody>
             </table>
@@ -1342,16 +1349,16 @@ footer {
         <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
           <h2 id="ecosystem-title">三、生态相关进展</h2>
           <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
-            aria-label="W31 开源生态参与信号：新增 Issue 22 个、新增 PR 20 个、合并作者 10 位；新增 60 个 Fork；SkillHub CLI npm 下载 1041 次">
-            <div class="ecosystem-signal"><strong>22 / 20 / 10</strong><span>新增 Issue / 新增 PR / 合并作者</span></div>
-            <div class="ecosystem-signal"><strong>+60</strong><span>本期新增 Fork</span></div>
-            <div class="ecosystem-signal"><strong>1,041</strong><span>SkillHub CLI npm 下载</span></div>
+            aria-label="W31 开源生态参与信号：新增 Issue 作者 3 位、新增 PR 作者 4 位、合并作者 8 位；当前可见本期创建 Fork 50 个；SkillHub CLI 在 2026 年 7 月 23 日至 29 日 UTC 日桶下载 1041 次">
+            <div class="ecosystem-signal"><strong>3 / 4 / 8</strong><span>新增 Issue 作者 / PR 作者 / 合并作者</span></div>
+            <div class="ecosystem-signal"><strong>50</strong><span>当前可见本期创建 Fork</span></div>
+            <div class="ecosystem-signal"><strong>1,041</strong><span>CLI 下载 · 7 个 UTC 日桶</span></div>
             <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
           </div>
           <ul class="ecosystem-list">
-            <li><strong>社区贡献</strong><span>16 个 PR 由 10 位作者完成合并，其中 9 位为社区 Contributor，贡献覆盖部署、认证、CLI、核心流程与文档。</span></li>
+            <li><strong>社区贡献</strong><span>13 个 PR 由 8 位作者完成合并，贡献覆盖部署、认证、CLI、核心流程与文档。</span></li>
             <li><strong>Agent 集成</strong><span><a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw Engine 指南</a> 已合并，新增一条 Agent 生态接入路径。</span></li>
-            <li><strong>项目可发现性</strong><span><a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>及 <a href="https://github.com/iflytek/skillhub/pull/603">Trendshift、AAIF 入口</a>已落地。</span></li>
+            <li><strong>项目可发现性</strong><span><a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>在周期内落地；<a href="https://github.com/iflytek/skillhub/pull/603">Trendshift、AAIF 入口</a>于期后合并。</span></li>
           </ul>
         </section>
 
@@ -1359,8 +1366,8 @@ footer {
           <h2 id="next-title">下周关注</h2>
           <p>以下动作延续到下一期跟踪。</p>
           <ol>
-            <li>为 19 个开放 P1 Issue 明确负责人和处置顺序，并批量处理 22 个 <code>triage/needs-info</code> Issue。</li>
-            <li>优先审查 <a href="https://github.com/iflytek/skillhub/pull/623">#623</a>、<a href="https://github.com/iflytek/skillhub/pull/624">#624</a>、<a href="https://github.com/iflytek/skillhub/pull/639">#639</a> 与 <a href="https://github.com/iflytek/skillhub/pull/633">#633</a>，保持 PR 存量下降趋势。</li>
+            <li>为 21 个开放 P1 Issue 明确负责人和处置顺序，并批量处理 28 个 <code>triage/needs-info</code> Issue。</li>
+            <li>优先审查 <a href="https://github.com/iflytek/skillhub/pull/623">#623</a>、<a href="https://github.com/iflytek/skillhub/pull/624">#624</a>、<a href="https://github.com/iflytek/skillhub/pull/639">#639</a> 与 <a href="https://github.com/iflytek/skillhub/pull/633">#633</a>，减少高价值开放 PR。</li>
             <li>明确 CLI 发版窗口；<a href="https://github.com/iflytek/skillhub/pull/608">#608 Namespace 修复</a>已进入源码，但尚未包含在 npm CLI 0.1.9 中。</li>
           </ol>
         </aside>
@@ -1378,60 +1385,60 @@ footer {
           <div class="health-cards">
             <article class="health-card">
               <div class="top"><span class="name">工程稳定性</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">97.6% <small>240/246</small></div>
-              <p>有效运行中有 6 次失败。</p>
-              <div class="detail">PR Tests 2 次、PR E2E 3 次、DeepWiki 1 次。</div>
+              <div class="health-metric">97.6% <small>203/208</small></div>
+              <p>有效运行中有 5 次失败。</p>
+              <div class="detail">PR Tests 2 次、PR E2E Tests 3 次。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">59 / 59 <small>执行成功</small></div>
-              <p>另有 14 次等待授权、7 次条件跳过。</p>
+              <div class="health-metric">52 / 52 <small>执行成功</small></div>
+              <p>另有 8 次等待授权、1 次条件跳过。</p>
               <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
-              <div class="health-metric">31 / 31 <small>Backlog Rescore</small></div>
-              <p>镜像发布 12/12，文档部署 4/4。</p>
-              <div class="detail">Release 相关发布成功；DeepWiki Crawler 失败 1 次。</div>
+              <div class="health-metric">28 / 28 <small>Backlog Rescore</small></div>
+              <p>Publish Images 11/11，文档部署 3/3。</p>
+              <div class="detail">Issue Triage 成功 26 次、条件跳过 45 次。</div>
             </article>
             <article class="health-card">
-              <div class="top"><span class="name">Release 交付</span><span class="status ok">应用达成</span></div>
-              <div class="health-metric">1 / 0 <small>应用 / CLI</small></div>
-              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a> 已于 7 月 30 日发布。</p>
-              <div class="detail">CLI 本周尚无新版本；最新 npm 版本仍为 0.1.9。</div>
+              <div class="top"><span class="name">Release 交付</span><span class="status warn">期内未达成</span></div>
+              <div class="health-metric">0 / 0 <small>应用 / CLI</small></div>
+              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a> 于期后 7 月 30 日 16:25 发布。</p>
+              <div class="detail">CLI 周期内及期后均无新版本，最新仍为 0.1.9。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">Issue 治理</span><span class="status risk">风险</span></div>
-              <div class="health-metric">+20 <small>本期净增</small></div>
-              <p>开放 40 个，其中 P1 19 个、<code>triage/needs-info</code> 22 个。</p>
+              <div class="health-metric">+13 <small>本期净流入</small></div>
+              <p>当前开放 46 个，其中 P1 21 个、<code>triage/needs-info</code> 28 个。</p>
               <div class="detail">输入速度明显高于关闭速度，是当前首要治理风险。</div>
             </article>
             <article class="health-card">
-              <div class="top"><span class="name">PR 治理</span><span class="status ok">改善中</span></div>
-              <div class="health-metric">-2 <small>存量净变化</small></div>
-              <p>合并 16 个、关闭未合并 6 个，当前开放 15 个。</p>
-              <div class="detail">30 天以上 PR 降至 3 个，仍需逐项做关闭或推进决策。</div>
+              <div class="top"><span class="name">PR 治理</span><span class="status ok">期内净流出</span></div>
+              <div class="health-metric">-6 <small>本期净流量</small></div>
+              <p>合并 13 个、关闭未合并 4 个，当前开放 16 个。</p>
+              <div class="detail">当前 30 天以上 PR 为 3 个，仍需逐项做关闭或推进决策。</div>
             </article>
           </div>
         </section>
 
         <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
           <h2 id="ci-title">CI 与自动化执行</h2>
-          <p class="section-lead">统计期内有 381 条 Actions 记录，其中 240 次成功、6 次失败、49 次等待授权、82 次跳过、4 次取消。</p>
+          <p class="section-lead">统计期内有 288 条 Actions 记录，其中 203 次成功、5 次失败、27 次等待授权、49 次跳过、4 次取消。</p>
           <div class="chart-box" data-module="actions-outcome-chart">
             <h3>Actions 结果构成</h3>
-            <div class="segbar" role="img" aria-label="W31 Actions 共 381 条记录：成功 240，失败 6，等待授权 49，条件跳过 82，取消 4">
-              <span class="seg-success" style="width:63.00%"></span>
-              <span class="seg-failure" style="width:1.57%"></span>
-              <span class="seg-auth" style="width:12.86%"></span>
-              <span class="seg-skipped" style="width:21.52%"></span>
-              <span class="seg-cancelled" style="width:1.05%"></span>
+            <div class="segbar" role="img" aria-label="W31 Actions 共 288 条记录：成功 203，失败 5，等待授权 27，条件跳过 49，取消 4">
+              <span class="seg-success" style="width:70.49%"></span>
+              <span class="seg-failure" style="width:1.74%"></span>
+              <span class="seg-auth" style="width:9.38%"></span>
+              <span class="seg-skipped" style="width:17.01%"></span>
+              <span class="seg-cancelled" style="width:1.39%"></span>
             </div>
             <div class="chart-legend" aria-hidden="true">
-              <span><i class="seg-success"></i>成功 <b>240</b></span>
-              <span><i class="seg-failure"></i>失败 <b>6</b></span>
-              <span><i class="seg-auth"></i>等待授权 <b>49</b></span>
-              <span><i class="seg-skipped"></i>跳过 <b>82</b></span>
+              <span><i class="seg-success"></i>成功 <b>203</b></span>
+              <span><i class="seg-failure"></i>失败 <b>5</b></span>
+              <span><i class="seg-auth"></i>等待授权 <b>27</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>49</b></span>
               <span><i class="seg-cancelled"></i>取消 <b>4</b></span>
             </div>
           </div>
@@ -1442,19 +1449,19 @@ footer {
                 <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
               </thead>
               <tbody>
-                <tr><td>PR Tests</td><td class="number">66</td><td class="number">42</td><td class="number">2</td><td class="number">14</td><td class="number">8</td></tr>
-                <tr><td>PR E2E Tests</td><td class="number">53</td><td class="number">27</td><td class="number">3</td><td class="number">14</td><td class="number">9</td></tr>
-                <tr><td>PR Scripts</td><td class="number">24</td><td class="number">18</td><td class="number">0</td><td class="number">6</td><td class="number">0</td></tr>
-                <tr><td>Security</td><td class="number">80</td><td class="number">59</td><td class="number">0</td><td class="number">14</td><td class="number">7</td></tr>
-                <tr><td>Issue Triage</td><td class="number">95</td><td class="number">35</td><td class="number">0</td><td class="number">0</td><td class="number">60</td></tr>
-                <tr><td>Issue Backlog Rescore</td><td class="number">31</td><td class="number">31</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Publish Images</td><td class="number">12</td><td class="number">12</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Deploy Docs</td><td class="number">4</td><td class="number">4</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>其他自动化</td><td class="number">16</td><td class="number">12</td><td class="number">1</td><td class="number">1</td><td class="number">2</td></tr>
+                <tr><td>PR Tests</td><td class="number">50</td><td class="number">38</td><td class="number">2</td><td class="number">8</td><td class="number">2</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">39</td><td class="number">25</td><td class="number">3</td><td class="number">8</td><td class="number">3</td></tr>
+                <tr><td>PR Scripts</td><td class="number">15</td><td class="number">12</td><td class="number">0</td><td class="number">3</td><td class="number">0</td></tr>
+                <tr><td>Security</td><td class="number">61</td><td class="number">52</td><td class="number">0</td><td class="number">8</td><td class="number">1</td></tr>
+                <tr><td>Issue Triage</td><td class="number">71</td><td class="number">26</td><td class="number">0</td><td class="number">0</td><td class="number">45</td></tr>
+                <tr><td>Issue Backlog Rescore</td><td class="number">28</td><td class="number">28</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Publish Images</td><td class="number">11</td><td class="number">11</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Deploy Docs</td><td class="number">3</td><td class="number">3</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>其他自动化</td><td class="number">10</td><td class="number">8</td><td class="number">0</td><td class="number">0</td><td class="number">2</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>本期薄弱点：</strong>6 次失败来自 PR Tests 2 次、PR E2E 3 次和 DeepWiki Documentation Crawler 1 次；等待授权共 49 次，不计入有效成功率分母。</p>
+          <p class="risk-note"><strong>本期薄弱点：</strong>5 次失败来自 PR Tests 2 次和 PR E2E Tests 3 次；等待授权共 27 次，不计入有效成功率分母。</p>
         </section>
 
         <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
@@ -1462,34 +1469,34 @@ footer {
           <div class="health-grid">
             <article class="health-note">
               <h3>安全与供应链</h3>
-              <p>Security 59 次实际执行全部成功。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
+              <p>Security 52 次实际执行全部成功。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
             </article>
             <article class="health-note">
               <h3>Release 交付</h3>
-              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a> 已于 7 月 30 日 16:25 发布，Publish Images 与 Publish Helm Chart 均成功。CLI 本周仍为 0；#608 的 Namespace 修复尚未进入 npm CLI 0.1.9。</p>
+              <p>周期内应用与 CLI Release 均为 0；<a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a> 于期后 7 月 30 日 16:25 发布。#608 的 Namespace 修复尚未进入 npm CLI 0.1.9。</p>
             </article>
           </div>
           <h3>Issue 健康</h3>
           <div class="chart-grid">
             <div class="chart-box" data-module="issue-age-chart">
               <h3>开放 Issue 年龄结构</h3>
-              <div class="bars" role="img" aria-label="W31 当前开放 Issue 40 个：不足 7 天 21 个，7 到 13 天 4 个，14 到 29 天 3 个，30 天以上 12 个">
-                <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">21</span></div>
-                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:19%"></span></span><span class="bar-value">4</span></div>
-                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:14.3%"></span></span><span class="bar-value">3</span></div>
-                <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:57.1%"></span></span><span class="bar-value">12</span></div>
+              <div class="bars" role="img" aria-label="W31 当前开放 Issue 46 个：不足 7 天 26 个，7 到 13 天 4 个，14 到 29 天 4 个，30 天以上 12 个">
+                <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">26</span></div>
+                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:15.4%"></span></span><span class="bar-value">4</span></div>
+                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:15.4%"></span></span><span class="bar-value">4</span></div>
+                <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:46.2%"></span></span><span class="bar-value">12</span></div>
               </div>
-              <p class="chart-note">长期存量数量未增长，但 22 个新 Issue 使治理压力转向短期分诊和价值判断。</p>
+              <p class="chart-note">当前快照包含期后进展；短期 Issue 占比高，治理压力集中在分诊、补充信息和价值判断。</p>
             </div>
             <div class="chart-box" data-module="issue-needs-info-chart">
               <h3><code>needs-info</code> 占比</h3>
               <div class="donut-layout">
-                <div class="donut" style="--value:55%" role="img" aria-label="W31 当前开放 Issue 中，22 个带 triage/needs-info 标签，占 40 个开放 Issue 的 55.0%">
-                  <div class="donut-center"><strong>55.0%</strong><span>22 / 40</span></div>
+                <div class="donut" style="--value:60.9%" role="img" aria-label="W31 当前开放 Issue 中，28 个带 triage/needs-info 标签，占 46 个开放 Issue 的 60.9%">
+                  <div class="donut-center"><strong>60.9%</strong><span>28 / 46</span></div>
                 </div>
                 <div class="donut-copy">
-                  <p><strong>22 个</strong>开放 Issue 仍需补充信息。</p>
-                  <p>绝对数量较上周快照增加 8 个，需要集中澄清或关闭。</p>
+                  <p><strong>28 个</strong>开放 Issue 仍需补充信息。</p>
+                  <p>该比例是当前快照，不作为周期趋势；需要集中澄清或关闭。</p>
                 </div>
               </div>
             </div>
@@ -1497,19 +1504,19 @@ footer {
           <h3>PR 健康</h3>
           <div class="chart-box" data-module="pr-age-chart">
             <h3>开放 PR 年龄结构</h3>
-            <div class="bars" role="img" aria-label="W31 当前开放 PR 15 个：不足 7 天 10 个，7 到 13 天 0 个，14 到 29 天 2 个，30 天以上 3 个">
-              <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">10</span></div>
+            <div class="bars" role="img" aria-label="W31 当前开放 PR 16 个：不足 7 天 11 个，7 到 13 天 0 个，14 到 29 天 2 个，30 天以上 3 个">
+              <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">11</span></div>
               <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:0%"></span></span><span class="bar-value">0</span></div>
-              <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:20%"></span></span><span class="bar-value">2</span></div>
-              <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:30%"></span></span><span class="bar-value">3</span></div>
+              <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:18.2%"></span></span><span class="bar-value">2</span></div>
+              <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:27.3%"></span></span><span class="bar-value">3</span></div>
             </div>
-            <p class="chart-note">30 天以上 PR 占比为 20.0%；本周合并与关闭决策仍显著降低了长期存量。</p>
+            <p class="chart-note">30 天以上 PR 占当前开放队列的 18.8%；该快照包含期后新增项，不用于反推本期存量变化。</p>
           </div>
         </section>
 
         <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
           <h2 id="response-title">社区响应</h2>
-          <p>22 个新增 Issue 中，<a href="https://github.com/iflytek/skillhub/issues/604">#604</a> 已关闭；#604—#606 及 <a href="https://github.com/iflytek/skillhub/issues/634">#634</a> 已形成对应修复、回归或替代 PR。<a href="https://github.com/iflytek/skillhub/issues/602">#602</a> 提出 MCP 广场和专家包方向，其余新输入仍以 Bug 和身份架构议题为主。该口径不等同于首次维护者响应 SLA。</p>
+          <p>15 个新增 Issue 中，<a href="https://github.com/iflytek/skillhub/issues/604">#604</a> 在周期内关闭；#604—#606 已形成 #607—#610 的修复或回归。<a href="https://github.com/iflytek/skillhub/issues/602">#602</a> 提出 MCP 广场和专家包方向，其余新输入以认证、事务一致性和 Web 工程问题为主。该口径不等同于首次维护者响应 SLA。</p>
         </section>
       </div>
 
@@ -1523,8 +1530,8 @@ footer {
         <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
           <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
           <div class="flow-summary">
-            <div class="flow-item"><strong>Issue +22 / -2</strong><span>净增 20 · 当前快照开放 40</span></div>
-            <div class="flow-item"><strong>PR +20 / 合并 16</strong><span>关闭未合并 6 · 净减 2 · 当前开放 15</span></div>
+            <div class="flow-item"><strong>Issue +15 / -2</strong><span>净流入 13 · 当前快照开放 46</span></div>
+            <div class="flow-item"><strong>PR +11 / 合并 13</strong><span>关闭未合并 4 · 净流出 6 · 当前开放 16</span></div>
           </div>
 
           <h3>新增 Issue（按价值排序）</h3>
@@ -1533,15 +1540,13 @@ footer {
               <caption class="sr-only">W31 新增 Issue 价值排序</caption>
               <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前进展</th></tr></thead>
               <tbody>
-                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/634">#634 禁用不安全的旧账户合并流程</a> / <a href="https://github.com/iflytek/skillhub/issues/640">#640 身份核心与 Provider 权限锁</a></td><td>涉及账户接管防护和统一身份授权边界。</td><td>#634 已形成替代 PR #639；#640 仍待实现方案。</td></tr>
-                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/605">#605 Token 撤销后 whoami/search 仍放行</a></td><td>凭证撤销语义不一致，存在认证风险。</td><td>已合并回归测试 #609，Issue 仍开放，需完成实现修复。</td></tr>
-                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/611">#611 删除版本残留子外键</a> / <a href="https://github.com/iflytek/skillhub/issues/612">#612 扫描任务早于事务提交</a></td><td>直接影响版本删除和发布扫描一致性。</td><td>均开放，需先补可复现测试与事务边界结论。</td></tr>
-                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/615">#615 审核审计失败导致状态已提交但返回 500</a> / <a href="https://github.com/iflytek/skillhub/issues/617">#617 首次发布坐标竞争</a></td><td>可能造成客户端认知与服务端状态不一致。</td><td>均开放，优先处理幂等与事务一致性。</td></tr>
-                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/613">#613 并发 OAuth 绑定 500</a> / <a href="https://github.com/iflytek/skillhub/issues/614">#614 旧 Session 阻断公开 API</a></td><td>影响登录与公开技能访问。</td><td>均开放，需覆盖并发和失效会话回归。</td></tr>
-                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/628">#628 统一身份联邦</a> / <a href="https://github.com/iflytek/skillhub/issues/629">#629 外部身份可信属性</a> / <a href="https://github.com/iflytek/skillhub/issues/632">#632 审批后配置全局成员</a></td><td>决定企业身份接入与授权边界。</td><td>已形成 #630、#631、#633 三个开放 PR，待集中审查。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/604">#604 Device Auth Redis 反序列化</a> / <a href="https://github.com/iflytek/skillhub/issues/605">#605 Token 撤销后仍放行</a> / <a href="https://github.com/iflytek/skillhub/issues/606">#606 CLI Namespace 与 403 语义</a></td><td>影响 CLI 登录、凭证撤销和命名空间解析。</td><td>#604 已在周期内关闭；#607—#610 已合并，#605、#606 仍需核对关闭条件。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/611">#611 删除版本残留子外键</a> / <a href="https://github.com/iflytek/skillhub/issues/612">#612 扫描任务早于事务提交</a></td><td>直接影响版本删除和发布扫描一致性。</td><td>#611 于期后关闭；#612 仍开放，需补事务后触发回归。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/613">#613 并发 OAuth 绑定 500</a> / <a href="https://github.com/iflytek/skillhub/issues/614">#614 旧 Session 阻断公开 API</a></td><td>影响登录与公开技能访问。</td><td>当前仍开放，需覆盖并发约束和失效会话回归。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/615">#615 审核审计部分成功</a> / <a href="https://github.com/iflytek/skillhub/issues/617">#617 首次发布坐标竞争</a></td><td>可能造成客户端认知与服务端状态不一致。</td><td>当前仍开放，优先处理幂等与事务一致性。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/616">#616 MVC 客户端错误返回 500</a> / <a href="https://github.com/iflytek/skillhub/issues/618">#618 Web 类型隔离</a></td><td>分别影响 API 错误语义和前端构建稳定性。</td><td>#618 已有开放 PR #619；#616 仍待实现。</td></tr>
                 <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/620">#620 审核进度</a> / <a href="https://github.com/iflytek/skillhub/issues/621">#621 主题持久化</a> / <a href="https://github.com/iflytek/skillhub/issues/622">#622 通知轮询</a></td><td>均有用户体验价值，但实现范围与优先级不同。</td><td>仍处于议题阶段，应先拆验收标准再排期。</td></tr>
                 <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/602">#602 MCP 广场与专家包</a></td><td>有生态扩展价值，但会扩大 SkillHub 的产品与维护边界。</td><td>先确认与 Skill 注册表、集合和 Agent 集成的关系，再决定是否拆分实施。</td></tr>
-                <tr><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/issues/626">#626</a> / <a href="https://github.com/iflytek/skillhub/issues/627">#627 Smoke Test 适配</a></td><td>提升持久环境与受限 Ingress 下的验证可靠性。</td><td>均开放，可在部署链路变更后配套推进。</td></tr>
               </tbody>
             </table>
           </div>
@@ -1553,17 +1558,14 @@ footer {
               <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
               <tbody>
                 <tr><td>新增并合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/607">#607 Device Auth</a> / <a href="https://github.com/iflytek/skillhub/pull/608">#608 CLI Namespace</a> / <a href="https://github.com/iflytek/skillhub/pull/609">#609 Token 回归</a> / <a href="https://github.com/iflytek/skillhub/pull/610">#610 403 语义</a></td><td>4 个新增 PR 均已合并，快速处理认证与 CLI 缺陷。</td></tr>
-                <tr><td>新增并合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/599">#599 README 引导</a> / <a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传</a> / <a href="https://github.com/iflytek/skillhub/pull/603">#603 生态入口</a></td><td>覆盖项目可发现性、发布一致性与生态展示，均在本期创建并合并。</td></tr>
+                <tr><td>新增并合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/599">#599 README 引导</a> / <a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传</a></td><td>覆盖项目可发现性与发布一致性，均在周期内创建并合并。</td></tr>
                 <tr><td>新增待审</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/623">#623 OAuth 回跳</a> / <a href="https://github.com/iflytek/skillhub/pull/624">#624 React 19 Portal 崩溃</a></td><td>直接影响登录回跳和 Web 稳定性，建议优先完成回归。</td></tr>
-                <tr><td>新增待审</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/631">#631 外部身份可信属性</a> / <a href="https://github.com/iflytek/skillhub/pull/633">#633 全局成员配置</a></td><td>统一身份联邦的授权边界实现，需结合 #630 设计审查。</td></tr>
-                <tr><td>新增待审</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/619">#619 Web 类型隔离</a> / <a href="https://github.com/iflytek/skillhub/pull/625">#625 标签跳转搜索</a> / <a href="https://github.com/iflytek/skillhub/pull/630">#630 身份联邦设计</a></td><td>覆盖工程隔离、发现体验和架构文档，当前均开放。</td></tr>
-                <tr><td>新增待审</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/639">#639 隔离不安全账户合并流程</a></td><td>替代已关闭的 #637，直接回应高风险认证 Issue #634。</td></tr>
-                <tr><td>新增待审</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/635">#635 内置 Starter Collection</a> / <a href="https://github.com/iflytek/skillhub/pull/636">#636 内置 Skill 构件校验</a></td><td>覆盖开箱内容与供应链校验，需要同步确认维护边界。</td></tr>
-                <tr><td>新增后关闭</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/600">#600 发布项目网站</a> / <a href="https://github.com/iflytek/skillhub/pull/637">#637 账户合并隔离</a> / <a href="https://github.com/iflytek/skillhub/pull/638">#638 Release Skill</a></td><td>均未合并；#637 已由 #639 替代，#600 与 #638 均在本期关闭。</td></tr>
-                <tr><td>本周合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/367">#367</a> / <a href="https://github.com/iflytek/skillhub/pull/443">#443</a> / <a href="https://github.com/iflytek/skillhub/pull/445">#445</a> / <a href="https://github.com/iflytek/skillhub/pull/505">#505</a></td><td>部署与生产化：PostgreSQL、Nginx、Helm、Redis Cluster。</td></tr>
-                <tr><td>本周合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/480">#480</a> / <a href="https://github.com/iflytek/skillhub/pull/560">#560</a> / #607—#610</td><td>认证与 CLI：OAuth Provider、懒加载恢复、Device Auth 与错误语义。</td></tr>
-                <tr><td>本周合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/592">#592</a> / <a href="https://github.com/iflytek/skillhub/pull/601">#601</a></td><td>核心流程：搜索索引重建和驳回版本重传。</td></tr>
-                <tr><td>本周合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/593">#593</a> / <a href="https://github.com/iflytek/skillhub/pull/598">#598</a> / <a href="https://github.com/iflytek/skillhub/pull/599">#599</a> / <a href="https://github.com/iflytek/skillhub/pull/603">#603</a></td><td>生态与文档：FAQ、HarnessClaw、README 与生态入口。</td></tr>
+                <tr><td>新增待审</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/619">#619 Web 类型隔离</a></td><td>回应 #618，当前仍开放，需先确认构建环境隔离边界。</td></tr>
+                <tr><td>期后合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/603">#603 生态入口</a></td><td>周期内创建、期末仍开放；7 月 30 日 09:13 合并，不计入本期合并数。</td></tr>
+                <tr><td>新增后关闭</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/600">#600 发布项目网站</a></td><td>周期内创建并关闭，未合并。</td></tr>
+                <tr><td>本期合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/443">#443</a> / <a href="https://github.com/iflytek/skillhub/pull/445">#445</a> / <a href="https://github.com/iflytek/skillhub/pull/480">#480</a> / <a href="https://github.com/iflytek/skillhub/pull/560">#560</a></td><td>部署与认证：Nginx、Helm、OAuth Provider 与登录页恢复。</td></tr>
+                <tr><td>本期合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/592">#592 搜索索引重建</a></td><td>核心流程：标签变更后异步重建搜索索引。</td></tr>
+                <tr><td>本期合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/593">#593</a> / <a href="https://github.com/iflytek/skillhub/pull/598">#598</a></td><td>生态与文档：FAQ 与 HarnessClaw 指南。</td></tr>
               </tbody>
             </table>
           </div>
@@ -1571,7 +1573,7 @@ footer {
 
         <section class="report-section" data-module="priority-queue" aria-labelledby="priority-title">
           <h2 id="priority-title">当前高价值维护队列</h2>
-          <p class="section-lead">以下为 2026-07-30 16:36 快照，只列需要明确决策的 A/B 项；价值分级是维护治理判断，不替代仓库现有 P1/P2 标签。</p>
+          <p class="section-lead">以下为 2026-07-31 14:35 快照，只列需要明确决策的 A/B 项；价值分级是维护治理判断，不替代仓库现有 P1/P2 标签。</p>
 
           <h3>Issue：A 级优先处理</h3>
           <div class="table-wrap">
@@ -1581,7 +1583,6 @@ footer {
               <tbody>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/634">#634 禁用不安全的旧账户合并流程</a></td><td>涉及潜在账户接管风险，已有替代实现 #639。</td><td>完成安全回归和迁移兼容审查后优先合并。</td></tr>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/605">#605 Token 撤销后部分 API 仍放行</a></td><td>认证安全语义不一致，且 Issue 在回归测试合并后仍开放。</td><td>确认失败用例覆盖 whoami/search，完成实现后关闭。</td></tr>
-                <tr><td><a href="https://github.com/iflytek/skillhub/issues/611">#611 版本删除外键残留</a></td><td>核心删除流程返回 500，可能留下不可治理状态。</td><td>补集成测试并明确级联删除或显式清理策略。</td></tr>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/612">#612 扫描任务与发布事务竞争</a></td><td>可能使合法发布因任务提前执行而失败。</td><td>将异步启动约束到事务提交后，并补稳定回归。</td></tr>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/615">#615 审核状态与审计不一致</a></td><td>服务端已提交状态却向客户端返回失败。</td><td>统一事务边界，避免部分成功和重复操作。</td></tr>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/617">#617 首次发布坐标并发竞争</a></td><td>影响同坐标并发发布的幂等与错误语义。</td><td>增加数据库约束映射与并发回归测试。</td></tr>
@@ -1623,7 +1624,7 @@ footer {
           <details data-module="cleanup-queue">
             <summary>展开：本周关闭未合并的 PR</summary>
             <div class="details-body">
-              <p>长期 PR <a href="https://github.com/iflytek/skillhub/pull/442">#442</a>、<a href="https://github.com/iflytek/skillhub/pull/457">#457</a>、<a href="https://github.com/iflytek/skillhub/pull/460">#460</a>，以及本期新增的 <a href="https://github.com/iflytek/skillhub/pull/600">#600</a>、<a href="https://github.com/iflytek/skillhub/pull/637">#637</a>、<a href="https://github.com/iflytek/skillhub/pull/638">#638</a> 均已关闭且未合并。配合 16 个合并 PR，开放 PR 从期初 17 个降至 15 个。</p>
+              <p>长期 PR <a href="https://github.com/iflytek/skillhub/pull/442">#442</a>、<a href="https://github.com/iflytek/skillhub/pull/457">#457</a>、<a href="https://github.com/iflytek/skillhub/pull/460">#460</a>，以及本期新增的 <a href="https://github.com/iflytek/skillhub/pull/600">#600</a> 在周期内关闭且未合并。配合 13 个合并 PR，本期 PR 净流出 6 个；当前开放 16 个的快照另含期后变化。</p>
             </div>
           </details>
         </section>
@@ -1639,14 +1640,15 @@ footer {
         <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
           <h2 id="method-title">统计口径</h2>
           <ul class="method-list">
-            <li><strong>统计周期</strong><span>2026-07-23 00:00—2026-07-30 16:36，Asia/Shanghai；按“上周四到本周四”展示和统计。</span></li>
-            <li><strong>当前快照</strong><span>2026-07-30 16:36；开放队列、仓库累计数及年龄结构均取该时点。</span></li>
-            <li><strong>周期衔接</strong><span>本期为首次按周四边界回溯，7 月 23—26 日与旧 W30 周一—周日口径存在重叠；从下一期起使用前一期截止时刻到本期截止时刻，边界事件不重复计数。</span></li>
-            <li><strong>Star 比较</strong><span>4,823 → 4,945（+122）覆盖 7 月 23 日 22:00 至 7 月 30 日 16:36，未覆盖本期最初 22 小时。</span></li>
-            <li><strong>Fork 比较</strong><span>本期新增 60 按 Fork 创建时间统计；总量 652 → 702（+50）覆盖 7 月 23 日 22:00 至 7 月 30 日 16:36，两者时间边界不同。</span></li>
+            <li><strong>统计周期</strong><span>2026-07-23 00:00—2026-07-30 00:00，Asia/Shanghai，采用半开区间 <code>[period_start, period_end)</code>；对应 UTC 为 7 月 22 日 16:00 至 7 月 29 日 16:00。</span></li>
+            <li><strong>当前快照</strong><span>2026-07-31 14:35；开放队列、仓库累计数及年龄结构均取该时点，周期结束后的变化不计入本期流量。</span></li>
+            <li><strong>周期衔接</strong><span>W30 截止时间与 W31 起始时间均为 7 月 23 日 00:00，相邻报告无重叠；边界时刻事件只进入后一周期。</span></li>
+            <li><strong>Star 证据</strong><span>当前 Stars 为 4,890；未取得周期起止两份可比库存快照，因此不报告 Star 周增量，也不使用当前 Stargazer 列表反推净增长。</span></li>
+            <li><strong>Fork 证据</strong><span>当前 Forks 为 703；50 表示当前列表中创建时间落在本期的可见记录，不代表 Fork 库存净增长。</span></li>
             <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权、条件跳过和取消不进入分母。</span></li>
             <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告分开统计；价值 A—D 为人工治理判断。</span></li>
-            <li><strong>Release</strong><span>应用 v0.2.15 于 7 月 30 日 16:25 发布并计入本期；CLI 本周尚无新 Release。</span></li>
+            <li><strong>Release</strong><span>周期内应用与 CLI Release 均为 0；应用 v0.2.15 于 7 月 30 日 16:25 发布，属于期后进展，不计入本期总数。</span></li>
+            <li><strong>npm 下载</strong><span>1,041 次覆盖 2026-07-23—2026-07-29 的 UTC 日桶，与 Asia/Shanghai 半开周期不完全对齐，因此仅作为带覆盖范围的生态观察，不称为完整周总量。</span></li>
             <li><strong>推广数据</strong><span>文章、直播、社区分享和合作项目由维护者补录；本期未提供，因而不展示推广模块，也不记为 0。</span></li>
           </ul>
         </section>
@@ -1659,13 +1661,13 @@ footer {
               <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
               <tbody>
                 <tr><td>GitHub REST API</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer</td><td>Traffic 与私有安全告警不可见。</td></tr>
-                <tr><td>Git 标签与提交历史</td><td>主分支提交、Merge Commit 与 v0.2.15 核对</td><td>CLI 仍以 npm 0.1.9 为最新版本。</td></tr>
-                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 统计期下载</td><td>1,041 次下载不等同于独立用户；7 月 30 日日值尚未结算。</td></tr>
+                <tr><td>Git 标签与提交历史</td><td>主分支提交、Merge Commit 与 Release 时间核对</td><td>v0.2.15 属于期后；CLI 仍以 npm 0.1.9 为最新版本。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 的 7 个 UTC 日桶</td><td>1,041 次下载不等同于独立用户，且覆盖范围与本报告时区边界不完全对齐。</td></tr>
                 <tr><td>维护者人工判断</td><td>价值排序、推广动作和产品边界</td><td>推广动作尚未提供。</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、W31 7 月 23 日 00:00 的 Star/Fork 快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
+          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、W31 起止两份可比 Star/Fork 库存快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
         </section>
       </div>
     </main>

--- a/weekly/source.json
+++ b/weekly/source.json
@@ -1,4 +1,4 @@
 {
   "repository": "https://github.com/XiaoSeS/skillhub-weekly.git",
-  "commit": "81cabe5ba7a73a938e06bb986d20aaed28fa9695"
+  "commit": "7750af08bd6d4c86552d0201de9e7b6d0f7f2b05"
 }


### PR DESCRIPTION
## Summary

- refresh the official weekly mirror from `XiaoSeS/skillhub-weekly@7750af08`
- update W31 to the Thursday-to-Thursday evidence boundary and latest verified snapshot
- build and validate weekly reports directly in the final VitePress Pages artifact

## Validation

- W31 report validator: 0 errors, 0 warnings
- standalone/mirror `site`, `assets`, and `scripts`: byte-for-byte parity
- VitePress build: passed
- final `docs/skillhub/.vitepress/dist/weekly`: passed site validation
- workflow YAML parsing and `git diff --check`: passed

Supersedes #665 with a DCO-signed commit; no file-content changes.
Refs #659
