### PR TITLE
fix(observability): avoid raw user IDs in generic exception logs

### DIFF
--- a/docs/superpowers/plans/2026-07-31-observability-redact-user-id.md
+++ b/docs/superpowers/plans/2026-07-31-observability-redact-user-id.md
@@ -1,0 +1,299 @@
+# Generic Exception Log User ID Redaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep generic exception logs diagnostically useful while replacing stable user IDs with a low-cardinality authenticated/anonymous state.
+
+**Architecture:** Limit the production change to `GlobalExceptionHandler`: all three generic exception log templates call one private authentication-state resolver and never format principal names. Capture the class logger in focused unit tests so assertions cover the final formatted messages while API responses, audit records, and metrics remain untouched.
+
+**Tech Stack:** Java 21, Spring Boot 3.2, Spring Security, SLF4J/Logback, JUnit 5, Mockito, AssertJ, Maven.
+
+---
+
+## File map
+
+- Modify `server/skillhub-app/src/main/java/com/iflytek/skillhub/exception/GlobalExceptionHandler.java`: replace raw user attribution in handled, unhandled, and storage failure logs with authentication state.
+- Modify `server/skillhub-app/src/test/java/com/iflytek/skillhub/exception/GlobalExceptionHandlerTest.java`: capture formatted Logback messages and cover authenticated, anonymous, and account-merge failure paths.
+
+### Task 1: Prove stable IDs leak from generic exception logs
+
+**Files:**
+- Test: `server/skillhub-app/src/test/java/com/iflytek/skillhub/exception/GlobalExceptionHandlerTest.java`
+
+- [ ] **Step 1: Add reusable log capture and authenticated request fixtures**
+
+Add a Logback `ListAppender<ILoggingEvent>`, detach it in `@AfterEach`, retain the `RequestIdAccessor` created in `setUp`, and create an authenticated request with a `PlatformPrincipal` whose ID is `stable-user-123`:
+
+```java
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.iflytek.skillhub.auth.merge.AccountMergeException;
+import com.iflytek.skillhub.auth.merge.AccountMergeFailureCode;
+import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
+import com.iflytek.skillhub.storage.StorageAccessException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+private static final String STABLE_USER_ID = "stable-user-123";
+private final Logger logger =
+        (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+private ListAppender<ILoggingEvent> appender;
+private RequestIdAccessor requestIdAccessor;
+
+@AfterEach
+void tearDown() {
+    if (appender != null) {
+        logger.detachAppender(appender);
+        appender.stop();
+    }
+}
+
+private void authenticateRequest() {
+    PlatformPrincipal principal = new PlatformPrincipal(
+            STABLE_USER_ID, "User", "user@example.com", null, "local", Set.of("USER"));
+    when(request.getUserPrincipal()).thenReturn(
+            new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+}
+
+private void attachAppender() {
+    logger.setLevel(Level.INFO);
+    appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+}
+
+private List<String> loggedMessages() {
+    return appender.list.stream()
+            .map(ILoggingEvent::getFormattedMessage)
+            .toList();
+}
+```
+
+In `setUp`, replace the local declaration with the retained field assignment:
+
+```java
+requestIdAccessor = new RequestIdAccessor();
+```
+
+- [ ] **Step 2: Add failing tests for handled, unhandled, storage, and anonymous paths**
+
+Use `requestIdAccessor.open("request-123")` around each handler invocation. Assert the relevant formatted message contains the unchanged diagnosis fields plus `authentication=authenticated` or `authentication=anonymous`, and does not contain `STABLE_USER_ID` or `userId=`. Parameterize account-merge handling with `MERGE_REAUTH_REQUIRED`, `MERGE_CONFLICT`, and `ACCOUNT_MERGE_UNAVAILABLE` to cover 401, 409, and 503 responses:
+
+```java
+@ParameterizedTest
+@EnumSource(value = AccountMergeFailureCode.class, names = {
+        "MERGE_REAUTH_REQUIRED", "MERGE_CONFLICT", "ACCOUNT_MERGE_UNAVAILABLE"
+})
+void handleAccountMergeException_shouldLogAuthenticationWithoutStableUserId(
+        AccountMergeFailureCode failureCode) {
+    authenticateRequest();
+    attachAppender();
+    when(request.getMethod()).thenReturn("POST");
+    when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+            .thenReturn("/api/v1/auth/account-merge/intents/test/confirm");
+
+    try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+        ResponseEntity<?> response = handler.handleAccountMergeException(
+                new AccountMergeException(failureCode), request);
+        assertThat(response.getStatusCode()).isEqualTo(failureCode.status());
+    }
+
+    assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+            .contains("requestId=request-123")
+            .contains("status=" + failureCode.status().value())
+            .contains("method=POST")
+            .contains("path=/api/v1/auth/account-merge/intents/test/confirm")
+            .contains("authentication=authenticated")
+            .contains("code=" + failureCode.messageCode())
+            .doesNotContain(STABLE_USER_ID)
+            .doesNotContain("userId="));
+}
+```
+
+Add these focused tests for the other two templates and the anonymous state:
+
+```java
+@Test
+void handleGlobalException_shouldLogAuthenticationWithoutStableUserId() {
+    authenticateRequest();
+    attachAppender();
+    when(request.getMethod()).thenReturn("GET");
+    when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+            .thenReturn("/api/v1/skills/sensitive");
+
+    try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+        ResponseEntity<ApiResponse<Void>> response = handler.handleGlobalException(
+                new RuntimeException("boom"), request);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+            .contains("Unhandled API exception")
+            .contains("requestId=request-123")
+            .contains("method=GET")
+            .contains("path=/api/v1/skills/sensitive")
+            .contains("authentication=authenticated")
+            .doesNotContain(STABLE_USER_ID)
+            .doesNotContain("userId="));
+}
+
+@Test
+void handleStorageAccess_shouldLogAuthenticationWithoutStableUserId() {
+    authenticateRequest();
+    attachAppender();
+    when(request.getMethod()).thenReturn("GET");
+    when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+            .thenReturn("/api/v1/skills/test/download");
+
+    StorageAccessException exception = new StorageAccessException(
+            "download", "skills/test.zip", new RuntimeException("unavailable"));
+    try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+        ResponseEntity<ApiResponse<Void>> response = handler.handleStorageAccess(exception, request);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+            .contains("Object storage unavailable")
+            .contains("requestId=request-123")
+            .contains("method=GET")
+            .contains("path=/api/v1/skills/test/download")
+            .contains("authentication=authenticated")
+            .contains("operation=download")
+            .contains("key=skills/test.zip")
+            .doesNotContain(STABLE_USER_ID)
+            .doesNotContain("userId="));
+}
+
+@Test
+void handleAsyncRequestTimeout_shouldLogAnonymousAuthenticationState() {
+    attachAppender();
+    when(request.getRequestURI()).thenReturn("/api/v1/publish");
+    when(request.getMethod()).thenReturn("POST");
+    when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+            .thenReturn("/api/v1/publish");
+
+    try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+        handler.handleAsyncRequestTimeout(new AsyncRequestTimeoutException(), request);
+    }
+
+    assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+            .contains("API request failed")
+            .contains("requestId=request-123")
+            .contains("status=408")
+            .contains("method=POST")
+            .contains("path=/api/v1/publish")
+            .contains("authentication=anonymous")
+            .contains("code=error.request.timeout")
+            .doesNotContain("userId="));
+}
+```
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cd server && ./mvnw -pl skillhub-app -am -Dtest=GlobalExceptionHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test
+```
+
+Expected: the new log assertions fail because production messages still contain `userId=stable-user-123` and do not contain `authentication=authenticated`.
+
+### Task 2: Replace raw user attribution with authentication state
+
+**Files:**
+- Modify: `server/skillhub-app/src/main/java/com/iflytek/skillhub/exception/GlobalExceptionHandler.java`
+- Test: `server/skillhub-app/src/test/java/com/iflytek/skillhub/exception/GlobalExceptionHandlerTest.java`
+
+- [ ] **Step 1: Change the three log templates and shared resolver**
+
+Remove the unused `PlatformPrincipal` import. In object-storage, unhandled, and handled-exception messages, replace `userId={}` with `authentication={}` and replace `resolveUserId(request)` with `resolveAuthenticationState(request)`. Implement only the low-cardinality resolver:
+
+```java
+private String resolveAuthenticationState(HttpServletRequest request) {
+    if (request.getUserPrincipal() instanceof Authentication authentication
+            && authentication.isAuthenticated()) {
+        return "authenticated";
+    }
+    return "anonymous";
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+cd server && ./mvnw -pl skillhub-app -am -Dtest=GlobalExceptionHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test
+```
+
+Expected: `GlobalExceptionHandlerTest` passes; account-merge responses remain 401, 409, and 503 as parameterized, and all formatted-message assertions pass.
+
+- [ ] **Step 3: Check formatting and unintended scope**
+
+Run:
+
+```bash
+git diff --check
+git diff -- server/skillhub-app/src/main/java/com/iflytek/skillhub/exception/GlobalExceptionHandler.java server/skillhub-app/src/test/java/com/iflytek/skillhub/exception/GlobalExceptionHandlerTest.java
+```
+
+Expected: no whitespace errors; production diff changes only the generic log identity field and helper, while the test diff contains only log-capture fixtures and coverage.
+
+- [ ] **Step 4: Commit the verified fix**
+
+```bash
+git add server/skillhub-app/src/main/java/com/iflytek/skillhub/exception/GlobalExceptionHandler.java server/skillhub-app/src/test/java/com/iflytek/skillhub/exception/GlobalExceptionHandlerTest.java
+git commit -m "fix(observability): redact generic log user IDs (ISSUE-112)"
+```
+
+### Task 3: Run quality gates and prepare review
+
+**Files:**
+- Verify only; no planned file changes.
+
+- [ ] **Step 1: Run the required backend gate**
+
+Run:
+
+```bash
+make test-backend-app
+```
+
+Expected: all `skillhub-app` tests and dependent module tests pass with zero failures and zero errors.
+
+- [ ] **Step 2: Verify no API or generated-contract drift**
+
+Run:
+
+```bash
+git diff origin/big-main...HEAD --name-only
+```
+
+Expected: only the design, plan, handler, and handler test files appear; no controller, DTO, OpenAPI, generated schema, audit, or metrics files changed, so no API document regeneration is required.
+
+- [ ] **Step 3: Run repository hygiene checks**
+
+Run:
+
+```bash
+git status --short --branch
+git log --format='%h %s' origin/big-main..HEAD
+git diff --check origin/big-main...HEAD
+```
+
+Expected: clean worktree; all commits contain `ISSUE-112`; no whitespace errors.
+
+- [ ] **Step 4: Obtain tester and reviewer results**
+
+Route the completed diff through the SkillHub tester quality gate and then the reviewer seven-dimension checklist. Any failure returns to Task 1 or Task 2 and repeats the full backend gate before review.
+
+- [ ] **Step 5: Push the one PM-designated branch and open the one final PR**
+
+Push only `fix/observability-redact-user-id`. Create a PR targeting `big-main` with title `fix(observability): avoid raw user IDs in generic exception logs`, body containing `Closes ISSUE-112`, the test command/results, API documentation status (“no API behavior or contract change”), and security impact. Do not merge the PR or operate on `main`.

--- a/docs/superpowers/specs/2026-07-31-observability-redact-user-id-design.md
+++ b/docs/superpowers/specs/2026-07-31-observability-redact-user-id-design.md
@@ -1,0 +1,15 @@
+# Generic Exception Log User Attribution Design
+
+## Scope
+
+Issue ISSUE-112 removes stable platform user identifiers from generic operational exception logs. API responses, dedicated audit records, metrics, authentication behavior, and request-body redaction remain unchanged.
+
+## Design
+
+`GlobalExceptionHandler` will replace the `userId` field in handled, unhandled, and object-storage failure log messages with an `authentication` field whose value is either `authenticated` or `anonymous`. The value is derived only from whether the servlet request exposes an authenticated Spring Security principal; no principal name or platform user ID is formatted.
+
+This keeps request ID, status, method, sanitized path, error code, storage operation, and storage key diagnostics intact while making the identity dimension low-cardinality.
+
+## Testing
+
+Focused unit tests will attach an in-memory appender to the handler logger and exercise authenticated and anonymous failures. Assertions will verify that formatted messages retain correlation and diagnosis fields, expose the expected authentication state, and never contain the authenticated principal's stable user ID. Account-merge handled failures will use the same generic logging path, so representative 401, 409, and 503 responses will be checked without changing response behavior.

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/exception/GlobalExceptionHandler.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/exception/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import com.iflytek.skillhub.auth.merge.AccountMergeException;
 import com.iflytek.skillhub.auth.merge.AccountMergeFailureCode;
 import com.iflytek.skillhub.auth.identity.IdentityLinkException;
 import com.iflytek.skillhub.auth.identity.IdentityLinkFailureCode;
-import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.dto.ApiResponse;
 import com.iflytek.skillhub.dto.ApiResponseFactory;
 import com.iflytek.skillhub.dto.AccountMergeErrorResponse;
@@ -244,11 +243,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleStorageAccess(StorageAccessException ex, HttpServletRequest request) {
         metrics.incrementStorageAccessFailure(ex.getOperation());
         logger.warn(
-                "Object storage unavailable [requestId={}, method={}, path={}, userId={}, operation={}, key={}]",
+                "Object storage unavailable [requestId={}, method={}, path={}, authentication={}, operation={}, key={}]",
                 requestIdAccessor.current(),
                 request.getMethod(),
                 sensitiveLogSanitizer.sanitizeRequestTarget(request),
-                resolveUserId(request),
+                resolveAuthenticationState(request),
                 ex.getOperation(),
                 ex.getKey(),
                 ex
@@ -273,11 +272,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGlobalException(Exception ex, HttpServletRequest request) {
         logger.error(
-                "Unhandled API exception [requestId={}, method={}, path={}, userId={}]",
+                "Unhandled API exception [requestId={}, method={}, path={}, authentication={}]",
                 requestIdAccessor.current(),
                 request.getMethod(),
                 sensitiveLogSanitizer.sanitizeRequestTarget(request),
-                resolveUserId(request),
+                resolveAuthenticationState(request),
                 ex
         );
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
@@ -286,12 +285,12 @@ public class GlobalExceptionHandler {
 
     private void logHandledException(HttpStatus status, String messageCode, HttpServletRequest request) {
         logger.info(
-                "API request failed [requestId={}, status={}, method={}, path={}, userId={}, code={}]",
+                "API request failed [requestId={}, status={}, method={}, path={}, authentication={}, code={}]",
                 requestIdAccessor.current(),
                 status.value(),
                 request.getMethod(),
                 sensitiveLogSanitizer.sanitizeRequestTarget(request),
-                resolveUserId(request),
+                resolveAuthenticationState(request),
                 messageCode
         );
     }
@@ -304,13 +303,11 @@ public class GlobalExceptionHandler {
                 apiResponseFactory.error(status.value(), error.messageCode(), error.messageArgs()));
     }
 
-    private String resolveUserId(HttpServletRequest request) {
-        if (!(request.getUserPrincipal() instanceof Authentication authentication)) {
-            return "anonymous";
+    private String resolveAuthenticationState(HttpServletRequest request) {
+        if (request.getUserPrincipal() instanceof Authentication authentication
+                && authentication.isAuthenticated()) {
+            return "authenticated";
         }
-        if (authentication.getPrincipal() instanceof PlatformPrincipal principal) {
-            return principal.userId();
-        }
-        return authentication.getName();
+        return "anonymous";
     }
 }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/exception/GlobalExceptionHandlerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/exception/GlobalExceptionHandlerTest.java
@@ -4,29 +4,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.iflytek.skillhub.auth.exception.AuthFlowException;
+import com.iflytek.skillhub.auth.merge.AccountMergeException;
+import com.iflytek.skillhub.auth.merge.AccountMergeFailureCode;
+import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.dto.ApiResponse;
 import com.iflytek.skillhub.dto.ApiResponseFactory;
 import com.iflytek.skillhub.dto.IdentityLinkErrorResponse;
-import com.iflytek.skillhub.auth.exception.AuthFlowException;
 import com.iflytek.skillhub.metrics.SkillHubMetrics;
 import com.iflytek.skillhub.observability.RequestIdAccessor;
 import com.iflytek.skillhub.security.SensitiveLogSanitizer;
+import com.iflytek.skillhub.storage.StorageAccessException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.support.StaticMessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 
 @ExtendWith(MockitoExtension.class)
 class GlobalExceptionHandlerTest {
+
+    private static final String STABLE_USER_ID = "stable-user-123";
 
     @Mock
     private SensitiveLogSanitizer sensitiveLogSanitizer;
@@ -37,7 +54,11 @@ class GlobalExceptionHandlerTest {
     @Mock
     private HttpServletRequest request;
 
+    private final Logger logger =
+            (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private ListAppender<ILoggingEvent> appender;
     private GlobalExceptionHandler handler;
+    private RequestIdAccessor requestIdAccessor;
 
     @BeforeEach
     void setUp() {
@@ -47,7 +68,7 @@ class GlobalExceptionHandlerTest {
                 "error.auth.local.invalidCredentials",
                 java.util.Locale.getDefault(),
                 "Invalid username or password");
-        RequestIdAccessor requestIdAccessor = new RequestIdAccessor();
+        requestIdAccessor = new RequestIdAccessor();
         ApiResponseFactory responseFactory = new ApiResponseFactory(
                 messageSource,
                 Clock.fixed(Instant.parse("2026-03-20T00:00:00Z"), ZoneOffset.UTC),
@@ -59,6 +80,14 @@ class GlobalExceptionHandlerTest {
                 metrics,
                 requestIdAccessor
         );
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (appender != null) {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
     }
 
     @Test
@@ -134,5 +163,128 @@ class GlobalExceptionHandlerTest {
                 (IdentityLinkErrorResponse) response.getBody();
         assertThat(body.reasonCode())
                 .isEqualTo("REAUTHENTICATION_REQUIRED");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AccountMergeFailureCode.class, names = {
+            "MERGE_REAUTH_REQUIRED", "MERGE_CONFLICT", "ACCOUNT_MERGE_UNAVAILABLE"
+    })
+    void handleAccountMergeException_shouldLogAuthenticationWithoutStableUserId(
+            AccountMergeFailureCode failureCode) {
+        authenticateRequest();
+        attachAppender();
+        when(request.getMethod()).thenReturn("POST");
+        when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+                .thenReturn("/api/v1/auth/account-merge/intents/test/confirm");
+
+        try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+            ResponseEntity<?> response = handler.handleAccountMergeException(
+                    new AccountMergeException(failureCode), request);
+            assertThat(response.getStatusCode()).isEqualTo(failureCode.status());
+        }
+
+        assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+                .contains("requestId=request-123")
+                .contains("status=" + failureCode.status().value())
+                .contains("method=POST")
+                .contains("path=/api/v1/auth/account-merge/intents/test/confirm")
+                .contains("authentication=authenticated")
+                .contains("code=" + failureCode.messageCode())
+                .doesNotContain(STABLE_USER_ID)
+                .doesNotContain("userId="));
+    }
+
+    @Test
+    void handleGlobalException_shouldLogAuthenticationWithoutStableUserId() {
+        authenticateRequest();
+        attachAppender();
+        when(request.getMethod()).thenReturn("GET");
+        when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+                .thenReturn("/api/v1/skills/sensitive");
+
+        try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+            ResponseEntity<ApiResponse<Void>> response = handler.handleGlobalException(
+                    new RuntimeException("boom"), request);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+                .contains("Unhandled API exception")
+                .contains("requestId=request-123")
+                .contains("method=GET")
+                .contains("path=/api/v1/skills/sensitive")
+                .contains("authentication=authenticated")
+                .doesNotContain(STABLE_USER_ID)
+                .doesNotContain("userId="));
+    }
+
+    @Test
+    void handleStorageAccess_shouldLogAuthenticationWithoutStableUserId() {
+        authenticateRequest();
+        attachAppender();
+        when(request.getMethod()).thenReturn("GET");
+        when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+                .thenReturn("/api/v1/skills/test/download");
+
+        StorageAccessException exception = new StorageAccessException(
+                "download", "skills/test.zip", new RuntimeException("unavailable"));
+        try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+            ResponseEntity<ApiResponse<Void>> response = handler.handleStorageAccess(exception, request);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        }
+
+        assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+                .contains("Object storage unavailable")
+                .contains("requestId=request-123")
+                .contains("method=GET")
+                .contains("path=/api/v1/skills/test/download")
+                .contains("authentication=authenticated")
+                .contains("operation=download")
+                .contains("key=skills/test.zip")
+                .doesNotContain(STABLE_USER_ID)
+                .doesNotContain("userId="));
+    }
+
+    @Test
+    void handleAsyncRequestTimeout_shouldLogAnonymousAuthenticationState() {
+        attachAppender();
+        when(request.getRequestURI()).thenReturn("/api/v1/publish");
+        when(request.getMethod()).thenReturn("POST");
+        when(sensitiveLogSanitizer.sanitizeRequestTarget(request))
+                .thenReturn("/api/v1/publish");
+
+        try (RequestIdAccessor.Scope ignored = requestIdAccessor.open("request-123")) {
+            handler.handleAsyncRequestTimeout(new AsyncRequestTimeoutException(), request);
+        }
+
+        assertThat(loggedMessages()).anySatisfy(message -> assertThat(message)
+                .contains("API request failed")
+                .contains("requestId=request-123")
+                .contains("status=408")
+                .contains("method=POST")
+                .contains("path=/api/v1/publish")
+                .contains("authentication=anonymous")
+                .contains("code=error.request.timeout")
+                .doesNotContain("userId="));
+    }
+
+    private void authenticateRequest() {
+        PlatformPrincipal principal = new PlatformPrincipal(
+                STABLE_USER_ID, "User", "user@example.com", null, "local", Set.of("USER"));
+        when(request.getUserPrincipal()).thenReturn(
+                new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+    }
+
+    private void attachAppender() {
+        logger.setLevel(Level.INFO);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    private List<String> loggedMessages() {
+        return appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
     }
 }


### PR DESCRIPTION
## 概述

避免 `GlobalExceptionHandler` 在通用运行日志中输出稳定平台用户 ID，同时保留认证状态和请求诊断字段。

## 变更内容

### 后端实现
- 将 handled、unhandled 与对象存储异常日志中的 `userId` 替换为低基数 `authentication=authenticated|anonymous`
- 保留 request ID、status、method、清洗后的 path、error code、storage operation/key 与异常堆栈
- API 响应、审计记录、指标标签和认证行为均未修改

### API 文档
- 无 API 行为或契约变更，无需更新 OpenAPI 文档或生成前端类型

### 测试覆盖
- 捕获 `GlobalExceptionHandler` 的最终格式化 Logback 消息
- 覆盖 authenticated、anonymous、unhandled、storage failure
- 覆盖 account merge 401、409、503，验证稳定用户 ID 不出现在运行日志中

## 质量门禁

- [x] 聚焦测试：`GlobalExceptionHandlerTest` 11 tests，0 failures，0 errors
- [x] `make BACKEND_TEST_JAVA_OPTIONS='-XX:+EnableDynamicAgentLoading -Duser.language=en -Duser.country=US' test-backend-app`
  - `skillhub-app`: 824 tests，0 failures，0 errors，39 skipped
  - 所有依赖 reactor 模块均 SUCCESS
- [x] `git diff --check origin/big-main...HEAD`
- [x] 无 Controller、DTO、OpenAPI 或 generated schema 变更
- [x] 无前端变更，不需要 Playwright E2E

## 安全考虑

- 通用异常日志不再包含原始稳定用户 ID，降低隐私暴露和高基数索引风险
- dedicated audit domain 保持不变
- 未添加原始用户 ID metric labels

## 相关 Issue

Closes ISSUE-112
Closes #670

## 测试说明

### 本地验证步骤
1. 执行上述聚焦测试，确认 authenticated/anonymous 日志可区分且不包含 `stable-user-123`
2. 执行完整后端门禁，确认所有 reactor 模块通过

### 回归测试范围
- 通用 API 异常响应
- account merge 401/409/503 失败响应
- 对象存储 503 失败响应
- 请求关联与路径清洗字段
