### PR TITLE
fix(docs): align weekly reports to Thursday close

### DIFF
--- a/weekly/site/reports.json
+++ b/weekly/site/reports.json
@@ -4,21 +4,21 @@
     {
       "week": "2026-W31",
       "title": "SkillHub 开源周报｜2026 年第 31 周",
-      "period": "2026-07-23—2026-07-30",
+      "period": "2026-07-24—2026-07-30",
       "snapshot": "2026-07-31 14:35 Asia/Shanghai",
       "path": "reports/2026-W31/"
     },
     {
       "week": "2026-W30",
       "title": "SkillHub 开源周报｜2026 年第 30 周",
-      "period": "2026-07-16—2026-07-23",
-      "snapshot": "2026-07-23 22:00 Asia/Shanghai",
+      "period": "2026-07-17—2026-07-23",
+      "snapshot": "2026-07-24 00:00 Asia/Shanghai",
       "path": "reports/2026-W30/"
     },
     {
       "week": "2026-W29",
       "title": "SkillHub 开源周报｜2026 年第 29 周",
-      "period": "2026-07-09—2026-07-16",
+      "period": "2026-07-10—2026-07-16",
       "snapshot": "2026-07-23 22:00 Asia/Shanghai",
       "path": "reports/2026-W29/"
     }

