### PR TITLE
feat(deploy): add Helm chart for Kubernetes deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,23 @@ kubectl apply -f deploy/k8s/services.yaml
 kubectl apply -f deploy/k8s/ingress.yaml
 ```
 
+### Helm
+
+A Helm chart is available under [`deploy/helm/skillhub/`](./deploy/helm/skillhub)
+for a values-driven install (backend, frontend, scanner, plus optional in-cluster
+PostgreSQL and Redis):
+
+```bash
+helm install skillhub ./deploy/helm/skillhub \
+  --namespace skillhub --create-namespace \
+  --set ingress.host=skills.example.com \
+  --set bootstrapAdmin.password='<strong-password>' \
+  --set postgresql.auth.password='<strong-db-password>'
+```
+
+See the [chart README](./deploy/helm/skillhub/README.md) for external
+database/Redis, S3 storage, and production hardening options.
+
 ## Smoke Test
 
 A lightweight smoke test script is available at [`scripts/smoke-test.sh`](./scripts/smoke-test.sh).

--- a/README_zh.md
+++ b/README_zh.md
@@ -195,12 +195,19 @@ curl -fsSL https://imageless.oss-cn-beijing.aliyuncs.com/runtime.sh | sh -s -- u
 ### 使用 Kubernetes
 
 ```bash
-# 应用 Kubernetes 清单
-kubectl apply -f deploy/k8s/
+# 方式一：Kustomize 清单（内置数据库）
+kubectl apply -k deploy/k8s/overlays/with-infra/
 
