### PR TITLE
docs: add Related Projects section linking astron-agent and astron-rpa

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,13 @@ npx clawhub publish ./my-skill
 
 [astron-agent](https://github.com/iflytek/astron-agent) is the iFlytek Astron agent framework. Skills stored in SkillHub can be referenced and loaded by astron-agent, enabling a governed, versioned skill lifecycle from development to production.
 
+## Related Projects
+
+SkillHub is part of the **[iFlytek Astron](https://github.com/iflytek)** open-source ecosystem. If SkillHub is useful to you, these sibling projects may be too:
+
+- **[astron-agent](https://github.com/iflytek/astron-agent)** — Enterprise-grade, commercial-friendly agentic workflow platform for building next-generation SuperAgents. Skills published to SkillHub can be loaded and run by astron-agent.
+- **[astron-rpa](https://github.com/iflytek/astron-rpa)** — Agent-ready RPA suite with out-of-the-box automation tools, built for individuals and enterprises.
+
 ---
 
 > 🌟 **Show & Tell** — Have you built something with SkillHub? We'd love to hear about it!

--- a/README_zh.md
+++ b/README_zh.md
@@ -351,6 +351,13 @@ npx clawhub publish ./my-skill
 
 [astron-agent](https://github.com/iflytek/astron-agent) 是科大讯飞星火智能体框架。存储在 SkillHub 中的技能可以被 astron-agent 引用和加载，实现从开发到生产的受治理、版本化的技能生命周期。
 
+## 相关项目
+
+SkillHub 是 **[讯飞 Astron](https://github.com/iflytek)** 开源生态的一部分。如果 SkillHub 对你有帮助，这些同生态的姊妹项目你可能也会用到：
+
+- **[astron-agent](https://github.com/iflytek/astron-agent)** — 企业级、商业友好的智能体工作流平台，用于构建新一代 SuperAgent；发布到 SkillHub 的技能可被 astron-agent 加载和运行。
+- **[astron-rpa](https://github.com/iflytek/astron-rpa)** — 开箱即用、面向 Agent 的 RPA 套件，为个人与企业提供自动化工具。
+
 ---
 
 > 🌟 **展示与分享** — 您使用 SkillHub 构建了什么？我们很想听听！


### PR DESCRIPTION
## Summary

- **What changed?** Adds a compact **Related Projects** section to `README.md` and `README_zh.md`, linking the sibling iFlytek Astron open-source projects — [astron-agent](https://github.com/iflytek/astron-agent) and [astron-rpa](https://github.com/iflytek/astron-rpa).
- **Why is this needed?** SkillHub currently has no cross-links to its sibling repos, so traffic to SkillHub doesn't help visitors discover the wider ecosystem. A short Related Projects module improves discoverability and cross-repo navigation. Descriptions are taken verbatim from each repo's GitHub "About".

Placed right after the "Usage with Agent Platforms" section so it sits in the ecosystem neighborhood (and next to the Agent Skills ecosystem section from #676, once that merges).

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed
- [ ] OpenAPI SDK regenerated or checked when API contracts changed
- [ ] Smoke test run when relevant

Docs-only change (two README files) — no code, API, or build surface touched, so the checks above are not applicable. Links verified against live repos.

## Risk

- User-facing impact: README content only.
- Deployment or migration impact: none.
- Rollback approach: revert the commit.

## Notes

- Related PR: #676 (Agent Skills ecosystem positioning) — thematically adjacent; this one is standalone-mergeable and does not conflict with it.
