### PR TITLE
docs(weekly): mirror reviewed W32 report

### DIFF
--- a/weekly/site/reports.json
+++ b/weekly/site/reports.json
@@ -3,9 +3,9 @@
   "reports": [
     {
       "week": "2026-W32",
-      "title": "SkillHub 开源周报｜2026 年第 32 周（数据截至 15:24）",
-      "period": "2026-07-31—2026-08-06（截至 15:24）",
-      "snapshot": "2026-08-06 15:24 Asia/Shanghai",
+      "title": "SkillHub 开源周报｜2026 年第 32 周",
+      "period": "2026-07-31—2026-08-06",
+      "snapshot": "2026-08-06 18:47 Asia/Shanghai",
       "path": "reports/2026-W32/"
     },
     {

--- a/weekly/site/reports/2026-W32/index.html
+++ b/weekly/site/reports/2026-W32/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta name="description" content="SkillHub 2026 年第 32 周开源周报快照：仓库状态、主分支迭代、生态进展及项目健康明细。">
-  <title>SkillHub 开源周报｜2026 年第 32 周（数据截至 15:24）</title>
+  <meta name="description" content="SkillHub 2026 年第 32 周开源周报：仓库状态、主分支迭代、生态进展及项目健康明细。">
+  <title>SkillHub 开源周报｜2026 年第 32 周</title>
   <script>document.documentElement.classList.add('js')</script>
   <style data-report-theme="notion-light">
 :root {
@@ -1195,19 +1195,19 @@ footer {
   <a class="skip-link" href="#report-content">跳到报告正文</a>
   <article class="report"
     data-period-start="2026-07-31T00:00:00+08:00"
-    data-period-end="2026-08-06T15:24:48+08:00"
+    data-period-end="2026-08-06T18:47:26+08:00"
     data-period-boundary="[)"
-    data-period-status="partial"
-    data-snapshot-at="2026-08-06T15:24:48+08:00"
+    data-period-status="manual-close"
+    data-snapshot-at="2026-08-06T18:47:26+08:00"
     data-pr-target-branch="main"
     data-star-evidence="current-visible-arrivals"
     data-star-api-status="success"
-    data-star-arrivals="72"
-    data-star-observed-total="4839"
-    data-star-observed-at="2026-08-06T15:28:48+08:00"
+    data-star-arrivals="77"
+    data-star-observed-total="4844"
+    data-star-observed-at="2026-08-06T18:50:41+08:00"
     data-star-previous-observed-total="4849"
     data-star-previous-observed-at="2026-07-31T16:35:00+08:00"
-    data-star-observation-delta="-10"
+    data-star-observation-delta="-5"
     data-star-start-at=""
     data-star-end-at="">
     <header class="masthead">
@@ -1223,18 +1223,18 @@ footer {
           <a href="https://github.com/iflytek/skillhub">GitHub 仓库</a>
         </nav>
       </div>
-      <h1>2026 年第 32 周 · 数据截至 15:24</h1>
+      <h1>2026 年第 32 周</h1>
       <p class="report-sub">项目健康 · 版本交付 · 开源生态 · Issue/PR 流转与价值队列</p>
       <div class="header-grid">
         <div class="meta-card">
           <div class="meta-grid">
             <div class="meta-item">
               <span class="key">正式周期</span>
-              <span class="value">2026-07-31 00:00—2026-08-06 23:59 · Asia/Shanghai</span>
+              <span class="value">2026-07-31—2026-08-06 · Asia/Shanghai</span>
             </div>
             <div class="meta-item">
-              <span class="key">数据截止</span>
-              <span class="value">2026-08-06 15:24 · 部分周期快照</span>
+              <span class="key">PR 统计分支</span>
+              <span class="value"><code>main</code></span>
             </div>
             <div class="meta-item">
               <span class="key">项目仓库</span>
@@ -1252,14 +1252,14 @@ footer {
             <strong>需关注</strong>
             <span class="status warn">Attention</span>
           </div>
-          <p>截至 15:24，Issue 与面向 <code>main</code> 的 PR 开放队列分别净减少 9 和 6，说明维护吞吐高于新增输入；其中处理了 9 个期初存量 PR。Actions 有效成功率为 98.0%，最后一次失败发生于 8 月 1 日。主要风险已从队列规模转向队列质量：16/33 个开放 Issue 仍需补充信息，13 个已超过 30 天。</p>
+          <p>本周 Issue 与面向 <code>main</code> 的 PR 开放队列分别净减少 9 和 6，维护吞吐高于新增输入，并处理了 9 个期初存量 PR。Actions 有效成功率为 94.2%，17 次失败中有 12 次集中在批量测试部署。主要风险是自动化稳定性和队列质量：16/33 个开放 Issue 仍需补充信息，13 个已超过 30 天。</p>
         </div>
       </div>
       <div class="metrics" aria-label="四项核心指标">
-        <div class="metric"><strong>4,839</strong><span>Stars · 较上次观测 -10</span></div>
-        <div class="metric"><strong>765</strong><span>Forks · 本期当前可见创建 80 · 试用信号</span></div>
-        <div class="metric"><strong>98.0%</strong><span>Actions 有效成功率 · 244/249 · 执行稳定</span></div>
-        <div class="metric"><strong>0 / 0</strong><span>应用 / CLI Release · 截至 15:24 · 尚待结报</span></div>
+        <div class="metric"><strong>4,844</strong><span>Stars · 较上次观测 -5</span></div>
+        <div class="metric"><strong>768</strong><span>Forks · 仓库当前库存</span></div>
+        <div class="metric"><strong>94.2%</strong><span>Actions 有效成功率 · 276/293 · 需关注</span></div>
+        <div class="metric"><strong>0 / 0</strong><span>应用 / CLI Release · 本期未发布</span></div>
       </div>
     </header>
 
@@ -1292,30 +1292,30 @@ footer {
               <div class="snapshot-list">
                 <div class="snapshot-row">
                   <span class="snapshot-label">Stars</span>
-                  <strong>4,839</strong>
-                  <span class="snapshot-change">较 7 月 31 日 16:35 观测值减少 10</span>
+                  <strong>4,844</strong>
+                  <span class="snapshot-change">较 7 月 31 日 16:35 观测值减少 5</span>
                 </div>
                 <div class="snapshot-row">
                   <span class="snapshot-label">Forks</span>
-                  <strong>765</strong>
-                  <span class="snapshot-change positive">当前可见本期创建 80</span>
+                  <strong>768</strong>
+                  <span class="snapshot-change">仓库库存字段</span>
                 </div>
               </div>
-              <p class="chart-note">Star 库存从上次观测的 4,849 降至 4,839，观测点间净变化为 -10。本期当前可见新增 72 个 Stargazer，但新增与取消会同时发生，72 不是净增长。两次观测不在严格周期边界，因此 -10 也不表述为周净增长。Fork 的 80 是本期当前仍可见的创建记录，同样不是库存净增长。</p>
+              <p class="chart-note">Star 库存从上次观测的 4,849 降至 4,844，观测点间净变化为 -5。本期当前可见新增 77 个 Stargazer，但新增与取消会同时发生，77 不是净增长。Fork 列表接口返回 1,023 条，与仓库库存字段 768 不一致，因此不展示本期 Fork 到达数。</p>
             </div>
             <div class="chart-box" data-module="weekly-collaboration-chart">
               <h3>本期协作流转</h3>
-              <div class="bars" role="img" aria-label="W32 截至快照协作流转：Issue 新增 13 个、关闭 22 个；目标为 main 的 PR 新增 17 个、合并 16 个、关闭未合并 7 个">
+              <div class="bars" role="img" aria-label="W32 协作流转：Issue 新增 13 个、关闭 22 个；目标为 main 的 PR 新增 18 个、合并 17 个、关闭未合并 7 个">
                 <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:59.1%"></span></span><span class="bar-value">13</span></div>
                 <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">22</span></div>
-                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:77.3%"></span></span><span class="bar-value">17</span></div>
-                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:72.7%"></span></span><span class="bar-value">16</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:81.8%"></span></span><span class="bar-value">18</span></div>
+                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:77.3%"></span></span><span class="bar-value">17</span></div>
                 <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:31.8%"></span></span><span class="bar-value">7</span></div>
               </div>
-              <p class="chart-note">Issue 关闭量比新增量多 9；面向 <code>main</code> 的 PR 完成 23 个、比新增多 6 个，当前开放 PR 为 10 个。其中 9 个完成项来自期初存量，说明主分支维护队列正在收缩。</p>
+              <p class="chart-note">Issue 关闭量比新增量多 9；面向 <code>main</code> 的 PR 完成 24 个、比新增多 6 个，当前开放 PR 为 10 个。其中 9 个完成项来自期初存量，说明主分支维护队列正在收缩。</p>
             </div>
           </div>
-          <p class="risk-note"><strong>数据解读：</strong>17 个新增 PR 均以 <code>main</code> 为目标，其中 11 个由维护者 XiaoSeS 创建，包含功能修复、周报同步和替代 PR，不等于 17 项独立功能。队列数量正在下降，但 48.5% 的开放 Issue 仍需补充信息；W32 Release 在 23:59 截止前仍是待完成事项。</p>
+          <p class="risk-note"><strong>数据解读：</strong>18 个新增 PR 均以 <code>main</code> 为目标，其中 12 个由维护者 XiaoSeS 创建，包含功能修复、周报同步和替代 PR，不等于 18 项独立功能。队列数量正在下降，但 48.5% 的开放 Issue 仍需补充信息；本期没有发布新的应用或 CLI 版本。</p>
         </section>
 
         <section class="report-section" data-module="feature-iterations" aria-labelledby="feature-title">
@@ -1348,16 +1348,16 @@ footer {
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>发布口径：</strong>截至快照，W32 没有应用或 CLI Release。报告只确认公开可验证的分支与 Release 状态；由于没有生产部署证据，不声称任何应用改动已经上线。</p>
+          <p class="risk-note"><strong>发布口径：</strong>W32 没有应用或 CLI Release。报告只确认公开可验证的分支与 Release 状态；由于没有生产部署证据，不声称任何应用改动已经上线。</p>
         </section>
 
         <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
           <h2 id="ecosystem-title">三、生态相关进展</h2>
           <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
-            aria-label="W32 截至快照开源生态参与信号：新增 Issue 作者 5 位、面向 main 的新增 PR 作者 3 位、合并社区贡献者 2 位；当前可见本期创建 Fork 80 个；SkillHub CLI 在 2026 年 7 月 31 日至 8 月 5 日 UTC 日桶下载 351 次">
+            aria-label="W32 开源生态参与信号：新增 Issue 作者 5 位、面向 main 的新增 PR 作者 3 位、合并社区贡献者 2 位；仓库 Fork 库存 768；SkillHub CLI 在 2026 年 7 月 31 日至 8 月 5 日的 6 个已结算 UTC 日桶下载 504 次">
             <div class="ecosystem-signal"><strong>5 / 3 / 2</strong><span>新增 Issue 作者 / PR 作者 / 合并社区贡献者</span></div>
-            <div class="ecosystem-signal"><strong>80</strong><span>当前可见本期创建 Fork</span></div>
-            <div class="ecosystem-signal"><strong>351</strong><span>CLI 下载 · 6 个 UTC 日桶</span></div>
+            <div class="ecosystem-signal"><strong>768</strong><span>Fork 仓库库存</span></div>
+            <div class="ecosystem-signal"><strong>504</strong><span>CLI 下载 · 6 个已结算 UTC 日桶</span></div>
             <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
           </div>
           <ul class="ecosystem-list">
@@ -1365,14 +1365,14 @@ footer {
             <li><strong>生态文档</strong><span><a href="https://github.com/iflytek/skillhub/pull/676">anthropics/skills 定位</a>与 <a href="https://github.com/iflytek/skillhub/pull/682">Related Projects</a> 已合入仓库 <code>main</code>，不表述为应用上线。</span></li>
             <li><strong>社区协作</strong><span><a href="https://github.com/iflytek/skillhub/pull/687">HER Hack-Astron 模板</a>已合并；6 个 UTC 日桶内仓库获得 5,220 次浏览与 3,423 次克隆。</span></li>
           </ul>
-          <p class="chart-note"><strong>数据解读：</strong>2 位社区贡献者完成 6 个合并 PR，体现的是贡献深度；Fork 创建和 npm 下载体现尝试与使用兴趣。三类信号来自不同人群，不能解释为转化漏斗。</p>
+          <p class="chart-note"><strong>数据解读：</strong>2 位社区贡献者完成 6 个合并 PR，体现贡献深度；Fork 仅展示可信的库存字段，npm 下载反映包获取行为。三类信号来自不同人群，不能解释为转化漏斗。</p>
         </section>
 
         <aside class="next-actions" data-module="next-actions" aria-labelledby="next-title">
           <h2 id="next-title">下周关注</h2>
           <p>以下动作延续到下一期跟踪。</p>
           <ol>
-            <li>完成应用与 CLI 的 W32 Release，或记录明确的跳过决策。</li>
+            <li>形成下一期应用或 CLI Release，并把本期未发布原因写入发布记录。</li>
             <li>合并或给出 <a href="https://github.com/iflytek/skillhub/pull/688">#688</a> 的审查结论，并为 <a href="https://github.com/iflytek/skillhub/issues/690">#690 扫描重试</a>形成可执行方案。</li>
             <li>完成 <a href="https://github.com/iflytek/skillhub/pull/576">#576</a>/<a href="https://github.com/iflytek/skillhub/pull/692">#692</a> 子路径部署决策，关闭已被新实现替代的旧 PR。</li>
           </ol>
@@ -1382,7 +1382,7 @@ footer {
       <div class="tab-panel" id="panel-health" role="tabpanel" tabindex="0"
         aria-labelledby="tab-health" data-panel="health" hidden>
         <div class="panel-intro">
-          <p>项目健康详情：用于维护者判断工程、交付和治理风险。</p>
+          <p>项目健康详情：用于判断工程、交付和治理风险。</p>
           <p>成功流水线不等同于“无漏洞”。</p>
         </div>
 
@@ -1390,28 +1390,28 @@ footer {
           <h2 id="health-summary-title">项目健康状态</h2>
           <div class="health-cards">
             <article class="health-card">
-              <div class="top"><span class="name">工程稳定性</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">98.0% <small>244/249</small></div>
-              <p>有效运行中有 5 次失败。</p>
-              <div class="detail">失败集中在 PR Tests 2 次、PR E2E 3 次；8 月 1 日后未再观察到失败，说明后半程已恢复稳定。</div>
+              <div class="top"><span class="name">工程稳定性</span><span class="status warn">需关注</span></div>
+              <div class="health-metric">94.2% <small>276/293</small></div>
+              <p>有效运行中有 17 次失败。</p>
+              <div class="detail">12 次集中在 8 月 6 日的批量测试部署，另有 PR Tests 2 次、PR E2E 3 次；常规 PR 检查总体稳定，但批量部署链路需要复盘。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">安全流水线</span><span class="status ok">稳定</span></div>
-              <div class="health-metric">64 / 64 <small>执行成功</small></div>
-              <p>另有 9 次等待授权、20 次条件跳过。</p>
+              <div class="health-metric">67 / 67 <small>执行成功</small></div>
+              <p>另有 8 次等待授权、39 次条件跳过。</p>
               <div class="detail">执行成功不代表公开漏洞数量为 0。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">自动化运营</span><span class="status warn">需关注</span></div>
               <div class="health-metric">27 / 27 <small>Backlog Rescore</small></div>
-              <p>Publish Images 7 次成功，文档部署 3/3。</p>
+              <p>Publish Images 7 次成功，文档部署 4/4。</p>
               <div class="detail">Issue Triage 成功 19 次、跳过 56 次、取消 1 次。</div>
             </article>
             <article class="health-card">
-              <div class="top"><span class="name">Release 交付</span><span class="status warn">待结报</span></div>
+              <div class="top"><span class="name">Release 交付</span><span class="status warn">未达目标</span></div>
               <div class="health-metric">0 / 0 <small>应用 / CLI</small></div>
-              <p>截至 15:24，W32 尚无应用或 CLI Release。</p>
-              <div class="detail">正式周期尚未结束，不能判定未达成；最新应用版本仍为 <a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a>。</div>
+              <p>W32 没有应用或 CLI Release。</p>
+              <div class="detail">“每周一个 Release”目标本期未达成；最新应用版本仍为 <a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a>。</div>
             </article>
             <article class="health-card">
               <div class="top"><span class="name">Issue 治理</span><span class="status warn">改善中</span></div>
@@ -1422,7 +1422,7 @@ footer {
             <article class="health-card">
               <div class="top"><span class="name">PR 治理</span><span class="status ok">期内净流出</span></div>
               <div class="health-metric">-6 <small>本期净流量</small></div>
-              <p>面向 <code>main</code>：新增 17、合并 16、关闭未合并 7，当前开放 10 个。</p>
+              <p>面向 <code>main</code>：新增 18、合并 17、关闭未合并 7，当前开放 10 个。</p>
               <div class="detail">本期处理 9 个期初存量 PR；剩余队列中 3 个超过 30 天。</div>
             </article>
           </div>
@@ -1430,21 +1430,21 @@ footer {
 
         <section class="report-section" data-module="workflow-execution" aria-labelledby="ci-title">
           <h2 id="ci-title">CI 与自动化执行</h2>
-          <p class="section-lead">截至快照共有 446 条 Actions 记录，其中 244 次成功、5 次失败、44 次等待授权、146 次跳过、7 次取消。</p>
+          <p class="section-lead">本期共有 562 条 Actions 记录，其中 276 次成功、17 次失败、40 次等待授权、222 次跳过、7 次取消。</p>
           <div class="chart-box" data-module="actions-outcome-chart">
             <h3>Actions 结果构成</h3>
-            <div class="segbar" role="img" aria-label="W32 截至快照 Actions 共 446 条记录：成功 244，失败 5，等待授权 44，条件跳过 146，取消 7">
-              <span class="seg-success" style="width:54.71%"></span>
-              <span class="seg-failure" style="width:1.12%"></span>
-              <span class="seg-auth" style="width:9.87%"></span>
-              <span class="seg-skipped" style="width:32.74%"></span>
-              <span class="seg-cancelled" style="width:1.57%"></span>
+            <div class="segbar" role="img" aria-label="W32 Actions 共 562 条记录：成功 276，失败 17，等待授权 40，条件跳过 222，取消 7">
+              <span class="seg-success" style="width:49.11%"></span>
+              <span class="seg-failure" style="width:3.02%"></span>
+              <span class="seg-auth" style="width:7.12%"></span>
+              <span class="seg-skipped" style="width:39.50%"></span>
+              <span class="seg-cancelled" style="width:1.25%"></span>
             </div>
             <div class="chart-legend" aria-hidden="true">
-              <span><i class="seg-success"></i>成功 <b>244</b></span>
-              <span><i class="seg-failure"></i>失败 <b>5</b></span>
-              <span><i class="seg-auth"></i>等待授权 <b>44</b></span>
-              <span><i class="seg-skipped"></i>跳过 <b>146</b></span>
+              <span><i class="seg-success"></i>成功 <b>276</b></span>
+              <span><i class="seg-failure"></i>失败 <b>17</b></span>
+              <span><i class="seg-auth"></i>等待授权 <b>40</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>222</b></span>
               <span><i class="seg-cancelled"></i>取消 <b>7</b></span>
             </div>
           </div>
@@ -1455,22 +1455,23 @@ footer {
                 <tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消</th></tr>
               </thead>
               <tbody>
-                <tr><td>Security</td><td class="number">93</td><td class="number">64</td><td class="number">0</td><td class="number">9</td><td class="number">20</td></tr>
+                <tr><td>Security</td><td class="number">114</td><td class="number">67</td><td class="number">0</td><td class="number">8</td><td class="number">39</td></tr>
                 <tr><td>Issue Triage</td><td class="number">76</td><td class="number">19</td><td class="number">0</td><td class="number">0</td><td class="number">57</td></tr>
-                <tr><td>PR Tests</td><td class="number">76</td><td class="number">45</td><td class="number">2</td><td class="number">9</td><td class="number">20</td></tr>
-                <tr><td>PR E2E</td><td class="number">64</td><td class="number">29</td><td class="number">3</td><td class="number">9</td><td class="number">23</td></tr>
-                <tr><td>PR Scripts</td><td class="number">47</td><td class="number">38</td><td class="number">0</td><td class="number">9</td><td class="number">0</td></tr>
+                <tr><td>PR Tests</td><td class="number">96</td><td class="number">47</td><td class="number">2</td><td class="number">8</td><td class="number">39</td></tr>
+                <tr><td>PR E2E</td><td class="number">83</td><td class="number">30</td><td class="number">3</td><td class="number">8</td><td class="number">42</td></tr>
+                <tr><td>PR Scripts</td><td class="number">66</td><td class="number">58</td><td class="number">0</td><td class="number">8</td><td class="number">0</td></tr>
                 <tr><td>Backlog Rescore</td><td class="number">27</td><td class="number">27</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
                 <tr><td>Claim Reward</td><td class="number">22</td><td class="number">0</td><td class="number">0</td><td class="number">0</td><td class="number">22</td></tr>
-                <tr><td>PR Helm Chart</td><td class="number">18</td><td class="number">3</td><td class="number">0</td><td class="number">7</td><td class="number">8</td></tr>
+                <tr><td>PR Helm Chart</td><td class="number">37</td><td class="number">3</td><td class="number">0</td><td class="number">7</td><td class="number">27</td></tr>
+                <tr><td>PR Batch Test Deploy</td><td class="number">18</td><td class="number">5</td><td class="number">12</td><td class="number">0</td><td class="number">1</td></tr>
                 <tr><td>PR CLI</td><td class="number">9</td><td class="number">8</td><td class="number">0</td><td class="number">1</td><td class="number">0</td></tr>
                 <tr><td>Publish Images</td><td class="number">9</td><td class="number">7</td><td class="number">0</td><td class="number">0</td><td class="number">2</td></tr>
-                <tr><td>Deploy Docs</td><td class="number">3</td><td class="number">3</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
-                <tr><td>其他自动化</td><td class="number">2</td><td class="number">1</td><td class="number">0</td><td class="number">0</td><td class="number">1</td></tr>
+                <tr><td>Deploy Docs</td><td class="number">4</td><td class="number">4</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>其他自动化</td><td class="number">1</td><td class="number">1</td><td class="number">0</td><td class="number">0</td><td class="number">0</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>数据解读：</strong>98.0% 表明已执行的检查整体稳定，且 8 月 1 日后未再观察到失败；但 44 次等待授权说明外部 PR 的检查覆盖仍存在门禁缺口，不能只看成功率。</p>
+          <p class="risk-note"><strong>数据解读：</strong>94.2% 低于前次快照，17 次失败中有 12 次来自 8 月 6 日的批量测试部署；常规 PR Tests 与 PR E2E 共 5 次失败。40 次等待授权仍说明外部 PR 的检查覆盖存在门禁缺口。</p>
         </section>
 
         <section class="report-section" data-module="delivery-and-backlog" aria-labelledby="delivery-title">
@@ -1478,21 +1479,21 @@ footer {
           <div class="health-grid">
             <article class="health-note">
               <h3>安全与供应链</h3>
-              <p>Security 64 次实际执行全部成功，另有 9 次等待授权。公开数据无法确认私有安全告警和生产扫描任务数量。</p>
+              <p>Security 67 次实际执行全部成功，另有 8 次等待授权和 39 次条件跳过。公开数据无法确认私有安全告警和生产扫描任务数量。</p>
             </article>
             <article class="health-note">
               <h3>Release 交付</h3>
-              <p>截至 15:24，应用与 CLI Release 均为 0；最新应用版本 <a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a> 于本期开始前发布。该指标当前表示“待完成”，只有 23:59 截止后才能判断周目标。</p>
+              <p>应用与 CLI Release 均为 0；最新应用版本 <a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.15">v0.2.15</a> 于本期开始前发布。“每周一个 Release”目标本期未达成。</p>
             </article>
           </div>
           <h3>Issue 健康</h3>
           <div class="chart-grid">
             <div class="chart-box" data-module="issue-age-chart">
               <h3>开放 Issue 年龄结构</h3>
-              <div class="bars" role="img" aria-label="W32 截至快照开放 Issue 33 个：不足 7 天 2 个，7 到 13 天 13 个，14 到 29 天 5 个，30 天以上 13 个">
+              <div class="bars" role="img" aria-label="W32 统计时点开放 Issue 33 个：不足 7 天 2 个，7 到 13 天 12 个，14 到 29 天 6 个，30 天以上 13 个">
                 <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:15.4%"></span></span><span class="bar-value">2</span></div>
-                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">13</span></div>
-                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:38.5%"></span></span><span class="bar-value">5</span></div>
+                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:92.3%"></span></span><span class="bar-value">12</span></div>
+                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:46.2%"></span></span><span class="bar-value">6</span></div>
                 <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:100%"></span></span><span class="bar-value">13</span></div>
               </div>
               <p class="chart-note">队列净减少说明处置速度改善；但 30 天以上仍有 13 个，占开放 Issue 的 39.4%，长期存量没有随总量同步消失。</p>
@@ -1500,7 +1501,7 @@ footer {
             <div class="chart-box" data-module="issue-needs-info-chart">
               <h3><code>needs-info</code> 占比</h3>
               <div class="donut-layout">
-                <div class="donut" style="--value:48.5%" role="img" aria-label="W32 截至快照开放 Issue 中，16 个带 triage/needs-info 标签，占 33 个开放 Issue 的 48.5%">
+                <div class="donut" style="--value:48.5%" role="img" aria-label="W32 统计时点开放 Issue 中，16 个带 triage/needs-info 标签，占 33 个开放 Issue 的 48.5%">
                   <div class="donut-center"><strong>48.5%</strong><span>16 / 33</span></div>
                 </div>
                 <div class="donut-copy">
@@ -1513,7 +1514,7 @@ footer {
           <h3>PR 健康</h3>
           <div class="chart-box" data-module="pr-age-chart">
             <h3>开放 PR 年龄结构</h3>
-            <div class="bars" role="img" aria-label="W32 截至快照开放 PR 10 个：不足 7 天 3 个，7 到 13 天 2 个，14 到 29 天 2 个，30 天以上 3 个">
+            <div class="bars" role="img" aria-label="W32 统计时点开放 PR 10 个：不足 7 天 3 个，7 到 13 天 2 个，14 到 29 天 2 个，30 天以上 3 个">
               <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">3</span></div>
               <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:66.7%"></span></span><span class="bar-value">2</span></div>
               <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:66.7%"></span></span><span class="bar-value">2</span></div>
@@ -1525,7 +1526,7 @@ footer {
 
         <section class="report-section" data-module="observable-response" aria-labelledby="response-title">
           <h2 id="response-title">社区响应</h2>
-          <p>截至快照新增 13 个 Issue、关闭 22 个；<a href="https://github.com/iflytek/skillhub/issues/690">#690 扫描失败重试</a>成为新的高风险输入。自动分诊不等同于维护者首次响应，本期未计算人工响应 SLA。</p>
+          <p>本期新增 13 个 Issue、关闭 22 个；<a href="https://github.com/iflytek/skillhub/issues/690">#690 扫描失败重试</a>成为新的高风险输入。自动分诊不等同于维护者首次响应，本期未计算人工响应 SLA。</p>
         </section>
       </div>
 
@@ -1540,14 +1541,14 @@ footer {
           <h2 id="flow-title">本周 Issue 与 PR 流转</h2>
           <div class="flow-summary">
             <div class="flow-item"><strong>Issue +13 / -22</strong><span>净流出 9 · 当前快照开放 33</span></div>
-            <div class="flow-item"><strong>PR +17 / 完成 23</strong><span>合并 16 + 关闭未合并 7 · 净流出 6 · 当前开放 10</span></div>
+            <div class="flow-item"><strong>PR +18 / 完成 24</strong><span>合并 17 + 关闭未合并 7 · 净流出 6 · 当前开放 10</span></div>
           </div>
-          <p class="risk-note"><strong>数据解读：</strong>本页只统计目标分支为 <code>main</code> 的 PR。“完成 23”是主分支维护流转量，不是 23 项功能上线；其中 9 个是期初存量 PR，16 个合并项仍需通过 Release 证据判断是否发布。</p>
+          <p class="risk-note"><strong>数据解读：</strong>本页只统计目标分支为 <code>main</code> 的 PR。“完成 24”是主分支维护流转量，不是 24 项功能上线；其中 9 个是期初存量 PR，17 个合并项仍需通过 Release 证据判断是否发布。</p>
 
           <h3>新增 Issue（按价值排序）</h3>
           <div class="table-wrap">
             <table>
-              <caption class="sr-only">W32 截至快照新增 Issue 价值排序</caption>
+              <caption class="sr-only">W32 新增 Issue 价值排序</caption>
               <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前进展</th></tr></thead>
               <tbody>
                 <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/690">#690 扫描失败后支持人工重试</a></td><td>影响安全扫描失败后的恢复能力，且标记为 P1/high risk。</td><td>仍开放并需要补充信息，应先明确状态机、幂等和权限边界。</td></tr>
@@ -1560,7 +1561,7 @@ footer {
           <h3>新增、合并与关闭 PR</h3>
           <div class="table-wrap">
             <table>
-              <caption class="sr-only">W32 截至快照关键 PR 流转</caption>
+              <caption class="sr-only">W32 关键 PR 流转</caption>
               <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
               <tbody>
                 <tr><td>合入 main</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/635">#635</a> / <a href="https://github.com/iflytek/skillhub/pull/636">#636</a> / <a href="https://github.com/iflytek/skillhub/pull/624">#624</a> / <a href="https://github.com/iflytek/skillhub/pull/625">#625</a></td><td>内置技能、产物校验和 Web 修复已进入主分支，但尚无包含这些改动的新应用 Release。</td></tr>
@@ -1574,7 +1575,7 @@ footer {
 
         <section class="report-section" data-module="priority-queue" aria-labelledby="priority-title">
           <h2 id="priority-title">当前高价值维护队列</h2>
-          <p class="section-lead">以下为 2026-08-06 15:24 快照，只列需要明确决策的 A/B 项；价值分级是维护治理判断，不替代仓库现有 P1/P2 标签。</p>
+          <p class="section-lead">以下为统计时点需要明确决策的 A/B 项；价值分级是治理判断，不替代仓库现有 P1/P2 标签。</p>
 
           <h3>Issue：A 级优先处理</h3>
           <div class="table-wrap">
@@ -1644,19 +1645,19 @@ footer {
         <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
           <h2 id="method-title">统计口径</h2>
           <ul class="method-list">
-            <li><strong>正式周期</strong><span>W32 展示范围为 2026-07-31 00:00—2026-08-06 23:59，Asia/Shanghai；完整程序过滤区间为 <code>[2026-07-31 00:00, 2026-08-07 00:00)</code>。</span></li>
-            <li><strong>当前覆盖</strong><span>本报告尚未截止，实际事件过滤区间为 <code>[2026-07-31 00:00, 2026-08-06 15:24:48)</code>，对应 UTC 为 <code>[2026-07-30 16:00, 2026-08-06 07:24:48)</code>。</span></li>
-            <li><strong>当前快照</strong><span>2026-08-06 15:24；开放队列、Fork 累计数及年龄结构取该时点。Star 证据于 15:28 完成采集，事件流仍按 15:24 排他截止过滤。</span></li>
-            <li><strong>周期衔接</strong><span>W31 的排他截止与 W32 起始均为 7 月 31 日 00:00，相邻报告无重叠；本快照后的事件将在正式结报刷新时补入。</span></li>
-            <li><strong>Star 证据</strong><span>7 月 31 日 16:35 的认证 API 观测值为 4,849，8 月 6 日 15:28 为 4,839，两个观测点之间的库存净变化为 -10。同期有 72 个 <code>starred_at</code> 落入部分周期且在后一次查询时仍可见的新增 Stargazer；新增与取消 Star 会同时发生，因此 72 不是净增长。完整分页数量与仓库总数均为 4,839。由于两次观测不在严格周期边界，-10 仅表示观测点间变化，也不能称为本周净增长。</span></li>
-            <li><strong>Fork 证据</strong><span>当前 Forks 为 765；80 表示当前列表中创建时间落在部分周期的可见记录，不代表 Fork 库存净增长。</span></li>
+            <li><strong>统计范围</strong><span>W32 展示范围为 2026-07-31—2026-08-06，Asia/Shanghai。</span></li>
+            <li><strong>统计边界</strong><span>事件统一过滤区间为 <code>[2026-07-31 00:00:00, 2026-08-06 18:47:26)</code>，对应 UTC 为 <code>[2026-07-30 16:00:00, 2026-08-06 10:47:26)</code>。</span></li>
+            <li><strong>数据快照</strong><span>开放队列、仓库库存及年龄结构以统计时点的认证 API 为准；Star 完整分页于 18:50 完成，事件流仍使用 18:47:26 的排他边界。</span></li>
+            <li><strong>周期衔接</strong><span>W31 的排他截止与 W32 起始均为 7 月 31 日 00:00，相邻报告无重叠；统计边界后的事件不计入 W32。</span></li>
+            <li><strong>Star 证据</strong><span>7 月 31 日 16:35 的认证 API 观测值为 4,849，8 月 6 日 18:50 为 4,844，两个观测点之间的库存净变化为 -5。同期有 77 个 <code>starred_at</code> 落入本期且在后一次查询时仍可见的新增 Stargazer；新增与取消 Star 会同时发生，因此 77 不是净增长。完整分页数量与仓库总数均为 4,844。由于两次库存观测不在严格周期边界，-5 仅表示观测点间变化。</span></li>
+            <li><strong>Fork 证据</strong><span>仓库库存字段为 768；Fork 列表接口完整分页返回 1,023 条，两个认证 API 来源不一致，因此本期不展示 Fork 到达数，也不推断 Fork 净增长。</span></li>
             <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权、条件跳过和取消不进入分母。</span></li>
-            <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告分开统计；PR 指标、列表和价值队列只纳入目标分支为 <code>main</code> 的记录。本期新增 17、合并 16、关闭未合并 7。价值 A—D 为人工治理判断。</span></li>
+            <li><strong>Issue / PR</strong><span>GitHub Issues API 会同时返回 PR，本报告分开统计；PR 指标、列表和价值队列只纳入目标分支为 <code>main</code> 的记录。本期新增 18、合并 17、关闭未合并 7。价值 A—D 为治理判断。</span></li>
             <li><strong>交付状态</strong><span>合入 <code>main</code>、进入 Release、生产部署是不同状态。本报告没有生产部署证据，因此不使用“已上线”结论。</span></li>
-            <li><strong>Release</strong><span>截至 15:24，应用与 CLI Release 均为 0；最新应用版本 v0.2.15 发布于 W32 开始前，不计入本期。正式周期未结束，因此该值不表示周目标未达成。</span></li>
-            <li><strong>npm 下载</strong><span>351 次覆盖 2026-07-31—2026-08-05 的 6 个 UTC 日桶，与 Asia/Shanghai 部分周期不完全对齐，因此仅作为带覆盖范围的生态观察。</span></li>
+            <li><strong>Release</strong><span>应用与 CLI Release 均为 0；最新应用版本 v0.2.15 发布于 W32 开始前，不计入本期。“每周一个 Release”目标本期未达成。</span></li>
+            <li><strong>npm 下载</strong><span>504 次覆盖 2026-07-31—2026-08-05 的 6 个已结算 UTC 日桶；8 月 6 日桶尚未结算，不以 0 计入。该范围与 Asia/Shanghai 统计边界不完全对齐，因此只作为生态观察。</span></li>
             <li><strong>Traffic</strong><span>5,220 次浏览与 3,423 次克隆覆盖相同 6 个 UTC 日桶；逐日 uniques 不相加为全周期独立用户。</span></li>
-            <li><strong>推广数据</strong><span>文章、直播、社区分享和合作项目由维护者补录；本期未提供，因而不展示推广模块，也不记为 0。</span></li>
+            <li><strong>推广数据</strong><span>文章、直播、社区分享和合作项目由项目方提供；本期未提供，因而不展示推广模块，也不记为 0。</span></li>
           </ul>
         </section>
 
@@ -1667,22 +1668,22 @@ footer {
               <caption>来源覆盖</caption>
               <thead><tr><th>来源</th><th>用途</th><th>限制</th></tr></thead>
               <tbody>
-                <tr><td>GitHub API（认证）</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer <code>starred_at</code></td><td>没有周期起止两份库存快照；当前可见新增不等于净增长。</td></tr>
+                <tr><td>GitHub API（认证）</td><td>仓库、Issue、PR、Release、Actions、Fork、Stargazer <code>starred_at</code></td><td>没有周期起止两份库存快照；当前可见新增不等于净增长；Fork 列表与库存字段不一致。</td></tr>
                 <tr><td>GitHub Traffic API</td><td>6 个 UTC 日桶的 Views 与 Clones</td><td>日桶与 Asia/Shanghai 边界不完全对齐；日 uniques 不可跨日求和。</td></tr>
-                <tr><td>Git 标签与提交历史</td><td>主分支合并与 Release 时间核对</td><td>最新 v0.2.15 在 W32 开始前发布；截至快照本期无 Release。</td></tr>
-                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 的 6 个 UTC 日桶</td><td>351 次下载不等同于独立用户，且覆盖范围与本报告时区边界不完全对齐。</td></tr>
-                <tr><td>维护者人工判断</td><td>价值排序、推广动作和产品边界</td><td>推广动作尚未提供。</td></tr>
+                <tr><td>Git 标签与提交历史</td><td>主分支合并与 Release 时间核对</td><td>最新 v0.2.15 在 W32 开始前发布；本期无 Release。</td></tr>
+                <tr><td>npm Downloads API</td><td><code>@astron-team/skillhub</code> 的 6 个已结算 UTC 日桶</td><td>504 次下载不等同于独立用户，且覆盖范围与本报告时区边界不完全对齐。</td></tr>
+                <tr><td>人工治理判断</td><td>价值排序、推广动作和产品边界</td><td>推广动作尚未提供。</td></tr>
               </tbody>
             </table>
           </div>
-          <p class="risk-note"><strong>未取得：</strong>GitHub Referrers、W32 起止两份可比 Star/Fork 库存快照、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。推广动作未由维护者提供，因此省略对应模块。</p>
+          <p class="risk-note"><strong>未取得：</strong>GitHub Referrers、W32 起止两份可比 Star/Fork 库存快照、可信的本期 Fork 到达数、私有安全告警，以及生产 SkillHub 实例的可用率、延迟、Skill 数量和扫描成功率。推广动作未由项目方提供，因此省略对应模块。</p>
         </section>
       </div>
     </main>
 
     <footer>
       <span>SkillHub Open Source Weekly · 2026-W32</span>
-      <span>本地草稿 · 截至快照 · 维护者治理视图</span>
+      <span>SkillHub 开源周报 · 项目治理视图</span>
     </footer>
   </article>
 

--- a/weekly/source.json
+++ b/weekly/source.json
@@ -1,4 +1,4 @@
 {
   "repository": "https://github.com/XiaoSeS/skillhub-weekly.git",
-  "commit": "a9f9fe0c3effe182bba16f9dfe4fcb2c65a39cdf"
+  "commit": "a02b0a5334f38b8a3936996fe518046179efcda1"
 }


### PR DESCRIPTION
## Summary

- mirror the manually reviewed W32 weekly report from XiaoSeS/skillhub-weekly
- update the weekly report manifest and source commit metadata
- keep the official Pages mirror byte-identical to the reviewed standalone site

Source preview commit: `a02b0a5334f38b8a3936996fe518046179efcda1`

## Validation

- mirror plan: 3 modified files, 0 deletions
- mirror byte and mode parity passed
- official weekly site build and route validation passed
- `git diff --check` passed