-# 或使用 Helm（即将推出）
-helm install skillhub ./deploy/helm
+# 方式二：Helm Chart（values 驱动，可选内置 PostgreSQL / Redis）
+helm install skillhub ./deploy/helm/skillhub \
+  --namespace skillhub --create-namespace \
+  --set ingress.host=skills.example.com \
+  --set bootstrapAdmin.password='<强密码>' \
+  --set postgresql.auth.password='<数据库强密码>'
 ```
+
+Helm Chart 的完整配置（外部数据库/Redis、S3 存储、生产加固等）见
+[chart README](./deploy/helm/skillhub/README.md)。
 
 ### 环境变量
 
@@ -302,7 +309,7 @@ SkillHub 采用清晰的分层架构：
 - [x] API 令牌管理
 - [x] 账户合并
 - [x] 国际化支持
-- [ ] Helm Chart 部署
+- [x] Helm Chart 部署
 - [ ] 高级搜索过滤器
 - [ ] 技能依赖管理
 - [ ] Webhook 集成

--- a/deploy/helm/skillhub/.helmignore
+++ b/deploy/helm/skillhub/.helmignore
@@ -1,0 +1,9 @@
+# Patterns to ignore when building packages.
+*.tmpl
+.git/
+.gitignore
+.DS_Store
+*.swp
+*.bak
+*.orig
+*~

--- a/deploy/helm/skillhub/Chart.yaml
+++ b/deploy/helm/skillhub/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: skillhub
+description: An enterprise-grade, self-hosted agent skill registry — publish, discover, and govern reusable skill packages.
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/iflytek/skillhub
+sources:
+  - https://github.com/iflytek/skillhub
+keywords:
+  - skillhub
+  - agent-skills
+  - registry
+  - skill-registry
+maintainers:
+  - name: iFlytek Astron
+    url: https://github.com/iflytek/skillhub
+icon: https://raw.githubusercontent.com/iflytek/skillhub/main/skillhub-logo.svg

--- a/deploy/helm/skillhub/README.md
+++ b/deploy/helm/skillhub/README.md
@@ -1,0 +1,122 @@
+# SkillHub Helm Chart
+
+A values-driven Helm chart for deploying [SkillHub](https://github.com/iflytek/skillhub)
+to Kubernetes. It packages the same topology as the Kustomize manifests under
+[`deploy/k8s`](../../k8s) — backend, frontend, scanner, plus optional in-cluster
+PostgreSQL and Redis — behind a single `values.yaml`.
+
+## Prerequisites
+
+- Kubernetes v1.24+
+- Helm v3.8+
+- An ingress controller (nginx by default) if you want host-based access
+- A default StorageClass (for PVCs), unless you disable persistence
+
+## Quick start
+
+```bash
+# From the repository root
+helm install skillhub ./deploy/helm/skillhub \
+  --namespace skillhub --create-namespace
+```
+
+This brings up the full stack with an in-cluster PostgreSQL and Redis.
+
+> ⚠️ The defaults ship demo credentials (`admin` / `ChangeMe!2026`, DB password
+> `change-me`). Override them before any real deployment.
+
+## Common configurations
+
+**Set a hostname and strong secrets:**
+
+```bash
+helm install skillhub ./deploy/helm/skillhub \
+  --namespace skillhub --create-namespace \
+  --set ingress.host=skills.example.com \
+  --set session.cookieSecure=true \
+  --set bootstrapAdmin.password='<strong-password>' \
+  --set postgresql.auth.password='<strong-db-password>'
+```
+
+**Use an external PostgreSQL and Redis:**
+
+```bash
+helm install skillhub ./deploy/helm/skillhub \
+  --namespace skillhub --create-namespace \
+  --set postgresql.enabled=false \
+  --set externalDatabase.url='jdbc:postgresql://db.internal:5432/skillhub' \
+  --set externalDatabase.username=skillhub \
+  --set externalDatabase.password='<db-password>' \
+  --set redis.enabled=false \
+  --set externalRedis.host=redis.internal
+```
+
+**Use S3 / OSS object storage instead of a PVC:**
+
+```bash
+helm install skillhub ./deploy/helm/skillhub \
+  --namespace skillhub --create-namespace \
+  --set storage.provider=s3 \
+  --set storage.s3.endpoint=https://oss-cn-shanghai.aliyuncs.com \
+  --set storage.s3.bucket=skillhub-prod \
+  --set storage.s3.region=cn-shanghai \
+  --set storage.s3.accessKey='<ak>' \
+  --set storage.s3.secretKey='<sk>'
+```
+
+**Bring your own Secret** (recommended for production — keeps credentials out of
+Helm values/history). Create a Secret with the keys listed in
+[`templates/secret.yaml`](./templates/secret.yaml), then:
+
+```bash
+helm install skillhub ./deploy/helm/skillhub \
+  --set existingSecret=my-skillhub-secret
+```
+
+## Key values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.registry` | `ghcr.io/iflytek` | Registry/namespace for all images |
+| `image.tag` | `latest` | Default tag for all components |
+| `imagePullSecrets` | `[]` | Pull secrets for private images |
+| `server.replicas` / `web.replicas` | `1` | Replica counts |
+| `scanner.enabled` | `true` | Deploy the security scanner |
+| `storage.provider` | `local` | `local` (PVC) or `s3` |
+| `storage.persistence.size` | `10Gi` | Skill storage PVC size (local) |
+| `session.cookieSecure` | `false` | Set `true` behind HTTPS |
+| `bootstrapAdmin.username` | `admin` | Initial admin user |
+| `bootstrapAdmin.password` | `ChangeMe!2026` | **Change this** |
+| `postgresql.enabled` | `true` | In-cluster PostgreSQL |
+| `postgresql.auth.password` | `change-me` | **Change this** |
+| `externalDatabase.url` | `""` | JDBC URL when `postgresql.enabled=false` |
+| `redis.enabled` | `true` | In-cluster Redis |
+| `externalRedis.host` | `""` | Redis host when `redis.enabled=false` |
+| `ingress.enabled` | `true` | Create an Ingress |
+| `ingress.host` | `skills.example.com` | Ingress hostname |
+| `existingSecret` | `""` | Use a pre-created Secret instead of rendering one |
+
+See [`values.yaml`](./values.yaml) for the complete list.
+
+## Validate the rendered manifests
+
+```bash
+helm lint ./deploy/helm/skillhub
+helm template skillhub ./deploy/helm/skillhub | kubectl apply --dry-run=client -f -
+```
+
+## Uninstall
+
+```bash
+helm uninstall skillhub --namespace skillhub
+```
+
+PersistentVolumeClaims created by the StatefulSets are retained by default —
+delete them manually if you want to reclaim storage.
+
+## Relationship to the Kustomize manifests
+
+The Kustomize manifests under [`deploy/k8s`](../../k8s) remain the reference,
+hand-editable form. This chart mirrors them and is aimed at users who prefer
+values-driven configuration and versioned Helm releases. The two are kept in
+sync intentionally.