--- a/weekly/site/reports/2026-W29/index.html
+++ b/weekly/site/reports/2026-W29/index.html
@@ -1193,7 +1193,17 @@ footer {
 </head>
 <body>
   <a class="skip-link" href="#report-content">跳到报告正文</a>
-  <article class="report">
+  <article class="report"
+    data-period-start="2026-07-10T00:00:00+08:00"
+    data-period-end="2026-07-17T00:00:00+08:00"
+    data-period-boundary="[)"
+    data-snapshot-at="2026-07-23T22:00:00+08:00"
+    data-star-evidence="current-visible-arrivals"
+    data-star-api-status="success"
+    data-star-arrivals="109"
+    data-star-observed-at="2026-07-31T16:35:58+08:00"
+    data-star-start-at=""
+    data-star-end-at="">
     <header class="masthead">
       <div class="topline">
         <div class="brand">
@@ -1214,7 +1224,7 @@ footer {
           <div class="meta-grid">
             <div class="meta-item">
               <span class="key">统计周期</span>
-              <span class="value">2026-07-09 00:00—2026-07-16 23:59（Asia/Shanghai）</span>
+              <span class="value">2026-07-10 00:00—2026-07-16 23:59 · Asia/Shanghai</span>
             </div>
             <div class="meta-item">
               <span class="key">当前状态快照</span>
@@ -1226,7 +1236,7 @@ footer {
             </div>
             <div class="meta-item">
               <span class="key">数据来源</span>
-              <span class="value">GitHub REST API · Actions · Git · npm Downloads API</span>
+              <span class="value">GitHub API（认证）· Actions · Git · npm Downloads API</span>
             </div>
           </div>
         </div>
@@ -1236,13 +1246,13 @@ footer {
             <strong>需关注</strong>
             <span class="status warn">Attention</span>
           </div>
-          <p>安全流水线稳定，但 Actions 有 5 次失败且周度 Release 未完成；长期 Issue/PR 积压仍是主要治理风险。</p>
+          <p>安全流水线稳定，但 Actions 有 3 次失败且周度 Release 未完成；长期 Issue/PR 积压仍是主要治理风险。</p>
         </div>
       </div>
       <div class="metrics" aria-label="四项核心指标">
-        <div class="metric"><strong>4,823</strong><span>Stars · 周增量未取得</span></div>
-        <div class="metric"><strong>652</strong><span>Forks · 本期新增 189</span></div>
-        <div class="metric"><strong>92.6%</strong><span>Actions 有效成功率 · 63/68</span></div>
+        <div class="metric"><strong>4,823</strong><span>Stars · 本期当前可见新增 109</span></div>
+        <div class="metric"><strong>652</strong><span>Forks · 本期当前可见创建 181</span></div>
+        <div class="metric"><strong>94.2%</strong><span>Actions 有效成功率 · 49/52</span></div>
         <div class="metric"><strong>0 / 0</strong><span>应用 / CLI Release · W29</span></div>
       </div>
     </header>
@@ -1277,26 +1287,26 @@ footer {
                 <div class="snapshot-row">
                   <span class="snapshot-label">Stars</span>
                   <strong>4,823</strong>
-                  <span class="snapshot-change missing">周初快照未取得，不能计算自然周增量</span>
+                  <span class="snapshot-change positive">本期当前可见新增 109</span>
                 </div>
                 <div class="snapshot-row">
                   <span class="snapshot-label">Forks</span>
                   <strong>652</strong>
-                  <span class="snapshot-change positive">本期新增 189</span>
+                  <span class="snapshot-change positive">本期当前可见创建 181</span>
                 </div>
               </div>
-              <p class="chart-note">规模数据截至 7 月 23 日 22:00；缺失值没有用 0 代替。</p>
+              <p class="chart-note">Stars 与 Forks 的本期值按认证 API 中当前仍可见、创建时间落入半开周期的记录统计；分别为 109 与 181，不代表库存净增长。</p>
             </div>
             <div class="chart-box" data-module="weekly-collaboration-chart">
               <h3>本周协作流转</h3>
-              <div class="bars" role="img" aria-label="W29 协作流转：Issue 新增 6 个、关闭 3 个；PR 新增 4 个、合并 0 个、关闭未合并 0 个">
-                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">6</span></div>
-                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:50%"></span></span><span class="bar-value">3</span></div>
-                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:66.7%"></span></span><span class="bar-value">4</span></div>
+              <div class="bars" role="img" aria-label="W29 协作流转：Issue 新增 5 个、关闭 3 个；PR 新增 2 个、合并 0 个、关闭未合并 0 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">5</span></div>
+                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:60%"></span></span><span class="bar-value">3</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:40%"></span></span><span class="bar-value">2</span></div>
                 <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:0%"></span></span><span class="bar-value">0</span></div>
                 <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:0%"></span></span><span class="bar-value">0</span></div>
               </div>
-              <p class="chart-note">Issue 净增 3、PR 净增 4；7 月 23 日快照开放 Issue 21 个、PR 19 个。主分支新增 3 个提交，本期未形成 Merge Commit。</p>
+              <p class="chart-note">Issue 净增 2、PR 净增 2；7 月 23 日快照开放 Issue 21 个、PR 19 个。主分支新增 3 个提交，本期未合并 PR。</p>
             </div>
           </div>
           <p class="risk-note"><strong>主要风险：</strong>开放 Issue 和 PR 中分别有 52.4% 与 52.6% 已超过 30 天，存量治理弱于新增需求识别。</p>
@@ -1344,15 +1354,15 @@ footer {
         <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
           <h2 id="ecosystem-title">三、生态相关进展</h2>
           <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
-            aria-label="W29 开源生态参与信号：6 位新 Issue 作者、3 位新 PR 作者、0 位合并贡献者；本期新增 189 个 Fork；SkillHub CLI npm 下载 644 次">
-            <div class="ecosystem-signal"><strong>6 / 3 / 0</strong><span>新 Issue 作者 / 新 PR 作者 / 合并贡献者</span></div>
-            <div class="ecosystem-signal"><strong>+189</strong><span>本期新增 Fork</span></div>
-            <div class="ecosystem-signal"><strong>644</strong><span>SkillHub CLI npm 下载</span></div>
+            aria-label="W29 开源生态参与信号：5 位新 Issue 作者、2 位新 PR 作者、0 位合并贡献者；当前可见本期创建 Fork 181 个；SkillHub CLI 在 2026 年 7 月 10 日至 16 日 UTC 日桶下载 541 次">
+            <div class="ecosystem-signal"><strong>5 / 2 / 0</strong><span>新 Issue 作者 / 新 PR 作者 / 合并贡献者</span></div>
+            <div class="ecosystem-signal"><strong>181</strong><span>当前可见本期创建 Fork</span></div>
+            <div class="ecosystem-signal"><strong>541</strong><span>CLI 下载 · 7 个 UTC 日桶</span></div>
             <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
           </div>
           <ul class="ecosystem-list">
-            <li><strong>社区输入</strong><span>6 位作者提交部署、namespace、OAuth、Hermes 与供应链议题，需求分布覆盖核心治理和生态接入。</span></li>
-            <li><strong>本地化与部署</strong><span><a href="https://github.com/iflytek/skillhub/pull/578">韩语本地化</a>、<a href="https://github.com/iflytek/skillhub/pull/576">可配置 Base Path</a>与 <a href="https://github.com/iflytek/skillhub/pull/575">部署 Cookie 配置</a>进入 Review。</span></li>
+            <li><strong>社区输入</strong><span>5 位作者提交部署、namespace、Hermes 与供应链议题，需求分布覆盖核心治理和生态接入。</span></li>
+            <li><strong>本地化与治理</strong><span><a href="https://github.com/iflytek/skillhub/pull/578">韩语本地化</a>与 <a href="https://github.com/iflytek/skillhub/pull/581">namespace 可见性修复</a>进入 Review。</span></li>
             <li><strong>期后生态进展</strong><span>双语 FAQ、Hermes 指南和 CLI 通用安装目标在 7 月 17—22 日完成，不计入本期交付量。</span></li>
             <li><strong>推广与合作</strong><span>本期尚未收到文章、直播、社区分享或合作项目清单；缺失数据不记为 0。</span></li>
           </ul>
@@ -1380,21 +1390,21 @@ footer {
           <div class="health-cards">
             <article class="health-card">
               <div class="top"><span class="name">工程稳定性</span><span class="status warn">需关注</span></div>
-              <div class="health-metric">92.6% <small>63/68</small></div>
-              <p>5 次失败中有 4 次来自 PR E2E。</p>
+              <div class="health-metric">94.2% <small>49/52</small></div>
+              <p>3 次失败均来自 PR E2E。</p>
               <div class="detail">有效成功率只统计实际成功与失败。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">10 / 10 <small>执行成功</small></div>
+              <div class="health-metric">7 / 7 <small>执行成功</small></div>
               <p>本期没有等待授权或失败记录。</p>
               <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
-              <div class="health-metric">31 / 32 <small>Backlog Rescore</small></div>
-              <p>Issue Triage 实际执行 6 次并全部成功。</p>
-              <div class="detail">Rescore 有 1 次失败，另有 12 次条件跳过。</div>
+              <div class="health-metric">28 / 28 <small>Backlog Rescore</small></div>
+              <p>Issue Triage 实际执行 5 次并全部成功。</p>
+              <div class="detail">Issue Triage 另有 7 次、奖励认领 3 次条件跳过。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">Release 交付</span><span class="status risk">风险</span></div>
@@ -1419,20 +1429,18 @@ footer {
 
         <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
           <h2 id="ci-title">CI 与自动化执行</h2>
-          <p class="section-lead">统计期内有 84 条 Actions 记录，其中 63 次成功、5 次失败、15 次跳过、1 次取消。</p>
+          <p class="section-lead">统计期内有 62 条 Actions 记录，其中 49 次成功、3 次失败、10 次跳过。</p>
           <div class="chart-box" data-module="actions-outcome-chart">
             <h3>Actions 结果构成</h3>
-            <div class="segbar" role="img" aria-label="W29 Actions 共 84 条记录：成功 63，失败 5，条件跳过 15，取消 1">
-              <span class="seg-success" style="width:75%"></span>
-              <span class="seg-failure" style="width:5.95%"></span>
-              <span class="seg-skipped" style="width:17.86%"></span>
-              <span class="seg-cancelled" style="width:1.19%"></span>
+            <div class="segbar" role="img" aria-label="W29 Actions 共 62 条记录：成功 49，失败 3，条件跳过 10">
+              <span class="seg-success" style="width:79.03%"></span>
+              <span class="seg-failure" style="width:4.84%"></span>
+              <span class="seg-skipped" style="width:16.13%"></span>
             </div>
             <div class="chart-legend" aria-hidden="true">
-              <span><i class="seg-success"></i>成功 <b>63</b></span>
-              <span><i class="seg-failure"></i>失败 <b>5</b></span>
-              <span><i class="seg-skipped"></i>跳过 <b>15</b></span>
-              <span><i class="seg-cancelled"></i>取消 <b>1</b></span>
+              <span><i class="seg-success"></i>成功 <b>49</b></span>
+              <span><i class="seg-failure"></i>失败 <b>3</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>10</b></span>
             </div>
           </div>
           <div class="table-wrap">
@@ -1442,17 +1450,16 @@ footer {
                 <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
               </thead>
               <tbody>
-                <tr><td>PR Tests</td><td class="number">9</td><td class="number">9</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>PR E2E Tests</td><td class="number">9</td><td class="number">4</td><td class="number">4</td><td class="number">0</td><td class="number">1</td></tr>
-                <tr><td>PR Scripts</td><td class="number">3</td><td class="number">3</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Security</td><td class="number">10</td><td class="number">10</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Issue Backlog Rescore</td><td class="number">32</td><td class="number">31</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Issue Triage</td><td class="number">18</td><td class="number">6</td><td class="number">0</td><td class="number">0</td><td class="number">12</td></tr>
+                <tr><td>PR Tests</td><td class="number">6</td><td class="number">6</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">6</td><td class="number">3</td><td class="number">3</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Security</td><td class="number">7</td><td class="number">7</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Issue Backlog Rescore</td><td class="number">28</td><td class="number">28</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Issue Triage</td><td class="number">12</td><td class="number">5</td><td class="number">0</td><td class="number">0</td><td class="number">7</td></tr>
                 <tr><td>Claim Issue Reward</td><td class="number">3</td><td class="number">0</td><td class="number">0</td><td class="number">0</td><td class="number">3</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>本期薄弱点：</strong>PR E2E 8 次实际形成结论，其中 4 次失败；Backlog Rescore 另有 1 次失败。</p>
+          <p class="risk-note"><strong>本期薄弱点：</strong>PR E2E 6 次实际形成结论，其中 3 次失败；其余实际执行的工作流均成功。</p>
         </section>
 
         <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
@@ -1460,7 +1467,7 @@ footer {
           <div class="health-grid">
             <article class="health-note">
               <h3>安全与供应链</h3>
-              <p>Security 实际执行 10 次并全部成功。仓库保留 CodeQL 定时扫描和 dependency review；公开数据无法确认未修复告警数量。</p>
+              <p>Security 实际执行 7 次并全部成功。仓库保留 CodeQL 定时扫描和 dependency review；公开数据无法确认未修复告警数量。</p>
             </article>
             <article class="health-note">
               <h3>Release 交付</h3>
@@ -1507,17 +1514,17 @@ footer {
 
         <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
           <h2 id="response-title">社区响应</h2>
-          <p>6 个新增 Issue 中，部署阻断问题 <a href="https://github.com/iflytek/skillhub/issues/574">#574</a> 和 CLI 可见性问题 <a href="https://github.com/iflytek/skillhub/issues/577">#577</a> 在本期关闭；namespace 问题 <a href="https://github.com/iflytek/skillhub/issues/580">#580</a> 形成配对 PR #581。按“关闭或形成配对实现”统计，可观察处置覆盖为 3/6。</p>
+          <p>5 个新增 Issue 中，CLI 可见性问题 <a href="https://github.com/iflytek/skillhub/issues/577">#577</a> 在本期关闭；namespace 问题 <a href="https://github.com/iflytek/skillhub/issues/580">#580</a> 形成配对 PR #581。按“关闭或形成配对实现”统计，可观察处置覆盖为 2/5。</p>
           <div class="table-wrap">
             <table>
               <caption>新增 Issue 的首次可观察处置</caption>
               <thead><tr><th>Issue</th><th>首次处置</th><th>耗时</th><th>状态</th></tr></thead>
               <tbody>
-                <tr><td><a href="https://github.com/iflytek/skillhub/issues/574">#574</a></td><td>形成部署修复 PR #575</td><td>约 4 小时</td><td>本期关闭</td></tr>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/577">#577</a></td><td>确认 ClawHub CLI 兼容边界</td><td>未取得</td><td>本期关闭</td></tr>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/580">#580</a></td><td>形成配对 PR #581</td><td>约 13 小时</td><td>推进中</td></tr>
                 <tr><td><a href="https://github.com/iflytek/skillhub/issues/582">#582</a></td><td>期后形成 Hermes 指南 PR #584</td><td>期后</td><td>期后完成</td></tr>
-                <tr><td><a href="https://github.com/iflytek/skillhub/issues/579">#579</a>、<a href="https://github.com/iflytek/skillhub/issues/583">#583</a></td><td>本期未观察到明确执行结论</td><td>未取得</td><td>待确认</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/579">#579</a></td><td>本期未观察到明确执行结论</td><td>未取得</td><td>待确认</td></tr>
+                <tr><td><a href="https://github.com/iflytek/skillhub/issues/583">#583</a></td><td>本期未观察到明确执行结论</td><td>未取得</td><td>待安全评审</td></tr>
               </tbody>
             </table>
           </div>
@@ -1534,8 +1541,8 @@ footer {
         <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
           <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
           <div class="flow-summary">
-            <div class="flow-item"><strong>Issue +6 / -3</strong><span>净增 3 · 7 月 23 日快照开放 21</span></div>
-            <div class="flow-item"><strong>PR +4 / 合并 0</strong><span>关闭未合并 0 · 净增 4 · 7 月 23 日快照开放 19</span></div>
+            <div class="flow-item"><strong>Issue +5 / -3</strong><span>净增 2 · 7 月 23 日快照开放 21</span></div>
+            <div class="flow-item"><strong>PR +2 / 合并 0</strong><span>关闭未合并 0 · 净增 2 · 7 月 23 日快照开放 19</span></div>
           </div>
 
           <h3>新增 Issue（按价值排序）</h3>
@@ -1544,11 +1551,10 @@ footer {
               <caption class="sr-only">W29 新增 Issue 价值排序</caption>
               <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前进展</th></tr></thead>
               <tbody>
-                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/574">#574 Release Compose 启动失败</a></td><td>直接阻断生产部署。</td><td>形成 PR #575，并在本期关闭。</td></tr>
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/580">#580 SUPER_ADMIN namespace 可见性</a></td><td>企业治理核心体验问题。</td><td>配对 PR #581 仍开放。</td></tr>
-                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/583">#583 DingTalk OAuth</a></td><td>身份接入价值高，安全风险也高。</td><td>与 PR #467 配对，待安全审查。</td></tr>
                 <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/579">#579 来源证明、签名与 SBOM</a></td><td>战略价值高，当前范围过大。</td><td>待拆分设计。</td></tr>
                 <tr><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/issues/582">#582 Hermes Skill 集成</a></td><td>边界清晰的生态文档需求。</td><td>期后合并并关闭。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/583">#583 DingTalk OAuth</a></td><td>企业身份接入价值高，需严格审查安全边界。</td><td>与 PR #467 配对，仍待集中评审。</td></tr>
                 <tr><td><span class="value-level value-d">D</span></td><td><a href="https://github.com/iflytek/skillhub/issues/577">#577 ClawHub visibility 参数</a></td><td>上游 CLI 能力边界问题。</td><td>本期关闭，不进入 SkillHub 实现队列。</td></tr>
               </tbody>
             </table>
@@ -1561,10 +1567,8 @@ footer {
               <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
               <tbody>
                 <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/581">#581 namespace 可见性</a></td><td>价值高、范围较大，需收敛并重跑门禁。</td></tr>
-                <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/575">#575 部署 Cookie 配置</a></td><td>回应启动阻断问题 #574；期后关闭未合并。</td></tr>
-                <tr><td>新增</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/576">#576 可配置 Base Path</a></td><td>支持子路径部署，期末仍开放。</td></tr>
                 <tr><td>新增</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/578">#578 韩语本地化</a></td><td>扩大本地化覆盖，期后关闭未合并。</td></tr>
-                <tr><td>本期结果</td><td>—</td><td>合并 0 / 关闭未合并 0</td><td>4 个新增 PR 均在期末保持开放。</td></tr>
+                <tr><td>本期结果</td><td>—</td><td>合并 0 / 关闭未合并 0</td><td>2 个新增 PR 均在期末保持开放。</td></tr>
               </tbody>
             </table>
           </div>
@@ -1636,10 +1640,11 @@ footer {
         <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
           <h2 id="method-title">统计口径</h2>
           <ul class="method-list">
-            <li><strong>统计周期</strong><span>2026-07-09 00:00—2026-07-16 23:59，Asia/Shanghai；按“上周四到本周四”回溯统计。</span></li>
+            <li><strong>统计周期</strong><span>展示为 2026-07-10 00:00—2026-07-16 23:59，Asia/Shanghai；程序过滤采用等价半开区间 <code>[2026-07-10 00:00, 2026-07-17 00:00)</code>，对应 UTC 为 7 月 9 日 16:00 至 7 月 16 日 16:00。</span></li>
             <li><strong>当前快照</strong><span>2026-07-23 22:00；开放 Issue/PR、Stars、Forks 和 Watchers 是期后快照，不回填为 W29 流量。</span></li>
-            <li><strong>期后进展</strong><span>7 月 17 日以后发生的合并、关闭和 Release 仅说明后续结果，明确不计入 W29。</span></li>
-            <li><strong>历史衔接</strong><span>本报告由原周一—周日口径回溯调整；7 月 16 日作为周四边界日期，也会出现在相邻 W30 的展示周期中。</span></li>
+            <li><strong>Star 证据</strong><span>109 表示 7 月 31 日 16:35 认证 API 中，<code>starred_at</code> 落入本期且当前仍可见的 Stargazer；它不代表 Star 库存净增长。</span></li>
+            <li><strong>期后进展</strong><span>7 月 17 日 00:00 及以后发生的合并、关闭和 Release 仅说明后续结果，明确不计入 W29。</span></li>
+            <li><strong>周期衔接</strong><span>W29 的排他截止与 W30 起始均为 7 月 17 日 00:00，相邻报告无重叠；周四 23:59 后的事件进入下一期。</span></li>
             <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权和条件性跳过不进入分母。</span></li>
             <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告将两者分开统计；价值 A—D 为人工治理判断。</span></li>
             <li><strong>推广数据</strong><span>推广动作由维护者补录；Fork、下载、Issue 作者和 PR 作者是不同信号，不作为转化漏斗。</span></li>
@@ -1653,14 +1658,14 @@ footer {
               <caption>来源覆盖</caption>
               <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
               <tbody>
-                <tr><td>GitHub 公共 REST API</td><td>仓库、Issue、PR、Release、Actions、Fork</td><td>Traffic 与私有安全告警不可见。</td></tr>
+                <tr><td>GitHub API（认证）</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer <code>starred_at</code></td><td>没有周期起止两份库存快照；当前可见新增不等于净增长。</td></tr>
                 <tr><td>GitHub Actions 与本地 Git</td><td>流水线运行、恢复证据和变更核对</td><td>外部 PR 等待授权时无实际执行样本。</td></tr>
-                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 本期下载</td><td>644 次下载不等同于独立用户。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 的 7 个 UTC 日桶</td><td>541 次下载不等同于独立用户，且覆盖范围与 Asia/Shanghai 周期不完全对齐。</td></tr>
                 <tr><td>维护者人工底稿</td><td>价值排序、推广动作和期后确认</td><td>推广动作尚未提供。</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、周初 Stargazer 快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
+          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、W29 起止两份可比 Star/Fork 库存快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
         </section>
       </div>
     </main>

--- a/weekly/site/reports/2026-W30/index.html
+++ b/weekly/site/reports/2026-W30/index.html
@@ -1193,7 +1193,17 @@ footer {
 </head>
 <body>
   <a class="skip-link" href="#report-content">跳到报告正文</a>
-  <article class="report">
+  <article class="report"
+    data-period-start="2026-07-17T00:00:00+08:00"
+    data-period-end="2026-07-24T00:00:00+08:00"
+    data-period-boundary="[)"
+    data-snapshot-at="2026-07-24T00:00:00+08:00"
+    data-star-evidence="current-visible-arrivals"
+    data-star-api-status="success"
+    data-star-arrivals="803"
+    data-star-observed-at="2026-07-31T16:35:58+08:00"
+    data-star-start-at=""
+    data-star-end-at="">
     <header class="masthead">
       <div class="topline">
         <div class="brand">
@@ -1214,11 +1224,11 @@ footer {
           <div class="meta-grid">
             <div class="meta-item">
               <span class="key">统计周期</span>
-              <span class="value">2026-07-16 00:00—2026-07-23 22:00（Asia/Shanghai）</span>
+              <span class="value">2026-07-17 00:00—2026-07-23 23:59 · Asia/Shanghai</span>
             </div>
             <div class="meta-item">
-              <span class="key">当前状态快照</span>
-              <span class="value">2026-07-23 22:00（Asia/Shanghai）</span>
+              <span class="key">期末状态复核</span>
+              <span class="value">2026-07-24 00:00（Asia/Shanghai）</span>
             </div>
             <div class="meta-item">
               <span class="key">项目仓库</span>
@@ -1226,7 +1236,7 @@ footer {
             </div>
             <div class="meta-item">
               <span class="key">数据来源</span>
-              <span class="value">GitHub REST API · Actions · Git · npm Downloads API</span>
+              <span class="value">GitHub API（认证）· Actions · Git · npm Downloads API</span>
             </div>
           </div>
         </div>
@@ -1240,9 +1250,9 @@ footer {
         </div>
       </div>
       <div class="metrics" aria-label="四项核心指标">
-        <div class="metric"><strong>4,823</strong><span>Stars · 统计期增量未取得</span></div>
-        <div class="metric"><strong>652</strong><span>Forks · 本期新增 27</span></div>
-        <div class="metric"><strong>91.3%</strong><span>Actions 有效成功率 · 126/138</span></div>
+        <div class="metric"><strong>4,823</strong><span>Stars · 本期当前可见新增 803</span></div>
+        <div class="metric"><strong>652</strong><span>Forks · 本期当前可见创建 26</span></div>
+        <div class="metric"><strong>90.8%</strong><span>Actions 有效成功率 · 118/130</span></div>
         <div class="metric"><strong>1 / 1</strong><span>应用 / CLI Release · W30</span></div>
       </div>
     </header>
@@ -1277,26 +1287,26 @@ footer {
                 <div class="snapshot-row">
                   <span class="snapshot-label">Stars</span>
                   <strong>4,823</strong>
-                  <span class="snapshot-change missing">期初快照未取得，不能计算净增量</span>
+                  <span class="snapshot-change positive">本期当前可见新增 803</span>
                 </div>
                 <div class="snapshot-row">
                   <span class="snapshot-label">Forks</span>
                   <strong>652</strong>
-                  <span class="snapshot-change positive">本期新增 27</span>
+                  <span class="snapshot-change positive">本期当前可见创建 26</span>
                 </div>
               </div>
-              <p class="chart-note">规模快照截至 7 月 23 日 22:00；Fork 新增按创建时间统计，Star 期初净快照未取得。</p>
+              <p class="chart-note">Stars 与 Forks 的本期值按认证 API 中当前仍可见、创建时间落入半开周期的记录统计；分别为 803 与 26，不代表库存净增长。</p>
             </div>
             <div class="chart-box" data-module="weekly-collaboration-chart">
               <h3>本周协作流转</h3>
-              <div class="bars" role="img" aria-label="W30 协作流转：Issue 新增 8 个、关闭 3 个；PR 新增 12 个、合并 5 个、关闭未合并 9 个">
-                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:66.7%"></span></span><span class="bar-value">8</span></div>
+              <div class="bars" role="img" aria-label="W30 协作流转：Issue 新增 7 个、关闭 3 个；PR 新增 12 个、合并 5 个、关闭未合并 9 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:58.3%"></span></span><span class="bar-value">7</span></div>
                 <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:25%"></span></span><span class="bar-value">3</span></div>
                 <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">12</span></div>
                 <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:41.7%"></span></span><span class="bar-value">5</span></div>
                 <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:75%"></span></span><span class="bar-value">9</span></div>
               </div>
-              <p class="chart-note">Issue 净增 5、当前开放 21；PR 净减 2、当前开放 19。主分支新增 19 个提交，其中 5 个 Merge Commit。</p>
+              <p class="chart-note">Issue 净增 4、期末开放 21；PR 净减 2、期末开放 19。主分支新增 18 个提交，本期合并 5 个 PR。</p>
             </div>
           </div>
           <p class="risk-note"><strong>主要风险：</strong>发布目标已经恢复，但开放 Issue 和 PR 中分别有 52.4% 与 52.6% 超过 30 天，且 PR E2E 本期有 8 次失败。</p>
@@ -1325,9 +1335,9 @@ footer {
                   <td>本周合并并关闭 #582，形成新的 Agent 生态接入路径。</td>
                 </tr>
                 <tr>
-                  <td><span class="status warn">推进中</span></td>
+                  <td><span class="status warn">期后完成</span></td>
                   <td><a href="https://github.com/iflytek/skillhub/issues/596">#596</a> / <a href="https://github.com/iflytek/skillhub/pull/601">PR #601 驳回版本重传 500</a></td>
-                  <td>发布核心流程修复已提交；需解决本周 CI/E2E 失败并完成回归。</td>
+                  <td>7 月 23 日本期提交，期后合并并完成回归。</td>
                 </tr>
                 <tr>
                   <td><span class="status warn">推进中</span></td>
@@ -1342,10 +1352,10 @@ footer {
         <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
           <h2 id="ecosystem-title">三、生态相关进展</h2>
           <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
-            aria-label="W30 开源生态参与信号：8 位新 Issue 作者、5 位新 PR 作者、3 位合并作者；本期新增 27 个 Fork；SkillHub CLI npm 下载 856 次">
-            <div class="ecosystem-signal"><strong>8 / 5 / 3</strong><span>新 Issue 作者 / 新 PR 作者 / 合并作者</span></div>
-            <div class="ecosystem-signal"><strong>+27</strong><span>本期新增 Fork</span></div>
-            <div class="ecosystem-signal"><strong>856</strong><span>SkillHub CLI npm 下载</span></div>
+            aria-label="W30 开源生态参与信号：7 位新 Issue 作者、5 位新 PR 作者、3 位合并作者；当前可见本期创建 Fork 26 个；SkillHub CLI 在 2026 年 7 月 17 日至 23 日 UTC 日桶下载 746 次">
+            <div class="ecosystem-signal"><strong>7 / 5 / 3</strong><span>新 Issue 作者 / 新 PR 作者 / 合并作者</span></div>
+            <div class="ecosystem-signal"><strong>26</strong><span>当前可见本期创建 Fork</span></div>
+            <div class="ecosystem-signal"><strong>746</strong><span>CLI 下载 · 7 个 UTC 日桶</span></div>
             <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
           </div>
           <ul class="ecosystem-list">
@@ -1377,19 +1387,19 @@ footer {
           <div class="health-cards">
             <article class="health-card">
               <div class="top"><span class="name">工程稳定性</span><span class="status warn">需关注</span></div>
-              <div class="health-metric">91.3% <small>126/138</small></div>
+              <div class="health-metric">90.8% <small>118/130</small></div>
               <p>12 次失败中有 8 次来自 PR E2E。</p>
               <div class="detail">失败覆盖多个开发分支，需要区分回归与环境问题。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">32 / 32 <small>执行成功</small></div>
+              <div class="health-metric">31 / 31 <small>执行成功</small></div>
               <p>另有 9 次等待授权、1 次条件跳过。</p>
               <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
-              <div class="health-metric">31 / 32 <small>Backlog Rescore</small></div>
+              <div class="health-metric">27 / 28 <small>Backlog Rescore</small></div>
               <p>DeepWiki 1 次失败；镜像发布 2 成功、1 失败。</p>
               <div class="detail">治理自动化整体可用，但存在分散失败点。</div>
             </article>
@@ -1416,18 +1426,18 @@ footer {
 
         <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
           <h2 id="ci-title">CI 与自动化执行</h2>
-          <p class="section-lead">统计期内有 213 条 Actions 记录，其中 126 次成功、12 次失败、32 次等待授权、42 次跳过、1 次取消。</p>
+          <p class="section-lead">统计期内有 205 条 Actions 记录，其中 118 次成功、12 次失败、32 次等待授权、42 次跳过、1 次取消。</p>
           <div class="chart-box" data-module="actions-outcome-chart">
             <h3>Actions 结果构成</h3>
-            <div class="segbar" role="img" aria-label="W30 Actions 共 213 条记录：成功 126，失败 12，等待授权 32，条件跳过 42，取消 1">
-              <span class="seg-success" style="width:59.15%"></span>
-              <span class="seg-failure" style="width:5.63%"></span>
-              <span class="seg-auth" style="width:15.02%"></span>
-              <span class="seg-skipped" style="width:19.72%"></span>
-              <span class="seg-cancelled" style="width:.47%"></span>
+            <div class="segbar" role="img" aria-label="W30 Actions 共 205 条记录：成功 118，失败 12，等待授权 32，条件跳过 42，取消 1">
+              <span class="seg-success" style="width:57.56%"></span>
+              <span class="seg-failure" style="width:5.85%"></span>
+              <span class="seg-auth" style="width:15.61%"></span>
+              <span class="seg-skipped" style="width:20.49%"></span>
+              <span class="seg-cancelled" style="width:.49%"></span>
             </div>
             <div class="chart-legend" aria-hidden="true">
-              <span><i class="seg-success"></i>成功 <b>126</b></span>
+              <span><i class="seg-success"></i>成功 <b>118</b></span>
               <span><i class="seg-failure"></i>失败 <b>12</b></span>
               <span><i class="seg-auth"></i>等待授权 <b>32</b></span>
               <span><i class="seg-skipped"></i>跳过 <b>42</b></span>
@@ -1441,21 +1451,21 @@ footer {
                 <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
               </thead>
               <tbody>
-                <tr><td>PR Tests</td><td class="number">36</td><td class="number">24</td><td class="number">1</td><td class="number">9</td><td class="number">2</td></tr>
-                <tr><td>PR E2E Tests</td><td class="number">22</td><td class="number">6</td><td class="number">8</td><td class="number">8</td><td class="number">0</td></tr>
+                <tr><td>PR Tests</td><td class="number">35</td><td class="number">23</td><td class="number">1</td><td class="number">9</td><td class="number">2</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">21</td><td class="number">5</td><td class="number">8</td><td class="number">8</td><td class="number">0</td></tr>
                 <tr><td>PR CLI</td><td class="number">6</td><td class="number">5</td><td class="number">0</td><td class="number">1</td><td class="number">0</td></tr>
                 <tr><td>PR Scripts</td><td class="number">12</td><td class="number">7</td><td class="number">0</td><td class="number">5</td><td class="number">0</td></tr>
                 <tr><td>PR Helm Chart</td><td class="number">1</td><td class="number">1</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Security</td><td class="number">42</td><td class="number">32</td><td class="number">0</td><td class="number">9</td><td class="number">1</td></tr>
-                <tr><td>Issue Backlog Rescore</td><td class="number">32</td><td class="number">31</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Issue Triage</td><td class="number">50</td><td class="number">13</td><td class="number">0</td><td class="number">0</td><td class="number">37</td></tr>
+                <tr><td>Security</td><td class="number">41</td><td class="number">31</td><td class="number">0</td><td class="number">9</td><td class="number">1</td></tr>
+                <tr><td>Issue Backlog Rescore</td><td class="number">28</td><td class="number">27</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Issue Triage</td><td class="number">49</td><td class="number">12</td><td class="number">0</td><td class="number">0</td><td class="number">37</td></tr>
                 <tr><td>Publish Images</td><td class="number">3</td><td class="number">2</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
                 <tr><td>Release CLI</td><td class="number">1</td><td class="number">1</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
                 <tr><td>其他自动化</td><td class="number">8</td><td class="number">4</td><td class="number">1</td><td class="number">0</td><td class="number">3</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>本期薄弱点：</strong>PR E2E 实际形成结论的 14 次运行中有 8 次失败；需区分真实回归、环境不稳定和分支早期失败，不能只看最终合并结果。</p>
+          <p class="risk-note"><strong>本期薄弱点：</strong>PR E2E 实际形成结论的 13 次运行中有 8 次失败；需区分真实回归、环境不稳定和分支早期失败，不能只看最终合并结果。</p>
         </section>
 
         <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
@@ -1463,7 +1473,7 @@ footer {
           <div class="health-grid">
             <article class="health-note">
               <h3>安全与供应链</h3>
-              <p>Security 32 次实际执行全部成功。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
+              <p>Security 31 次实际执行全部成功，另有 9 次等待授权、1 次条件跳过。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
             </article>
             <article class="health-note">
               <h3>Release 交付</h3>
@@ -1510,7 +1520,7 @@ footer {
 
         <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
           <h2 id="response-title">社区响应</h2>
-          <p>本期 8 个新增 Issue 中，#582、#586、#594 已关闭，#596 在约 23 小时后形成配对 PR #601，#597 由 PR #592 继续跟踪。按“关闭或形成明确配对实现”统计，可观察处置覆盖为 5/8；该口径不等同于首次维护者响应 SLA。</p>
+          <p>本期 7 个新增 Issue 中，#586、#594 已关闭，#596 在期后形成配对 PR #601，#597 由 PR #592 继续跟踪。按“关闭或形成明确配对实现”统计，截至快照可观察处置覆盖为 4/7；该口径不等同于首次维护者响应 SLA。</p>
         </section>
       </div>
 
@@ -1524,8 +1534,8 @@ footer {
         <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
           <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
           <div class="flow-summary">
-            <div class="flow-item"><strong>Issue +8 / -3</strong><span>净增 5 · 当前快照开放 21</span></div>
-            <div class="flow-item"><strong>PR +12 / 合并 5</strong><span>关闭未合并 9 · 净减 2 · 当前快照开放 19</span></div>
+            <div class="flow-item"><strong>Issue +7 / -3</strong><span>净增 4 · 期末开放 21</span></div>
+            <div class="flow-item"><strong>PR +12 / 合并 5</strong><span>关闭未合并 9 · 净减 2 · 期末开放 19</span></div>
           </div>
 
           <h3>新增 Issue（按价值排序）</h3>
@@ -1537,11 +1547,10 @@ footer {
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/596">#596 驳回版本同版本号重传返回 500</a></td><td>直接阻断发布核心流程。</td><td>配对 PR #601 已提交，CI/E2E 待修复。</td></tr>
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/586">#586 启动脚本缺少 Cookie Secret</a></td><td>阻断依赖 OSS 脚本部署的用户。</td><td>本期完成同步并关闭。</td></tr>
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/594">#594 GitLab OAuth Base URI 不生效</a></td><td>影响企业身份接入，官方标记 high risk。</td><td>本周约 4 小时内关闭；需保留关闭依据。</td></tr>
-                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/583">#583 DingTalk OAuth</a></td><td>身份接入价值高，安全边界也需要严格审查。</td><td>与 PR #467 配对，期末仍开放。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/602">#602 MCP 广场与专家包</a></td><td>有生态价值，但会扩大产品与维护边界。</td><td>需先确认与 Registry 集合、Agent 集成的关系。</td></tr>
                 <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/597">#597 搜索异步重建缺少 MDC、重试与指标</a></td><td>关系到索引长期一致性和可运维性。</td><td>作为 PR #592 的稳健性后续。</td></tr>
                 <tr><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/issues/587">#587 Skill Health Score</a></td><td>治理价值存在，但需先定义外部遥测契约。</td><td>当前信息不足，需明确遥测来源与责任边界。</td></tr>
                 <tr><td><span class="value-level value-d">D</span></td><td><a href="https://github.com/iflytek/skillhub/issues/589">#589 Skill 工作台</a></td><td>可能把 Registry 扩展为创作 IDE。</td><td>已标记 deferred，建议独立验证。</td></tr>
-                <tr><td><span class="value-level value-d">D</span></td><td><a href="https://github.com/iflytek/skillhub/issues/602">#602 MCP 广场和专家包</a></td><td>涉及产品边界扩张。</td><td>已标记 deferred，先澄清定位。</td></tr>
               </tbody>
             </table>
           </div>
@@ -1552,12 +1561,13 @@ footer {
               <caption class="sr-only">W30 关键 PR 流转</caption>
               <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
               <tbody>
-                <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传修复</a></td><td>发布核心修复；本周 PR Tests 与 E2E 失败。</td></tr>
+                <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传修复</a></td><td>7 月 23 日本期提交，期后合并并完成回归。</td></tr>
                 <tr><td>新增</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/592">#592 搜索索引异步重建</a></td><td>修复标签变化后的搜索一致性，当前仍开放。</td></tr>
                 <tr><td>合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/529">#529 双语 FAQ</a> / <a href="https://github.com/iflytek/skillhub/pull/591">#591 Scanner 依赖固定</a> / <a href="https://github.com/iflytek/skillhub/pull/595">#595 CLI 0.1.9</a></td><td>完成社区文档、镜像构建和 CLI 发版闭环。</td></tr>
                 <tr><td>合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/584">#584 Hermes 指南</a> / <a href="https://github.com/iflytek/skillhub/pull/585">#585 通用安装目标</a></td><td>完成 Agent 集成和跨 Agent 安装路径。</td></tr>
                 <tr><td>新增</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/593">#593 运维 FAQ</a> / <a href="https://github.com/iflytek/skillhub/pull/598">#598 HarnessClaw 指南</a></td><td>文档型贡献，完成事实核对后可小步合并。</td></tr>
-                <tr><td>其他新增</td><td>—</td><td>#588 / #590 / #599 / #600</td><td>覆盖俄语本地化、安全修复、README 传播与站点文档；#588、#590、#600 在本期关闭未合并。</td></tr>
+                <tr><td>新增</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/599">#599 README 引导</a> / <a href="https://github.com/iflytek/skillhub/pull/600">#600 项目网站</a></td><td>#599 期后合并；#600 本期关闭未合并。</td></tr>
+                <tr><td>其他新增</td><td>—</td><td>#588 / #590</td><td>覆盖俄语本地化与安全修复，均在本期关闭未合并。</td></tr>
                 <tr><td>关闭未合并</td><td>—</td><td>#317 / #459 / #569 / #572 / #575 / #578</td><td>配合新增后关闭的 #588、#590、#600，本期共完成 9 个未合并关闭决策。</td></tr>
               </tbody>
             </table>
@@ -1630,11 +1640,11 @@ footer {
         <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
           <h2 id="method-title">统计口径</h2>
           <ul class="method-list">
-            <li><strong>统计周期</strong><span>2026-07-16 00:00—2026-07-23 22:00，Asia/Shanghai；按“上周四到本周四”回溯统计。</span></li>
-            <li><strong>当前快照</strong><span>2026-07-23 22:00；开放队列与仓库累计数均取该时点。</span></li>
-            <li><strong>Star 比较</strong><span>期初净 Star 快照未取得，因此只展示期末 4,823，不推断统计期净增长。</span></li>
-            <li><strong>历史衔接</strong><span>本报告由原周一—周日口径回溯调整；7 月 16 日和 7 月 23 日是周四边界日期，也会出现在相邻报告的展示周期中。</span></li>
-            <li><strong>期后进展</strong><span>7 月 23 日 22:00 以后发生的合并、关闭和 Release 只作为后续状态，不计入 W30。</span></li>
+            <li><strong>统计周期</strong><span>展示为 2026-07-17 00:00—2026-07-23 23:59，Asia/Shanghai；程序过滤采用等价半开区间 <code>[2026-07-17 00:00, 2026-07-24 00:00)</code>，对应 UTC 为 7 月 16 日 16:00 至 7 月 23 日 16:00。</span></li>
+            <li><strong>期末状态</strong><span>仓库累计数与开放队列取 2026-07-23 22:00 快照；复核后续两小时 Issue/PR 事件流无变化，因此期末开放 Issue 21、PR 19。Star 当前可见新增另按 7 月 31 日认证列表重算。</span></li>
+            <li><strong>Star 证据</strong><span>803 表示 7 月 31 日 16:35 认证 API 中，<code>starred_at</code> 落入本期且当前仍可见的 Stargazer；它不代表 Star 库存净增长。</span></li>
+            <li><strong>周期衔接</strong><span>W29 的排他截止与 W30 起始均为 7 月 17 日 00:00；W30 的排他截止与 W31 起始均为 7 月 24 日 00:00，相邻报告无重叠。</span></li>
+            <li><strong>期后进展</strong><span>7 月 24 日 00:00 及以后发生的合并、关闭和 Release 只作为后续状态，不计入 W30。</span></li>
             <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权、条件跳过和取消不进入分母。</span></li>
             <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告分开统计；价值 A—D 为人工治理判断。</span></li>
             <li><strong>推广数据</strong><span>推广动作由维护者补录；Fork、下载、Issue 作者和 PR 作者不组成转化漏斗。</span></li>
@@ -1648,14 +1658,14 @@ footer {
               <caption>来源覆盖</caption>
               <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
               <tbody>
-                <tr><td>GitHub REST API</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer</td><td>Traffic 与私有安全告警不可见。</td></tr>
+                <tr><td>GitHub API（认证）</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer <code>starred_at</code></td><td>没有周期起止两份库存快照；当前可见新增不等于净增长。</td></tr>
                 <tr><td>Git 标签与提交历史</td><td>核对 v0.2.14 交付内容</td><td>只用于补充公开 Release 信息。</td></tr>
-                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 本期下载</td><td>856 次下载不等同于独立用户。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 的 7 个 UTC 日桶</td><td>746 次下载不等同于独立用户，且覆盖范围与 Asia/Shanghai 周期不完全对齐。</td></tr>
                 <tr><td>维护者人工判断</td><td>价值排序、推广动作和产品边界</td><td>推广动作尚未提供。</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、期初净 Star 快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
+          <p class="risk-note"><strong>未取得：</strong>GitHub Traffic、Referrers、W30 起止两份可比 Star/Fork 库存快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。</p>
         </section>
       </div>
     </main>

--- a/weekly/site/reports/2026-W31/index.html
+++ b/weekly/site/reports/2026-W31/index.html
@@ -1194,13 +1194,16 @@ footer {
 <body>
   <a class="skip-link" href="#report-content">跳到报告正文</a>
   <article class="report"
-    data-period-start="2026-07-23T00:00:00+08:00"
-    data-period-end="2026-07-30T00:00:00+08:00"
+    data-period-start="2026-07-24T00:00:00+08:00"
+    data-period-end="2026-07-31T00:00:00+08:00"
     data-period-boundary="[)"
     data-snapshot-at="2026-07-31T14:35:33+08:00"
-    data-star-evidence="snapshot-only"
+    data-star-evidence="current-visible-arrivals"
+    data-star-api-status="success"
+    data-star-arrivals="130"
+    data-star-observed-at="2026-07-31T16:35:58+08:00"
     data-star-start-at=""
-    data-star-end-at="2026-07-31T14:35:33+08:00">
+    data-star-end-at="">
     <header class="masthead">
       <div class="topline">
         <div class="brand">
@@ -1221,7 +1224,7 @@ footer {
           <div class="meta-grid">
             <div class="meta-item">
               <span class="key">统计周期</span>
-              <span class="value">2026-07-23 00:00—2026-07-30 00:00 · Asia/Shanghai · [)</span>
+              <span class="value">2026-07-24 00:00—2026-07-30 23:59 · Asia/Shanghai</span>
             </div>
             <div class="meta-item">
               <span class="key">当前状态快照</span>
@@ -1233,7 +1236,7 @@ footer {
             </div>
             <div class="meta-item">
               <span class="key">数据来源</span>
-              <span class="value">GitHub REST API · Actions · Git · npm Downloads API</span>
+              <span class="value">GitHub API（认证）· Actions · Git · npm Downloads API</span>
             </div>
           </div>
         </div>
@@ -1243,14 +1246,14 @@ footer {
             <strong>需关注</strong>
             <span class="status warn">Attention</span>
           </div>
-          <p>周期内 Actions 有效成功率为 97.6%，但没有应用或 CLI Release；期后已发布 v0.2.15。Issue 净流入 13 个，当前开放 P1 达 21 个，是主要风险。</p>
+          <p>周期内 Actions 有效成功率为 98.2%，应用 v0.2.15 已发布、CLI 未发版；Issue 净流入 21 个，当前开放 P1 达 21 个，是主要风险。</p>
         </div>
       </div>
       <div class="metrics" aria-label="四项核心指标">
-        <div class="metric"><strong>4,890</strong><span>Stars · 当前快照，周增量未取得</span></div>
-        <div class="metric"><strong>703</strong><span>Forks · 本期当前可见创建 50</span></div>
-        <div class="metric"><strong>97.6%</strong><span>Actions 有效成功率 · 203/208</span></div>
-        <div class="metric"><strong>0 / 0</strong><span>应用 / CLI Release · 本期</span></div>
+        <div class="metric"><strong>4,849</strong><span>Stars · 本期当前可见新增 130</span></div>
+        <div class="metric"><strong>703</strong><span>Forks · 本期当前可见创建 58</span></div>
+        <div class="metric"><strong>98.2%</strong><span>Actions 有效成功率 · 278/283</span></div>
+        <div class="metric"><strong>1 / 0</strong><span>应用 / CLI Release · 本期</span></div>
       </div>
     </header>
 
@@ -1283,30 +1286,30 @@ footer {
               <div class="snapshot-list">
                 <div class="snapshot-row">
                   <span class="snapshot-label">Stars</span>
-                  <strong>4,890</strong>
-                  <span class="snapshot-change missing">周增量未取得</span>
+                  <strong>4,849</strong>
+                  <span class="snapshot-change positive">本期当前可见新增 130</span>
                 </div>
                 <div class="snapshot-row">
                   <span class="snapshot-label">Forks</span>
                   <strong>703</strong>
-                  <span class="snapshot-change positive">当前可见本期创建 50</span>
+                  <span class="snapshot-change positive">当前可见本期创建 58</span>
                 </div>
               </div>
-              <p class="chart-note">Stars 仅有 7 月 31 日快照，不能反推周增量；Fork 为当前列表中创建时间落在半开周期内的可见记录，不代表净增长。</p>
+              <p class="chart-note">Stars 与 Forks 的本期值按认证 API 中当前仍可见、创建时间落入半开周期的记录统计；分别为 130 与 58，不代表库存净增长。</p>
             </div>
             <div class="chart-box" data-module="weekly-collaboration-chart">
               <h3>本期协作流转</h3>
-              <div class="bars" role="img" aria-label="W31 协作流转：Issue 新增 15 个、关闭 2 个；PR 新增 11 个、合并 13 个、关闭未合并 4 个">
-                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">15</span></div>
-                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:13.3%"></span></span><span class="bar-value">2</span></div>
-                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:73.3%"></span></span><span class="bar-value">11</span></div>
-                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:86.7%"></span></span><span class="bar-value">13</span></div>
-                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:26.7%"></span></span><span class="bar-value">4</span></div>
+              <div class="bars" role="img" aria-label="W31 协作流转：Issue 新增 24 个、关闭 3 个；PR 新增 24 个、合并 20 个、关闭未合并 6 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">24</span></div>
+                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:12.5%"></span></span><span class="bar-value">3</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">24</span></div>
+                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:83.3%"></span></span><span class="bar-value">20</span></div>
+                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:25%"></span></span><span class="bar-value">6</span></div>
               </div>
-              <p class="chart-note">周期内 Issue 净流入 13，PR 净流出 6；当前快照开放 Issue 46 个、PR 16 个。主分支新增 53 个提交，其中 16 个 Merge Commit。</p>
+              <p class="chart-note">周期内 Issue 净流入 21，PR 净流出 2；当前快照开放 Issue 46 个、PR 16 个。主分支新增 56 个提交，本期合并 20 个 PR。</p>
             </div>
           </div>
-          <p class="risk-note"><strong>主要风险：</strong>Issue 输入速度显著高于处置速度，当前开放 P1 21 个、<code>triage/needs-info</code> 28 个；周期内应用与 CLI 均未发版，应用 v0.2.15 已在期后补发。</p>
+          <p class="risk-note"><strong>主要风险：</strong>Issue 输入速度显著高于处置速度，当前开放 P1 21 个、<code>triage/needs-info</code> 28 个；应用 v0.2.15 已在本期发布，但 CLI 仍停留在 0.1.9。</p>
         </section>
 
         <section class="report-section" data-module="feature-iterations" aria-labelledby="feature-title">
@@ -1323,8 +1326,8 @@ footer {
                 </tr>
                 <tr>
                   <td><span class="status ok">已完成</span></td>
-                  <td>认证与 CLI 稳定性修复</td>
-                  <td>修复 <a href="https://github.com/iflytek/skillhub/pull/607">Device Auth Redis 反序列化</a>、<a href="https://github.com/iflytek/skillhub/pull/608">Namespace 坐标</a>与 <a href="https://github.com/iflytek/skillhub/pull/610">403 错误语义</a>，并补充 <a href="https://github.com/iflytek/skillhub/pull/609">Token 撤销回归测试</a>。</td>
+                  <td>认证、CLI 与身份核心</td>
+                  <td>修复 <a href="https://github.com/iflytek/skillhub/pull/607">Device Auth Redis 反序列化</a>、<a href="https://github.com/iflytek/skillhub/pull/608">Namespace 坐标</a>与 <a href="https://github.com/iflytek/skillhub/pull/610">403 错误语义</a>；<a href="https://github.com/iflytek/skillhub/pull/643">统一身份核心</a>在周期内合并。</td>
                 </tr>
                 <tr>
                   <td><span class="status ok">已完成</span></td>
@@ -1334,12 +1337,12 @@ footer {
                 <tr>
                   <td><span class="status ok">已完成</span></td>
                   <td>生态与文档补全</td>
-                  <td><a href="https://github.com/iflytek/skillhub/pull/593">社区 FAQ</a>、<a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw 指南</a>与 <a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>在周期内合并；<a href="https://github.com/iflytek/skillhub/pull/603">生态入口 #603</a>在期后合并。</td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/593">社区 FAQ</a>、<a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw 指南</a>、<a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>与 <a href="https://github.com/iflytek/skillhub/pull/603">生态入口 #603</a>均在周期内合并。</td>
                 </tr>
                 <tr>
-                  <td><span class="status warn">期后完成</span></td>
+                  <td><span class="status ok">已完成</span></td>
                   <td><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a></td>
-                  <td>7 月 30 日 16:25 发布，包含本期已合并的部署、认证、发布与搜索改动；该 Release 位于周期结束后，不计入本期 Release 总数。</td>
+                  <td>7 月 30 日 16:25 发布，包含本期已合并的部署、认证、发布与搜索改动；计入 W31 应用 Release。</td>
                 </tr>
               </tbody>
             </table>
@@ -1349,16 +1352,16 @@ footer {
         <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
           <h2 id="ecosystem-title">三、生态相关进展</h2>
           <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
-            aria-label="W31 开源生态参与信号：新增 Issue 作者 3 位、新增 PR 作者 4 位、合并作者 8 位；当前可见本期创建 Fork 50 个；SkillHub CLI 在 2026 年 7 月 23 日至 29 日 UTC 日桶下载 1041 次">
-            <div class="ecosystem-signal"><strong>3 / 4 / 8</strong><span>新增 Issue 作者 / PR 作者 / 合并作者</span></div>
-            <div class="ecosystem-signal"><strong>50</strong><span>当前可见本期创建 Fork</span></div>
-            <div class="ecosystem-signal"><strong>1,041</strong><span>CLI 下载 · 7 个 UTC 日桶</span></div>
+            aria-label="W31 开源生态参与信号：新增 Issue 作者 2 位、新增 PR 作者 6 位、合并作者 11 位；当前可见本期创建 Fork 58 个；SkillHub CLI 在 2026 年 7 月 24 日至 30 日 UTC 日桶下载 909 次">
+            <div class="ecosystem-signal"><strong>2 / 6 / 11</strong><span>新增 Issue 作者 / PR 作者 / 合并作者</span></div>
+            <div class="ecosystem-signal"><strong>58</strong><span>当前可见本期创建 Fork</span></div>
+            <div class="ecosystem-signal"><strong>909</strong><span>CLI 下载 · 7 个 UTC 日桶</span></div>
             <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
           </div>
           <ul class="ecosystem-list">
-            <li><strong>社区贡献</strong><span>13 个 PR 由 8 位作者完成合并，贡献覆盖部署、认证、CLI、核心流程与文档。</span></li>
+            <li><strong>社区贡献</strong><span>20 个 PR 由 11 位作者完成合并，贡献覆盖部署、认证、CLI、核心流程与文档。</span></li>
             <li><strong>Agent 集成</strong><span><a href="https://github.com/iflytek/skillhub/pull/598">HarnessClaw Engine 指南</a> 已合并，新增一条 Agent 生态接入路径。</span></li>
-            <li><strong>项目可发现性</strong><span><a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>在周期内落地；<a href="https://github.com/iflytek/skillhub/pull/603">Trendshift、AAIF 入口</a>于期后合并。</span></li>
+            <li><strong>项目可发现性</strong><span><a href="https://github.com/iflytek/skillhub/pull/599">README Star/Watch 引导</a>与 <a href="https://github.com/iflytek/skillhub/pull/603">Trendshift、AAIF 入口</a>均在周期内落地。</span></li>
           </ul>
         </section>
 
@@ -1385,38 +1388,38 @@ footer {
           <div class="health-cards">
             <article class="health-card">
               <div class="top"><span class="name">工程稳定性</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">97.6% <small>203/208</small></div>
+              <div class="health-metric">98.2% <small>278/283</small></div>
               <p>有效运行中有 5 次失败。</p>
-              <div class="detail">PR Tests 2 次、PR E2E Tests 3 次。</div>
+              <div class="detail">PR Tests 1 次、PR E2E Tests 3 次、DeepWiki 1 次。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">52 / 52 <small>执行成功</small></div>
-              <p>另有 8 次等待授权、1 次条件跳过。</p>
+              <div class="health-metric">69 / 69 <small>执行成功</small></div>
+              <p>另有 12 次等待授权、18 次条件跳过。</p>
               <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
               <div class="health-metric">28 / 28 <small>Backlog Rescore</small></div>
-              <p>Publish Images 11/11，文档部署 3/3。</p>
-              <div class="detail">Issue Triage 成功 26 次、条件跳过 45 次。</div>
+              <p>Publish Images 12/12，文档部署 4/4。</p>
+              <div class="detail">Issue Triage 成功 36 次、条件跳过 62 次。</div>
             </article>
             <article class="health-card">
-              <div class="top"><span class="name">Release 交付</span><span class="status warn">期内未达成</span></div>
-              <div class="health-metric">0 / 0 <small>应用 / CLI</small></div>
-              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a> 于期后 7 月 30 日 16:25 发布。</p>
+              <div class="top"><span class="name">Release 交付</span><span class="status warn">部分达成</span></div>
+              <div class="health-metric">1 / 0 <small>应用 / CLI</small></div>
+              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a> 于本期 7 月 30 日 16:25 发布。</p>
               <div class="detail">CLI 周期内及期后均无新版本，最新仍为 0.1.9。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">Issue 治理</span><span class="status risk">风险</span></div>
-              <div class="health-metric">+13 <small>本期净流入</small></div>
+              <div class="health-metric">+21 <small>本期净流入</small></div>
               <p>当前开放 46 个，其中 P1 21 个、<code>triage/needs-info</code> 28 个。</p>
               <div class="detail">输入速度明显高于关闭速度，是当前首要治理风险。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">PR 治理</span><span class="status ok">期内净流出</span></div>
-              <div class="health-metric">-6 <small>本期净流量</small></div>
-              <p>合并 13 个、关闭未合并 4 个，当前开放 16 个。</p>
+              <div class="health-metric">-2 <small>本期净流量</small></div>
+              <p>合并 20 个、关闭未合并 6 个，当前开放 16 个。</p>
               <div class="detail">当前 30 天以上 PR 为 3 个，仍需逐项做关闭或推进决策。</div>
             </article>
           </div>
@@ -1424,22 +1427,22 @@ footer {
 
         <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
           <h2 id="ci-title">CI 与自动化执行</h2>
-          <p class="section-lead">统计期内有 288 条 Actions 记录，其中 203 次成功、5 次失败、27 次等待授权、49 次跳过、4 次取消。</p>
+          <p class="section-lead">统计期内有 451 条 Actions 记录，其中 278 次成功、5 次失败、43 次等待授权、119 次跳过、6 次取消。</p>
           <div class="chart-box" data-module="actions-outcome-chart">
             <h3>Actions 结果构成</h3>
-            <div class="segbar" role="img" aria-label="W31 Actions 共 288 条记录：成功 203，失败 5，等待授权 27，条件跳过 49，取消 4">
-              <span class="seg-success" style="width:70.49%"></span>
-              <span class="seg-failure" style="width:1.74%"></span>
-              <span class="seg-auth" style="width:9.38%"></span>
-              <span class="seg-skipped" style="width:17.01%"></span>
-              <span class="seg-cancelled" style="width:1.39%"></span>
+            <div class="segbar" role="img" aria-label="W31 Actions 共 451 条记录：成功 278，失败 5，等待授权 43，条件跳过 119，取消 6">
+              <span class="seg-success" style="width:61.64%"></span>
+              <span class="seg-failure" style="width:1.11%"></span>
+              <span class="seg-auth" style="width:9.53%"></span>
+              <span class="seg-skipped" style="width:26.39%"></span>
+              <span class="seg-cancelled" style="width:1.33%"></span>
             </div>
             <div class="chart-legend" aria-hidden="true">
-              <span><i class="seg-success"></i>成功 <b>203</b></span>
+              <span><i class="seg-success"></i>成功 <b>278</b></span>
               <span><i class="seg-failure"></i>失败 <b>5</b></span>
-              <span><i class="seg-auth"></i>等待授权 <b>27</b></span>
-              <span><i class="seg-skipped"></i>跳过 <b>49</b></span>
-              <span><i class="seg-cancelled"></i>取消 <b>4</b></span>
+              <span><i class="seg-auth"></i>等待授权 <b>43</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>119</b></span>
+              <span><i class="seg-cancelled"></i>取消 <b>6</b></span>
             </div>
           </div>
           <div class="table-wrap">
@@ -1449,19 +1452,19 @@ footer {
                 <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
               </thead>
               <tbody>
-                <tr><td>PR Tests</td><td class="number">50</td><td class="number">38</td><td class="number">2</td><td class="number">8</td><td class="number">2</td></tr>
-                <tr><td>PR E2E Tests</td><td class="number">39</td><td class="number">25</td><td class="number">3</td><td class="number">8</td><td class="number">3</td></tr>
-                <tr><td>PR Scripts</td><td class="number">15</td><td class="number">12</td><td class="number">0</td><td class="number">3</td><td class="number">0</td></tr>
-                <tr><td>Security</td><td class="number">61</td><td class="number">52</td><td class="number">0</td><td class="number">8</td><td class="number">1</td></tr>
-                <tr><td>Issue Triage</td><td class="number">71</td><td class="number">26</td><td class="number">0</td><td class="number">0</td><td class="number">45</td></tr>
+                <tr><td>PR Tests</td><td class="number">84</td><td class="number">51</td><td class="number">1</td><td class="number">12</td><td class="number">20</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">73</td><td class="number">36</td><td class="number">3</td><td class="number">12</td><td class="number">22</td></tr>
+                <tr><td>PR Scripts</td><td class="number">36</td><td class="number">30</td><td class="number">0</td><td class="number">6</td><td class="number">0</td></tr>
+                <tr><td>Security</td><td class="number">99</td><td class="number">69</td><td class="number">0</td><td class="number">12</td><td class="number">18</td></tr>
+                <tr><td>Issue Triage</td><td class="number">98</td><td class="number">36</td><td class="number">0</td><td class="number">0</td><td class="number">62</td></tr>
                 <tr><td>Issue Backlog Rescore</td><td class="number">28</td><td class="number">28</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Publish Images</td><td class="number">11</td><td class="number">11</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>Deploy Docs</td><td class="number">3</td><td class="number">3</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>其他自动化</td><td class="number">10</td><td class="number">8</td><td class="number">0</td><td class="number">0</td><td class="number">2</td></tr>
+                <tr><td>Publish Images</td><td class="number">12</td><td class="number">12</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>Deploy Docs</td><td class="number">4</td><td class="number">4</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>其他自动化</td><td class="number">17</td><td class="number">12</td><td class="number">1</td><td class="number">1</td><td class="number">3</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>本期薄弱点：</strong>5 次失败来自 PR Tests 2 次和 PR E2E Tests 3 次；等待授权共 27 次，不计入有效成功率分母。</p>
+          <p class="risk-note"><strong>本期薄弱点：</strong>5 次失败来自 PR Tests 1 次、PR E2E Tests 3 次和 DeepWiki 1 次；等待授权共 43 次，不计入有效成功率分母。</p>
         </section>
 
         <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
@@ -1469,11 +1472,11 @@ footer {
           <div class="health-grid">
             <article class="health-note">
               <h3>安全与供应链</h3>
-              <p>Security 52 次实际执行全部成功。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
+              <p>Security 69 次实际执行全部成功。公开数据无法确认 Dependabot、CodeQL 未修复告警和生产扫描任务数量。</p>
             </article>
             <article class="health-note">
               <h3>Release 交付</h3>
-              <p>周期内应用与 CLI Release 均为 0；<a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a> 于期后 7 月 30 日 16:25 发布。#608 的 Namespace 修复尚未进入 npm CLI 0.1.9。</p>
+              <p>周期内应用 Release 为 1、CLI Release 为 0；<a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">应用 v0.2.15</a> 于 7 月 30 日 16:25 发布。#608 的 Namespace 修复尚未进入 npm CLI 0.1.9。</p>
             </article>
           </div>
           <h3>Issue 健康</h3>
@@ -1516,7 +1519,7 @@ footer {
 
         <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
           <h2 id="response-title">社区响应</h2>
-          <p>15 个新增 Issue 中，<a href="https://github.com/iflytek/skillhub/issues/604">#604</a> 在周期内关闭；#604—#606 已形成 #607—#610 的修复或回归。<a href="https://github.com/iflytek/skillhub/issues/602">#602</a> 提出 MCP 广场和专家包方向，其余新输入以认证、事务一致性和 Web 工程问题为主。该口径不等同于首次维护者响应 SLA。</p>
+          <p>24 个新增 Issue 中，<a href="https://github.com/iflytek/skillhub/issues/604">#604</a> 与 <a href="https://github.com/iflytek/skillhub/issues/611">#611</a> 在周期内关闭；#604—#606 已形成 #607—#610 的修复或回归。新增输入主要集中在认证、事务一致性、身份联邦和 Web 工程问题；该口径不等同于首次维护者响应 SLA。</p>
         </section>
       </div>
 
@@ -1530,8 +1533,8 @@ footer {
         <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
           <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
           <div class="flow-summary">
-            <div class="flow-item"><strong>Issue +15 / -2</strong><span>净流入 13 · 当前快照开放 46</span></div>
-            <div class="flow-item"><strong>PR +11 / 合并 13</strong><span>关闭未合并 4 · 净流出 6 · 当前开放 16</span></div>
+            <div class="flow-item"><strong>Issue +24 / -3</strong><span>净流入 21 · 当前快照开放 46</span></div>
+            <div class="flow-item"><strong>PR +24 / 合并 20</strong><span>关闭未合并 6 · 净流出 2 · 当前开放 16</span></div>
           </div>
 
           <h3>新增 Issue（按价值排序）</h3>
@@ -1541,12 +1544,13 @@ footer {
               <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前进展</th></tr></thead>
               <tbody>
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/604">#604 Device Auth Redis 反序列化</a> / <a href="https://github.com/iflytek/skillhub/issues/605">#605 Token 撤销后仍放行</a> / <a href="https://github.com/iflytek/skillhub/issues/606">#606 CLI Namespace 与 403 语义</a></td><td>影响 CLI 登录、凭证撤销和命名空间解析。</td><td>#604 已在周期内关闭；#607—#610 已合并，#605、#606 仍需核对关闭条件。</td></tr>
-                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/611">#611 删除版本残留子外键</a> / <a href="https://github.com/iflytek/skillhub/issues/612">#612 扫描任务早于事务提交</a></td><td>直接影响版本删除和发布扫描一致性。</td><td>#611 于期后关闭；#612 仍开放，需补事务后触发回归。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/611">#611 删除版本残留子外键</a> / <a href="https://github.com/iflytek/skillhub/issues/612">#612 扫描任务早于事务提交</a></td><td>直接影响版本删除和发布扫描一致性。</td><td>#611 于本期关闭；#612 仍开放，需补事务后触发回归。</td></tr>
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/613">#613 并发 OAuth 绑定 500</a> / <a href="https://github.com/iflytek/skillhub/issues/614">#614 旧 Session 阻断公开 API</a></td><td>影响登录与公开技能访问。</td><td>当前仍开放，需覆盖并发约束和失效会话回归。</td></tr>
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/615">#615 审核审计部分成功</a> / <a href="https://github.com/iflytek/skillhub/issues/617">#617 首次发布坐标竞争</a></td><td>可能造成客户端认知与服务端状态不一致。</td><td>当前仍开放，优先处理幂等与事务一致性。</td></tr>
                 <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/616">#616 MVC 客户端错误返回 500</a> / <a href="https://github.com/iflytek/skillhub/issues/618">#618 Web 类型隔离</a></td><td>分别影响 API 错误语义和前端构建稳定性。</td><td>#618 已有开放 PR #619；#616 仍待实现。</td></tr>
                 <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/620">#620 审核进度</a> / <a href="https://github.com/iflytek/skillhub/issues/621">#621 主题持久化</a> / <a href="https://github.com/iflytek/skillhub/issues/622">#622 通知轮询</a></td><td>均有用户体验价值，但实现范围与优先级不同。</td><td>仍处于议题阶段，应先拆验收标准再排期。</td></tr>
-                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/602">#602 MCP 广场与专家包</a></td><td>有生态扩展价值，但会扩大 SkillHub 的产品与维护边界。</td><td>先确认与 Skill 注册表、集合和 Agent 集成的关系，再决定是否拆分实施。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/628">#628 身份联邦架构</a> / <a href="https://github.com/iflytek/skillhub/issues/629">#629 外部身份可信属性</a> / <a href="https://github.com/iflytek/skillhub/issues/634">#634 禁用旧账户合并</a> / <a href="https://github.com/iflytek/skillhub/issues/640">#640 身份核心</a></td><td>集中影响外部身份信任、账户接管风险和统一身份边界。</td><td>#640 已形成并合并 #643；其余事项继续按迁移与安全门禁推进。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/626">#626</a> / <a href="https://github.com/iflytek/skillhub/issues/627">#627 部署 Smoke Test</a></td><td>影响持久环境和受限 Ingress 下的发布验证。</td><td>需将环境假设改为显式配置，并保留可观察失败。</td></tr>
               </tbody>
             </table>
           </div>
@@ -1558,11 +1562,11 @@ footer {
               <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
               <tbody>
                 <tr><td>新增并合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/607">#607 Device Auth</a> / <a href="https://github.com/iflytek/skillhub/pull/608">#608 CLI Namespace</a> / <a href="https://github.com/iflytek/skillhub/pull/609">#609 Token 回归</a> / <a href="https://github.com/iflytek/skillhub/pull/610">#610 403 语义</a></td><td>4 个新增 PR 均已合并，快速处理认证与 CLI 缺陷。</td></tr>
-                <tr><td>新增并合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/599">#599 README 引导</a> / <a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传</a></td><td>覆盖项目可发现性与发布一致性，均在周期内创建并合并。</td></tr>
+                <tr><td>本期合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/599">#599 README 引导</a> / <a href="https://github.com/iflytek/skillhub/pull/601">#601 驳回版本重传</a></td><td>两项在 W30 创建，本期完成项目可发现性与发布一致性交付。</td></tr>
                 <tr><td>新增待审</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/623">#623 OAuth 回跳</a> / <a href="https://github.com/iflytek/skillhub/pull/624">#624 React 19 Portal 崩溃</a></td><td>直接影响登录回跳和 Web 稳定性，建议优先完成回归。</td></tr>
                 <tr><td>新增待审</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/619">#619 Web 类型隔离</a></td><td>回应 #618，当前仍开放，需先确认构建环境隔离边界。</td></tr>
-                <tr><td>期后合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/603">#603 生态入口</a></td><td>周期内创建、期末仍开放；7 月 30 日 09:13 合并，不计入本期合并数。</td></tr>
-                <tr><td>新增后关闭</td><td><span class="value-level value-c">C</span></td><td><a href="https://github.com/iflytek/skillhub/pull/600">#600 发布项目网站</a></td><td>周期内创建并关闭，未合并。</td></tr>
+                <tr><td>新增并合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/603">#603 生态入口</a></td><td>7 月 24 日创建、7 月 30 日合并，计入本期新增与合并。</td></tr>
+                <tr><td>新增并合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/643">#643 身份核心</a> / <a href="https://github.com/iflytek/skillhub/pull/641">#641 版本依赖删除</a> / <a href="https://github.com/iflytek/skillhub/pull/648">#648 身份门禁</a> / <a href="https://github.com/iflytek/skillhub/pull/649">#649 Binding V2</a></td><td>7 月 30 日完成身份核心、治理安全和迁移护栏交付。</td></tr>
                 <tr><td>本期合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/443">#443</a> / <a href="https://github.com/iflytek/skillhub/pull/445">#445</a> / <a href="https://github.com/iflytek/skillhub/pull/480">#480</a> / <a href="https://github.com/iflytek/skillhub/pull/560">#560</a></td><td>部署与认证：Nginx、Helm、OAuth Provider 与登录页恢复。</td></tr>
                 <tr><td>本期合并</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/592">#592 搜索索引重建</a></td><td>核心流程：标签变更后异步重建搜索索引。</td></tr>
                 <tr><td>本期合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/593">#593</a> / <a href="https://github.com/iflytek/skillhub/pull/598">#598</a></td><td>生态与文档：FAQ 与 HarnessClaw 指南。</td></tr>
@@ -1624,7 +1628,7 @@ footer {
           <details data-module="cleanup-queue">
             <summary>展开：本周关闭未合并的 PR</summary>
             <div class="details-body">
-              <p>长期 PR <a href="https://github.com/iflytek/skillhub/pull/442">#442</a>、<a href="https://github.com/iflytek/skillhub/pull/457">#457</a>、<a href="https://github.com/iflytek/skillhub/pull/460">#460</a>，以及本期新增的 <a href="https://github.com/iflytek/skillhub/pull/600">#600</a> 在周期内关闭且未合并。配合 13 个合并 PR，本期 PR 净流出 6 个；当前开放 16 个的快照另含期后变化。</p>
+              <p>长期 PR <a href="https://github.com/iflytek/skillhub/pull/442">#442</a>、<a href="https://github.com/iflytek/skillhub/pull/457">#457</a>、<a href="https://github.com/iflytek/skillhub/pull/460">#460</a>，以及本期新增后被替代的 <a href="https://github.com/iflytek/skillhub/pull/637">#637</a>、<a href="https://github.com/iflytek/skillhub/pull/638">#638</a>、<a href="https://github.com/iflytek/skillhub/pull/642">#642</a> 在周期内关闭且未合并。配合 20 个合并 PR，本期 PR 净流出 2 个；当前开放 16 个。</p>
             </div>
           </details>
         </section>
@@ -1640,15 +1644,15 @@ footer {
         <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
           <h2 id="method-title">统计口径</h2>
           <ul class="method-list">
-            <li><strong>统计周期</strong><span>2026-07-23 00:00—2026-07-30 00:00，Asia/Shanghai，采用半开区间 <code>[period_start, period_end)</code>；对应 UTC 为 7 月 22 日 16:00 至 7 月 29 日 16:00。</span></li>
-            <li><strong>当前快照</strong><span>2026-07-31 14:35；开放队列、仓库累计数及年龄结构均取该时点，周期结束后的变化不计入本期流量。</span></li>
-            <li><strong>周期衔接</strong><span>W30 截止时间与 W31 起始时间均为 7 月 23 日 00:00，相邻报告无重叠；边界时刻事件只进入后一周期。</span></li>
-            <li><strong>Star 证据</strong><span>当前 Stars 为 4,890；未取得周期起止两份可比库存快照，因此不报告 Star 周增量，也不使用当前 Stargazer 列表反推净增长。</span></li>
-            <li><strong>Fork 证据</strong><span>当前 Forks 为 703；50 表示当前列表中创建时间落在本期的可见记录，不代表 Fork 库存净增长。</span></li>
+            <li><strong>统计周期</strong><span>展示为 2026-07-24 00:00—2026-07-30 23:59，Asia/Shanghai；程序过滤采用等价半开区间 <code>[2026-07-24 00:00, 2026-07-31 00:00)</code>，对应 UTC 为 7 月 23 日 16:00 至 7 月 30 日 16:00。</span></li>
+            <li><strong>当前快照</strong><span>2026-07-31 14:35；开放队列、Fork 累计数及年龄结构取该时点。Star 总量与新增证据更新于 16:35；周期结束后的变化不计入本期流量。</span></li>
+            <li><strong>周期衔接</strong><span>W30 的排他截止与 W31 起始均为 7 月 24 日 00:00，相邻报告无重叠；周四 23:59 后的事件进入下一期。</span></li>
+            <li><strong>Star 证据</strong><span>7 月 31 日 16:35 的当前 Stars 为 4,849；130 表示同次认证 API 查询中，<code>starred_at</code> 落入本期且当前仍可见的 Stargazer。完整分页数量与仓库总数均为 4,849；该值不是周期净增长，也不能替代起止库存快照。</span></li>
+            <li><strong>Fork 证据</strong><span>当前 Forks 为 703；58 表示当前列表中创建时间落在本期的可见记录，不代表 Fork 库存净增长。</span></li>
             <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权、条件跳过和取消不进入分母。</span></li>
             <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告分开统计；价值 A—D 为人工治理判断。</span></li>
-            <li><strong>Release</strong><span>周期内应用与 CLI Release 均为 0；应用 v0.2.15 于 7 月 30 日 16:25 发布，属于期后进展，不计入本期总数。</span></li>
-            <li><strong>npm 下载</strong><span>1,041 次覆盖 2026-07-23—2026-07-29 的 UTC 日桶，与 Asia/Shanghai 半开周期不完全对齐，因此仅作为带覆盖范围的生态观察，不称为完整周总量。</span></li>
+            <li><strong>Release</strong><span>周期内应用 Release 为 1、CLI Release 为 0；应用 v0.2.15 于 7 月 30 日 16:25 发布，计入本期。</span></li>
+            <li><strong>npm 下载</strong><span>909 次覆盖 2026-07-24—2026-07-30 的 UTC 日桶，与 Asia/Shanghai 半开周期不完全对齐，因此仅作为带覆盖范围的生态观察，不称为完整周总量。</span></li>
             <li><strong>推广数据</strong><span>文章、直播、社区分享和合作项目由维护者补录；本期未提供，因而不展示推广模块，也不记为 0。</span></li>
           </ul>
         </section>
@@ -1660,9 +1664,9 @@ footer {
               <caption>来源覆盖</caption>
               <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
               <tbody>
-                <tr><td>GitHub REST API</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer</td><td>Traffic 与私有安全告警不可见。</td></tr>
-                <tr><td>Git 标签与提交历史</td><td>主分支提交、Merge Commit 与 Release 时间核对</td><td>v0.2.15 属于期后；CLI 仍以 npm 0.1.9 为最新版本。</td></tr>
-                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 的 7 个 UTC 日桶</td><td>1,041 次下载不等同于独立用户，且覆盖范围与本报告时区边界不完全对齐。</td></tr>
+                <tr><td>GitHub API（认证）</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer <code>starred_at</code></td><td>没有周期起止两份库存快照；当前可见新增不等于净增长。</td></tr>
+                <tr><td>Git 标签与提交历史</td><td>主分支提交、合并与 Release 时间核对</td><td>v0.2.15 计入本期；CLI 仍以 npm 0.1.9 为最新版本。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 的 7 个 UTC 日桶</td><td>909 次下载不等同于独立用户，且覆盖范围与本报告时区边界不完全对齐。</td></tr>
                 <tr><td>维护者人工判断</td><td>价值排序、推广动作和产品边界</td><td>推广动作尚未提供。</td></tr>
               </tbody>
             </table>

--- a/weekly/source.json
+++ b/weekly/source.json
@@ -1,4 +1,4 @@
 {
   "repository": "https://github.com/XiaoSeS/skillhub-weekly.git",
-  "commit": "7750af08bd6d4c86552d0201de9e7b6d0f7f2b05"
+  "commit": "ce6d9cdb8668926b8bfd02c5e2ef5f6ed426ac0a"
 }


### PR DESCRIPTION
## What

- mirror the approved XiaoSeS weekly site at commit `ce6d9cdb8668926b8bfd02c5e2ef5f6ed426ac0a`
- align W29, W30, and W31 to the Friday 00:00 through Thursday 23:59 reporting cadence
- retain authenticated W31 Star evidence and include application release v0.2.15 in the correct period

## Why

The weekly release/report cadence closes on Thursday at 23:59. The official mirror still used the earlier boundary and therefore disagreed with the approved standalone Pages site.

Closes #659

## How

- synchronize `site/`, `assets/`, and `scripts/` from the reviewed standalone repository
- update `weekly/source.json` to the exact standalone merge commit
- keep the existing self-contained Notion-light HTML, charts, tabs, and modular sections unchanged

## Testing

- `validate_report.py` for W29, W30, and W31: 0 errors, 0 warnings
- byte-for-byte parity for `site/`, `assets/`, and `scripts/`
- `npm ci && npm run build` in `docs/skillhub`
- build into `docs/skillhub/.vitepress/dist/weekly`
- `python3 weekly/scripts/validate_site.py docs/skillhub/.vitepress/dist/weekly`
- `git diff --check`

## Impact

Documentation/Pages content only. No application runtime or API changes. After merge, the existing `Deploy Docs` workflow will publish the updated `/weekly/` routes.