### PR TITLE
fix(auth): omit account merge request bodies from logs

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/RequestLoggingFilter.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/RequestLoggingFilter.java
@@ -37,7 +37,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             "/sse"
     );
     private static final Set<String> SENSITIVE_BODY_PREFIXES = Set.of(
-            "/api/v1/auth/"
+            "/api/v1/auth/",
+            "/api/v1/account/merge"
     );
     private final SensitiveLogSanitizer sensitiveLogSanitizer;
 

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/filter/RequestLoggingFilterTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/filter/RequestLoggingFilterTest.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -201,6 +203,43 @@ class RequestLoggingFilterTest {
                     .doesNotContain("ST-request-log-secret")
                     .doesNotContain("state-secret")
                     .doesNotContain("body-secret");
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/account/merge/reauthenticate/local",
+            "/api/v1/account/merge/intents/merge-intent/secondary-auth/local",
+            "/api/v1/account/merge/verify"
+    })
+    void doFilterInternal_omitsAccountMergeBody(String requestUri)
+            throws Exception {
+        RequestLoggingFilter filter = filter();
+        attachAppender();
+        MockHttpServletRequest request =
+                new MockHttpServletRequest("POST", requestUri);
+        request.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        request.setContent(
+                """
+                {"username":"secondary-user","password":"body-secret",
+                 "verificationToken":"verification-secret"}
+                """.getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response =
+                new MockHttpServletResponse();
+
+        filter.doFilter(
+                request,
+                response,
+                (req, res) -> req.getReader().lines().count());
+
+        assertThat(loggedMessages()).anySatisfy(message -> {
+            assertThat(message)
+                    .contains("POST " + requestUri)
+                    .doesNotContain("secondary-user")
+                    .doesNotContain("body-secret")
+                    .doesNotContain("verification-secret")
+                    .doesNotContain("Body:");
         });
     }
 


### PR DESCRIPTION
## What

- omit request bodies for all `/api/v1/account/merge*` routes
- add regression coverage for primary reauthentication, secondary local proof, and legacy verification

## Why

The account merge flow accepts passwords and legacy verification tokens. The request logging filter
already omitted `/api/v1/auth/*` bodies, but the new account merge route family was outside that
boundary and could write credentials to application logs.

Follow-up to #668. Relates to #662.

## How

Extend the existing sensitive body prefix list to cover the complete account merge route family.
Request metadata such as method, sanitized target, status, duration, address, content type, and user
agent remains available; only the body is omitted.

## Testing

- reproduced the leak with three failing `RequestLoggingFilterTest` parameter cases
- verified the same cases pass after the filter change
- targeted backend reactor test:
  `./mvnw -pl skillhub-app -am -Dtest=RequestLoggingFilterTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Impact

No API or persistence change. This only reduces sensitive request-body logging for account merge
routes.