--- a/deploy/helm/skillhub/templates/NOTES.txt
+++ b/deploy/helm/skillhub/templates/NOTES.txt
@@ -1,0 +1,52 @@
+SkillHub has been deployed. 🎉
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Components:
+  - Backend API : {{ include "skillhub.server.fullname" . }}:{{ .Values.server.service.port }}
+  - Frontend    : {{ include "skillhub.web.fullname" . }}:{{ .Values.web.service.port }}
+{{- if .Values.scanner.enabled }}
+  - Scanner     : {{ include "skillhub.scanner.fullname" . }}:{{ .Values.scanner.service.port }}
+{{- end }}
+{{- if .Values.postgresql.enabled }}
+  - PostgreSQL  : in-cluster ({{ include "skillhub.postgresql.fullname" . }})
+{{- else }}
+  - PostgreSQL  : external ({{ .Values.externalDatabase.url }})
+{{- end }}
+{{- if .Values.redis.enabled }}
+  - Redis       : in-cluster ({{ include "skillhub.redis.fullname" . }})
+{{- else }}
+  - Redis       : external ({{ .Values.externalRedis.host }}:{{ .Values.externalRedis.port }})
+{{- end }}
+
+1. Watch the pods come up:
+
+   kubectl get pods -n {{ .Release.Namespace }} -w
+
+{{- if .Values.ingress.enabled }}
+
+2. Access the UI once the Ingress is ready:
+
+   http://{{ .Values.ingress.host }}/
+
+   (Point {{ .Values.ingress.host }} at your ingress controller's address.)
+{{- else }}
+
+2. Ingress is disabled. Port-forward to reach the UI locally:
+
+   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "skillhub.web.fullname" . }} 8080:{{ .Values.web.service.port }}
+   # then open http://localhost:8080
+{{- end }}
+
+3. Default admin login:
+   username: {{ .Values.bootstrapAdmin.username }}
+{{- if .Values.existingSecret }}
+   password: (from existing secret "{{ .Values.existingSecret }}", key bootstrap-admin-password)
+{{- else }}
+   password: (value of bootstrapAdmin.password)
+{{- end }}
+
+⚠️  Change the default admin password and database password before exposing
+    this deployment. See values.yaml: bootstrapAdmin.password and
+    postgresql.auth.password (or supply your own via --set / existingSecret).

--- a/deploy/helm/skillhub/templates/_helpers.tpl
+++ b/deploy/helm/skillhub/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Chart name (respecting nameOverride) */}}
+{{- define "skillhub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Fully qualified app name */}}
+{{- define "skillhub.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Chart label value */}}
+{{- define "skillhub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Component names */}}
+{{- define "skillhub.server.fullname" -}}{{ printf "%s-server" (include "skillhub.fullname" .) }}{{- end -}}
+{{- define "skillhub.web.fullname" -}}{{ printf "%s-web" (include "skillhub.fullname" .) }}{{- end -}}
+{{- define "skillhub.scanner.fullname" -}}{{ printf "%s-scanner" (include "skillhub.fullname" .) }}{{- end -}}
+{{- define "skillhub.postgresql.fullname" -}}{{ printf "%s-postgresql" (include "skillhub.fullname" .) }}{{- end -}}
+{{- define "skillhub.redis.fullname" -}}{{ printf "%s-redis" (include "skillhub.fullname" .) }}{{- end -}}
+{{- define "skillhub.configmap.fullname" -}}{{ printf "%s-config" (include "skillhub.fullname" .) }}{{- end -}}
+{{- define "skillhub.secret.fullname" -}}{{ printf "%s-secret" (include "skillhub.fullname" .) }}{{- end -}}
+{{- define "skillhub.storage.pvcName" -}}{{ printf "%s-storage" (include "skillhub.fullname" .) }}{{- end -}}
+
+{{/* Effective Secret name (existingSecret takes precedence) */}}
+{{- define "skillhub.secretName" -}}
+{{- if .Values.existingSecret -}}{{ .Values.existingSecret }}{{- else -}}{{ include "skillhub.secret.fullname" . }}{{- end -}}
+{{- end -}}
+
+{{/* Common metadata labels */}}
+{{- define "skillhub.labels" -}}
+helm.sh/chart: {{ include "skillhub.chart" . }}
+app.kubernetes.io/part-of: skillhub
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Build a component image reference.
+Usage: {{ include "skillhub.image" (list . .Values.server) }}
+*/}}
+{{- define "skillhub.image" -}}
+{{- $root := index . 0 -}}
+{{- $comp := index . 1 -}}
+{{- printf "%s/%s:%s" $root.Values.image.registry $comp.image.repository (default $root.Values.image.tag $comp.image.tag) -}}
+{{- end -}}
+
+{{/* Datasource (JDBC) resolution */}}
+{{- define "skillhub.datasourceUrl" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "jdbc:postgresql://%s:5432/%s" (include "skillhub.postgresql.fullname" .) .Values.postgresql.auth.database -}}
+{{- else -}}
+{{- required "externalDatabase.url is required when postgresql.enabled=false" .Values.externalDatabase.url -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "skillhub.datasourceUsername" -}}
+{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.username }}{{- else -}}{{ required "externalDatabase.username is required when postgresql.enabled=false" .Values.externalDatabase.username }}{{- end -}}
+{{- end -}}
+
+{{- define "skillhub.datasourcePassword" -}}
+{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.password }}{{- else -}}{{ required "externalDatabase.password is required when postgresql.enabled=false" .Values.externalDatabase.password }}{{- end -}}
+{{- end -}}
+
+{{/* Redis resolution */}}
+{{- define "skillhub.redisHost" -}}
+{{- if .Values.redis.enabled -}}{{ include "skillhub.redis.fullname" . }}{{- else -}}{{ required "externalRedis.host is required when redis.enabled=false" .Values.externalRedis.host }}{{- end -}}
+{{- end -}}
+
+{{- define "skillhub.redisPort" -}}
+{{- if .Values.redis.enabled -}}6379{{- else -}}{{ .Values.externalRedis.port | default 6379 }}{{- end -}}
+{{- end -}}

--- a/deploy/helm/skillhub/templates/configmap.yaml
+++ b/deploy/helm/skillhub/templates/configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "skillhub.configmap.fullname" . }}
+  labels:
+    {{- include "skillhub.labels" . | nindent 4 }}
+data:
+  # Redis
+  redis-host: {{ include "skillhub.redisHost" . | quote }}
+  redis-port: {{ include "skillhub.redisPort" . | quote }}
+
+  # Storage
+  storage-base-path: {{ .Values.storage.basePath | quote }}
+  skillhub-storage-provider: {{ .Values.storage.provider | quote }}
+
+  # Scanner
+  skill-scanner-enabled: {{ .Values.scanner.enabled | quote }}
+  skill-scanner-url: {{ printf "http://%s:%d" (include "skillhub.scanner.fullname" .) (int .Values.scanner.service.port) | quote }}
+  skill-scanner-mode: {{ .Values.scanner.mode | quote }}
+
+  # Bootstrap admin (non-sensitive)
+  bootstrap-admin-enabled: {{ .Values.bootstrapAdmin.enabled | quote }}
+  bootstrap-admin-user-id: {{ .Values.bootstrapAdmin.userId | quote }}
+  bootstrap-admin-username: {{ .Values.bootstrapAdmin.username | quote }}
+  bootstrap-admin-display-name: {{ .Values.bootstrapAdmin.displayName | quote }}
+  bootstrap-admin-email: {{ .Values.bootstrapAdmin.email | quote }}
+
+  # Session
+  session-cookie-secure: {{ .Values.session.cookieSecure | quote }}

--- a/deploy/helm/skillhub/templates/ingress.yaml
+++ b/deploy/helm/skillhub/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "skillhub.fullname" . }}
+  labels:
+    {{- include "skillhub.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.apiPath | default "/api" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "skillhub.server.fullname" . }}
+                port:
+                  number: {{ .Values.server.service.port }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "skillhub.web.fullname" . }}
+                port:
+                  number: {{ .Values.web.service.port }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/postgresql-statefulset.yaml
+++ b/deploy/helm/skillhub/templates/postgresql-statefulset.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "skillhub.postgresql.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.postgresql.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "skillhub.postgresql.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "skillhub.postgresql.fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "skillhub.postgresql.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgresql.image }}
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: spring-datasource-username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: spring-datasource-password
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          {{- with .Values.postgresql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+        {{- if .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClass | quote }}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "skillhub.postgresql.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.postgresql.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgres
+      name: postgres
+  selector:
+    app.kubernetes.io/name: {{ include "skillhub.postgresql.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/redis-statefulset.yaml
+++ b/deploy/helm/skillhub/templates/redis-statefulset.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "skillhub.redis.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.redis.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "skillhub.redis.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "skillhub.redis.fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "skillhub.redis.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports:
+            - containerPort: 6379
+              name: redis
+          command: ["redis-server", "--appendonly", "yes"]
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          {{- with .Values.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size }}
+        {{- if .Values.redis.persistence.storageClass }}
+        storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "skillhub.redis.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.redis.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      name: redis
+  selector:
+    app.kubernetes.io/name: {{ include "skillhub.redis.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/scanner-deployment.yaml
+++ b/deploy/helm/skillhub/templates/scanner-deployment.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.scanner.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "skillhub.scanner.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.scanner.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.scanner.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "skillhub.scanner.fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "skillhub.scanner.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: scanner
+          image: {{ include "skillhub.image" (list . .Values.scanner) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.scanner.service.port }}
+              name: http
+          env:
+            - name: SKILL_SCANNER_LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: skill-scanner-llm-api-key
+                  optional: true
+            - name: SKILL_SCANNER_LLM_MODEL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: skill-scanner-llm-model
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          {{- with .Values.scanner.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/scanner-service.yaml
+++ b/deploy/helm/skillhub/templates/scanner-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.scanner.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "skillhub.scanner.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.scanner.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "skillhub.scanner.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.scanner.service.port }}
+      targetPort: http
+{{- end }}

--- a/deploy/helm/skillhub/templates/secret.yaml
+++ b/deploy/helm/skillhub/templates/secret.yaml
@@ -1,0 +1,29 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "skillhub.secret.fullname" . }}
+  labels:
+    {{- include "skillhub.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Database
+  spring-datasource-url: {{ include "skillhub.datasourceUrl" . | quote }}
+  spring-datasource-username: {{ include "skillhub.datasourceUsername" . | quote }}
+  spring-datasource-password: {{ include "skillhub.datasourcePassword" . | quote }}
+
+  # Bootstrap admin password
+  bootstrap-admin-password: {{ .Values.bootstrapAdmin.password | quote }}
+
+  # GitHub OAuth (optional)
+  oauth2-github-client-id: {{ .Values.oauth2.github.clientId | quote }}
+  oauth2-github-client-secret: {{ .Values.oauth2.github.clientSecret | quote }}
+
+  # Scanner LLM (optional)
+  skill-scanner-llm-api-key: {{ .Values.scanner.llm.apiKey | quote }}
+  skill-scanner-llm-model: {{ .Values.scanner.llm.model | quote }}
+
+  # S3 / OSS storage (optional)
+  skillhub-storage-s3-access-key: {{ .Values.storage.s3.accessKey | quote }}
+  skillhub-storage-s3-secret-key: {{ .Values.storage.s3.secretKey | quote }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/server-deployment.yaml
+++ b/deploy/helm/skillhub/templates/server-deployment.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.server.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "skillhub.server.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.server.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.server.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "skillhub.server.fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "skillhub.server.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: server
+          image: {{ include "skillhub.image" (list . .Values.server) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.server.service.port }}
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: {{ .Values.server.springProfile | quote }}
+
+            # Database
+            - name: SPRING_DATASOURCE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: spring-datasource-url
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: spring-datasource-username
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: spring-datasource-password
+
+            # Redis
+            - name: SPRING_DATA_REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: redis-host
+            - name: SPRING_DATA_REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: redis-port
+
+            # Storage
+            - name: STORAGE_BASE_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: storage-base-path
+            - name: SKILLHUB_STORAGE_PROVIDER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: skillhub-storage-provider
+            {{- if eq .Values.storage.provider "s3" }}
+            - name: SKILLHUB_STORAGE_S3_ENDPOINT
+              value: {{ .Values.storage.s3.endpoint | quote }}
+            - name: SKILLHUB_STORAGE_S3_BUCKET
+              value: {{ .Values.storage.s3.bucket | quote }}
+            - name: SKILLHUB_STORAGE_S3_REGION
+              value: {{ .Values.storage.s3.region | quote }}
+            - name: SKILLHUB_STORAGE_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: skillhub-storage-s3-access-key
+                  optional: true
+            - name: SKILLHUB_STORAGE_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: skillhub-storage-s3-secret-key
+                  optional: true
+            {{- end }}
+
+            # Scanner
+            - name: SKILLHUB_SECURITY_SCANNER_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: skill-scanner-enabled
+            - name: SKILLHUB_SECURITY_SCANNER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: skill-scanner-url
+            - name: SKILLHUB_SECURITY_SCANNER_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: skill-scanner-mode
+
+            # Session
+            - name: SESSION_COOKIE_SECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: session-cookie-secure
+
+            # Bootstrap admin (non-sensitive)
+            - name: BOOTSTRAP_ADMIN_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: bootstrap-admin-enabled
+            - name: BOOTSTRAP_ADMIN_USER_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: bootstrap-admin-user-id
+            - name: BOOTSTRAP_ADMIN_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: bootstrap-admin-username
+            - name: BOOTSTRAP_ADMIN_DISPLAY_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: bootstrap-admin-display-name
+            - name: BOOTSTRAP_ADMIN_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "skillhub.configmap.fullname" . }}
+                  key: bootstrap-admin-email
+
+            # Bootstrap admin password (sensitive)
+            - name: BOOTSTRAP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: bootstrap-admin-password
+                  optional: true
+
+            # OAuth2 GitHub (optional)
+            - name: OAUTH2_GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: oauth2-github-client-id
+                  optional: true
+            - name: OAUTH2_GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "skillhub.secretName" . }}
+                  key: oauth2-github-client-secret
+                  optional: true
+            {{- with .Values.server.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: skillhub-storage
+              mountPath: {{ .Values.storage.basePath }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          {{- with .Values.server.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: skillhub-storage
+          {{- if and (eq .Values.storage.provider "local") .Values.storage.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "skillhub.storage.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/server-service.yaml
+++ b/deploy/helm/skillhub/templates/server-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.server.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "skillhub.server.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.server.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "skillhub.server.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.server.service.port }}
+      targetPort: http
+{{- end }}

--- a/deploy/helm/skillhub/templates/storage-pvc.yaml
+++ b/deploy/helm/skillhub/templates/storage-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and (eq .Values.storage.provider "local") .Values.storage.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "skillhub.storage.pvcName" . }}
+  labels:
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.storage.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.persistence.size }}
+  {{- if .Values.storage.persistence.storageClass }}
+  storageClassName: {{ .Values.storage.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/web-deployment.yaml
+++ b/deploy/helm/skillhub/templates/web-deployment.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.web.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "skillhub.web.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.web.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "skillhub.web.fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "skillhub.web.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: {{ include "skillhub.image" (list . .Values.web) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SKILLHUB_API_UPSTREAM
+              value: {{ printf "http://%s:%d" (include "skillhub.server.fullname" .) (int .Values.server.service.port) | quote }}
+          ports:
+            - containerPort: 80
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /nginx-health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /nginx-health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          {{- with .Values.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/skillhub/templates/web-service.yaml
+++ b/deploy/helm/skillhub/templates/web-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "skillhub.web.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "skillhub.web.fullname" . }}
+    {{- include "skillhub.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "skillhub.web.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.web.service.port }}
+      targetPort: http
+{{- end }}

--- a/deploy/helm/skillhub/values.yaml
+++ b/deploy/helm/skillhub/values.yaml
@@ -1,0 +1,182 @@
+# Default values for the SkillHub Helm chart.
+# This chart mirrors the Kustomize manifests under deploy/k8s and makes them
+# values-driven. See deploy/helm/skillhub/README.md for the full guide.
+
+# -- Override the chart name portion of resource names.
+nameOverride: ""
+# -- Override the full resource name prefix (defaults to <release>-skillhub logic).
+fullnameOverride: ""
+
+image:
+  # -- Registry / namespace prepended to every component image.
+  registry: ghcr.io/iflytek
+  # -- Default image tag applied to all SkillHub components unless overridden per-component.
+  tag: latest
+  # -- Default image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets applied to every pod (e.g. for a private GHCR package).
+imagePullSecrets: []
+# - name: ghcr-secret
+
+# ---------------------------------------------------------------------------
+# Backend API (Spring Boot)
+# ---------------------------------------------------------------------------
+server:
+  enabled: true
+  image:
+    repository: skillhub-server
+    # -- Overrides image.tag for the backend only.
+    tag: ""
+  replicas: 1
+  springProfile: docker
+  service:
+    port: 8080
+  # -- Extra environment variables appended to the backend container.
+  extraEnv: []
+  resources: {}
+
+# ---------------------------------------------------------------------------
+# Frontend (React / Nginx)
+# ---------------------------------------------------------------------------
+web:
+  enabled: true
+  image:
+    repository: skillhub-web
+    tag: ""
+  replicas: 1
+  service:
+    port: 80
+  resources: {}
+
+# ---------------------------------------------------------------------------
+# Security scanner
+# ---------------------------------------------------------------------------
+scanner:
+  enabled: true
+  image:
+    repository: skillhub-scanner
+    tag: ""
+  replicas: 1
+  # -- Scan mode: upload | download.
+  mode: upload
+  service:
+    port: 8000
+  # -- Optional LLM configuration for scanning (stored in the chart Secret).
+  llm:
+    apiKey: ""
+    model: ""
+  resources: {}
+
+# ---------------------------------------------------------------------------
+# Skill package storage
+# ---------------------------------------------------------------------------
+storage:
+  # -- Storage provider: local | s3
+  provider: local
+  basePath: /var/lib/skillhub/storage
+  # PVC used when provider=local.
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  # S3 / OSS settings, used when provider=s3.
+  s3:
+    endpoint: ""
+    bucket: ""
+    region: ""
+    accessKey: ""
+    secretKey: ""
+
+session:
+  # -- Set to true when serving over HTTPS so the session cookie is marked Secure.
+  cookieSecure: false
+
+bootstrapAdmin:
+  enabled: true
+  userId: docker-admin
+  username: admin
+  displayName: Platform Admin
+  email: admin@example.com
+  # -- CHANGE THIS for any real deployment.
+  password: "ChangeMe!2026"
+
+oauth2:
+  github:
+    clientId: ""
+    clientSecret: ""
+
+# ---------------------------------------------------------------------------
+# In-cluster PostgreSQL (StatefulSet). Disable to use an external database.
+# ---------------------------------------------------------------------------
+postgresql:
+  enabled: true
+  image: postgres:16-alpine
+  auth:
+    database: skillhub
+    username: skillhub
+    # -- CHANGE THIS for any real deployment.
+    password: change-me
+  persistence:
+    size: 10Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Used when postgresql.enabled=false.
+externalDatabase:
+  # -- Full JDBC URL, e.g. jdbc:postgresql://my-host:5432/skillhub
+  url: ""
+  username: ""
+  password: ""
+
+# ---------------------------------------------------------------------------
+# In-cluster Redis (StatefulSet). Disable to use an external Redis.
+# ---------------------------------------------------------------------------
+redis:
+  enabled: true
+  image: redis:7-alpine
+  persistence:
+    size: 5Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+# Used when redis.enabled=false.
+externalRedis:
+  host: ""
+  port: 6379
+
+# ---------------------------------------------------------------------------
+# Ingress
+# ---------------------------------------------------------------------------
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+  host: skills.example.com
+  # -- API prefix routed to the backend service.
+  apiPath: /api
+  tls: []
+  # - secretName: skillhub-tls
+  #   hosts:
+  #     - skills.example.com
+
+# ---------------------------------------------------------------------------
+# Use a pre-existing Secret instead of one rendered by this chart.
+# It must provide the same keys as templates/secret.yaml.
+# ---------------------------------------------------------------------------
+existingSecret: ""


### PR DESCRIPTION
## Summary

- **What changed?** Adds a values-driven **Helm chart** under `deploy/helm/skillhub/`, plus wires it into the README Kubernetes sections and marks the "Helm Chart 部署" roadmap item done.
- **Why is this needed?** K8s deployment was previously only hand-editable Kustomize manifests. The chart lowers the integration barrier for the many automated/clone-driven users (see #678) and fulfills the existing `helm install skillhub ./deploy/helm`「即将推出」placeholder in the README.

Closes #678.

## What's in the chart

Mirrors the existing Kustomize manifests (`deploy/k8s`) 1:1, made values-driven:

- **Workloads**: backend (`skillhub-server`), frontend (`skillhub-web`), scanner (`skillhub-scanner`) — same env, ports, and probes as the manifests.
- **Data stores**: optional in-cluster PostgreSQL & Redis StatefulSets (`postgresql.enabled` / `redis.enabled`), or point at an external DB/Redis (`externalDatabase.*` / `externalRedis.*`) — matching the `with-infra` / `external` overlays.
- **Storage**: `storage.provider=local` (PVC) or `s3` (injects `SKILLHUB_STORAGE_S3_*` + credentials from the Secret).
- **Config/secrets**: ConfigMap + Secret with the same keys as `secret.yaml.example`; `existingSecret` escape hatch to keep credentials out of Helm values.
- **Ingress**: toggle, className, host, TLS, `/api`→backend and `/`→frontend routing.
- `NOTES.txt`, a chart `README.md`, and `_helpers.tpl` for consistent naming/labels.

With release name `skillhub` the rendered Service DNS is identical to the Kustomize output (`skillhub-server`, `skillhub-postgresql`, …), so it's drop-in compatible.

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Deploy-only change (no app code). Validated the chart locally with Helm v3.16.3:

```bash
helm lint ./deploy/helm/skillhub                         # 0 failures
helm template skillhub ./deploy/helm/skillhub            # 14 objects, all valid k8s YAML
# alternate configs also render cleanly:
#   postgresql.enabled=false + externalDatabase.*  -> required-value guard fires when url missing
#   redis.enabled=false + externalRedis.host
#   storage.provider=s3
#   ingress.enabled=false, scanner.enabled=false
#   existingSecret=... -> no Secret object rendered
```

> Note: this repo has no Helm CI yet. A `helm lint` / `ct lint` GitHub Action would be a good follow-up so the chart stays in sync with the Kustomize manifests.

## Risk

- User-facing impact: additive — new opt-in deployment path; existing Kustomize flow untouched.
- Deployment or migration impact: none (nothing runs it automatically).
- Rollback approach: revert the commit; the chart directory is self-contained.

## Notes

- Related issue: #678
- Follow-up work: publish the chart to an OCI registry (GHCR) / gh-pages Helm repo for `helm install oci://…`; add chart-testing CI.
- Docs updated: README.md / README_zh.md Kubernetes sections + roadmap checkbox.
