### PR TITLE
feat(metadata): add compliance snapshot mappings

### DIFF
--- a/docs/07-skill-protocol.md
+++ b/docs/07-skill-protocol.md
@@ -52,8 +52,20 @@ description: When to use
 x-astron-category: code-review
 x-astron-runtime: claude-code        # 预留
 x-astron-min-version: "1.0"          # 预留
+x-astron-compliance:                 # 可选，平台私有合规元数据
+  - standard: mitre-attack
+    version: "v19.1"
+    controlId: T1059
+    evidence:
+      - type: packaged-file
+        path: references/standards.md
 ---
 ```
+
+> 合规元数据先按 SkillHub/Astron 私有扩展实现，字段名采用 `x-astron-compliance`。
+> 当前第一阶段支持发布校验和版本级 `complianceSnapshot` 固化；详情展示、审核 diff、搜索 facet
+> 和 Runtime trace 集成按后续阶段推进。设计边界、分阶段实现和 Runtime 职责划分见
+> [24-compliance-metadata-design.md](24-compliance-metadata-design.md)。
 
 ## 8.3 技能包目录结构
 

--- a/docs/24-compliance-metadata-design.md
+++ b/docs/24-compliance-metadata-design.md
@@ -1,0 +1,404 @@
+# Compliance Metadata 设计方案
+
+状态：第一阶段已落地发布校验和版本级 snapshot 固化；详情展示、审核 diff、搜索 facet 和 Runtime trace 集成仍按本文后续阶段推进。
+
+## 1. 背景
+
+Issue #556 提出的方向是让 SkillHub 支持“可标准映射、可审计引用”的技能元数据。它参考了两个不同类型的开源仓库：
+
+- `mukul975/Anthropic-Cybersecurity-Skills`：大量 `SKILL.md` 在 frontmatter 中声明 MITRE ATT&CK、NIST CSF 等标准映射，并通过 `references/standards.md` 等文件补充证据。
+- `calesthio/OpenMontage`：通过 pipeline manifest、artifact schema、checkpoint 和 review gate 证明垂直工作流的可恢复、可审核和可追踪。
+
+这两个仓库给 SkillHub 的启发不同：
+
+- 标准映射应该进入 skill 协议和版本事实，而不是只作为 UI 标签。
+- 运行时 trace 应由执行方记录，SkillHub 不应承担 Agent Runtime 的执行事实。
+
+需要注意：`compliance` 不是当前已经被广泛应用的 `SKILL.md` 标准字段。SkillHub 现有协议文档已经约定 `x-astron-*` 作为平台私有扩展命名空间。因此第一阶段应使用 `x-astron-compliance`，先解决 SkillHub 自己的治理和审计需求；未来如果 OpenSkills / Agent Skills 生态形成公开字段，再通过兼容读取 `compliance` 或迁移工具对齐。
+
+因此本方案采用职责分离：
+
+> SkillHub 负责“这个技能版本声明了什么合规能力”；Agent Runtime 负责“这次执行实际用了哪个技能版本”。两者通过 `skillVersionId + complianceSnapshotDigest` 关联。
+
+## 2. 职责边界
+
+### 2.1 SkillHub 职责
+
+SkillHub 是技能注册中心和元数据权威源，负责：
+
+- 解析 `SKILL.md` frontmatter 中的 `x-astron-compliance` 字段。
+- 发布时校验 compliance 元数据和证据引用。
+- 将规范化结果固化为技能版本级 snapshot。
+- 在已有技能详情、版本详情、审核和搜索能力中投影 compliance 信息。
+- 记录 SkillHub 内部发生的发布、审核、compliance 变更审计。
+- 为未来 Agent Runtime 引用提供稳定的 `skillVersionId` 和 `complianceSnapshotDigest`。
+
+### 2.2 Agent Runtime 职责
+
+Agent Runtime，例如 Astron、Claude Code、Codex、OpenClaw 或其他执行方，负责：
+
+- 实际加载和执行技能。
+- 生成 execution trace。
+- 记录本次执行使用的 skill coordinate、skill version、`skillVersionId` 和 `complianceSnapshotDigest`。
+- 记录运行时输入输出摘要、审批 gate、执行结果、错误和运行时策略。
+
+SkillHub 不记录 Agent 每次执行，也不实现 Agent execution trace。
+
+## 3. 非目标
+
+第一阶段不做以下内容：
+
+- 不新增独立 compliance 查询 API。
+- 不实现 Astron execution trace。
+- 不新增复杂 facet / 聚合搜索。
+- 不引入外部审计系统集成。
+- 不把 `compliance` 当作已经存在的上游通用标准字段。
+- 不为了 compliance 过早新建复杂表结构，除非后续性能或查询需求明确。
+
+## 4. 协议草案
+
+建议在 `SKILL.md` frontmatter 中先支持 SkillHub/Astron 私有扩展字段 `x-astron-compliance`：
+
+```yaml
+---
+name: incident-response-helper
+description: Guide analysts through incident response triage and evidence collection.
+version: "1.2.0"
+x-astron-compliance:
+  - standard: mitre-attack
+    version: "v19.1"
+    controlId: T1059
+    title: Command and Scripting Interpreter
+    evidence:
+      - type: packaged-file
+        path: references/standards.md
+      - type: external-url
+        url: https://attack.mitre.org/techniques/T1059/
+---
+```
+
+字段含义：
+
+| 字段 | 含义 |
+|---|---|
+| `standard` | 标准名称，例如 `mitre-attack`、`nist-csf`、`soc2`、`hipaa` |
+| `version` | 标准版本，例如 `v19.1`、`2.0` |
+| `controlId` | 标准控制项、技术编号或条款 ID |
+| `title` | 人类可读名称 |
+| `evidence` | 证据列表 |
+| `evidence.type` | `packaged-file` 或 `external-url` |
+| `evidence.path` | 技能包内证据文件路径，仅 `packaged-file` 使用 |
+| `evidence.url` | 外部证据链接，仅 `external-url` 使用 |
+
+未来兼容策略：
+
+- 写入规范：第一阶段只推荐作者写 `x-astron-compliance`。
+- 读取兼容：如果后续生态出现公开 `compliance` 字段，解析器可以同时读取 `compliance` 和 `x-astron-compliance`，但需要定义冲突优先级。
+- 对外展示：UI 和审计报告仍统一展示为“Compliance Metadata”，不暴露内部字段名前缀给普通用户。
+
+## 5. 版本级 Snapshot
+
+发布时，SkillHub 将 compliance 规范化为版本级 snapshot，并写入版本元数据。
+
+第一阶段优先复用：
+
+```text
+skill_version.parsed_metadata_json
+```
+
+建议结构：
+
+```json
+{
+  "frontmatter": {
+    "name": "incident-response-helper",
+    "description": "Guide analysts through incident response triage and evidence collection.",
+    "version": "1.2.0",
+    "x-astron-compliance": []
+  },
+  "complianceSnapshot": {
+    "schemaVersion": "1.0",
+    "items": [
+      {
+        "standard": "mitre-attack",
+        "version": "v19.1",
+        "controlId": "T1059",
+        "title": "Command and Scripting Interpreter",
+        "evidence": [
+          {
+            "type": "packaged-file",
+            "path": "references/standards.md",
+            "sha256": "..."
+          },
+          {
+            "type": "external-url",
+            "url": "https://attack.mitre.org/techniques/T1059/"
+          }
+        ]
+      }
+    ],
+    "digest": "sha256:..."
+  }
+}
+```
+
+`digest` 用于未来运行时 trace 或外部审计引用。第一阶段只生成并写入
+`parsed_metadata_json`，不新增独立 endpoint；后续再通过既有详情或版本详情投影给前端。
+
+## 6. 分步执行计划
+
+### Phase 1：协议和领域模型
+
+目标：先把 `x-astron-compliance` 字段定义清楚，并放在领域层。
+
+建议新增位置：
+
+```text
+server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/
+```
+
+候选对象：
+
+```text
+ComplianceMapping
+ComplianceEvidence
+ComplianceEvidenceType
+ComplianceMetadataService
+ComplianceSnapshot
+```
+
+设计要求：
+
+- `SkillMetadataParser` 继续只负责解析 frontmatter，不承担 compliance 业务校验。
+- `ComplianceMetadataService` 负责提取、规范化、校验 compliance。
+- 不在 controller 中做 compliance 校验。
+- 使用已有 `x-astron-*` 私有扩展命名空间，不新增未验证的公开字段。
+
+### Phase 2：发布时解析和校验
+
+目标：技能发布时能识别并校验 compliance。
+
+接入点：
+
+```text
+SkillPackageValidator
+SkillPublishService
+SkillVersion.parsedMetadataJson
+```
+
+基础校验规则：
+
+- `x-astron-compliance` 缺失时兼容旧技能。
+- `x-astron-compliance` 存在时必须是数组。
+- 每个 mapping 必须是对象。
+- `standard`、`version`、`controlId` 必填。
+- `title` 可选，但应有长度限制。
+- `evidence` 可选；提供时必须是数组。
+- 同一版本内不允许重复 `standard + version + controlId`。
+- mapping 数量、evidence 数量和字符串长度要有上限。
+
+证据校验规则：
+
+- `packaged-file.path` 必须存在于技能包。
+- `packaged-file.path` 不允许 `../` 路径逃逸。
+- `external-url.url` 只允许 `http` / `https`。
+- 包内证据文件应计算 `sha256` 并写入 snapshot。
+
+错误信息要求：
+
+- 使用现有 i18n 机制。
+- 不在领域服务中散落不可翻译的长英文错误字符串。
+
+### Phase 3：固化版本级 Snapshot
+
+目标：每个技能版本都有不可变 compliance snapshot。
+
+实现要求：
+
+- 发布成功后生成规范化 `complianceSnapshot`。
+- snapshot 内容和 digest 与该 `SkillVersion` 绑定。
+- 后续详情、审核、搜索均读取 snapshot，不重新解释最新源码。
+- snapshot 为空时也要有确定行为，避免旧技能受影响。
+
+第一阶段不强制新建表。后续出现结构化过滤、统计或性能瓶颈时，再考虑：
+
+- `jsonb` GIN index；
+- `skill_version_compliance_mapping` 表；
+- 搜索 projection 表扩展。
+
+### Phase 4：已有接口投影，不新增独立 API
+
+目标：让前端和审核能看到 compliance，但不发布猜测性 public API。
+
+建议：
+
+- 在已有技能详情或版本详情 response 中增加 compliance projection。
+- 审核详情中带出当前版本 compliance snapshot。
+- 不新增以下 endpoint：
+
+```text
+GET /api/skills/{namespace}/{slug}/versions/{version}/compliance
+GET /api/skills/{namespace}/{slug}/versions/{version}/metadata
+```
+
+后续只有出现明确使用方时再新增独立 API，例如：
+
+- Agent Runtime 只需要拉 compliance snapshot，不需要完整技能详情。
+- 企业审计系统按 `skillVersionId` 拉取合规声明。
+- 前端需要单独比较两个版本的 compliance diff。
+- 完整 detail payload 性能不可接受。
+
+如果后续需要独立 API，优先考虑按不可变版本 ID 设计：
+
+```text
+GET /api/skill-versions/{skillVersionId}/compliance
+```
+
+### Phase 5：轻量搜索
+
+目标：先提升可发现性，不直接做复杂 facet。
+
+后续阶段：
+
+- 在搜索文档重建时，将 snapshot 中的 `standard`、`controlId`、`title` 加入搜索文本。
+- 用户搜索 `T1059`、`mitre-attack`、`nist-csf` 时能命中对应技能。
+
+更后续再考虑：
+
+- 按 standard filter。
+- 按 controlId filter。
+- compliance coverage 聚合。
+- 独立索引或结构化 projection。
+
+### Phase 6：审核和审计
+
+目标：只记录 SkillHub 自己发生的事实。
+
+审核展示：
+
+- 当前版本 compliance snapshot。
+- 与上一发布版本的 diff：
+  - 新增 mapping；
+  - 删除 mapping；
+  - 修改 mapping；
+  - evidence 变化；
+  - digest 变化。
+
+审计记录：
+
+- 发布时记录 compliance digest。
+- 审核通过 / 拒绝时记录 compliance diff 摘要。
+- evidence 变化作为风险信息进入 audit detail。
+
+不记录：
+
+- Agent 执行输入输出。
+- Astron trace。
+- runtime 调用结果。
+
+### Phase 7：文档
+
+目标：让技能作者、平台维护者和 Agent Runtime 接入方都理解边界。
+
+需要更新的文档：
+
+- `docs/07-skill-protocol.md`：实现稳定后补充正式 `x-astron-compliance` 协议。
+- 用户文档：说明如何在 `SKILL.md` 中声明 `x-astron-compliance`。
+- 管理员文档：说明发布校验、审核 diff、审计记录。
+- 集成文档：说明 Runtime 如何引用 `skillVersionId + complianceSnapshotDigest`。
+
+文档必须明确：
+
+> SkillHub 只提供版本级 compliance snapshot。运行时 trace 由 Agent Runtime 记录，并可引用 SkillHub 的 `skillVersionId` 和 `complianceSnapshotDigest`。
+
+### Phase 8：测试
+
+单元测试：
+
+- 无 `x-astron-compliance` 的旧技能正常发布。
+- 合法 `x-astron-compliance` 正常解析。
+- `standard` 缺失失败。
+- `version` 缺失失败。
+- `controlId` 缺失失败。
+- 重复 `standard + version + controlId` 失败。
+- `packaged-file.path` 不存在失败。
+- `packaged-file.path` 路径逃逸失败。
+- `external-url.url` scheme 非法失败。
+- digest 稳定生成。
+
+发布链路测试：
+
+- 上传含 `x-astron-compliance` 的技能包成功。
+- 上传非法 `x-astron-compliance` 的技能包失败。
+- 发布后 `parsedMetadataJson` 包含 `complianceSnapshot`。
+- snapshot digest 与内容一致。
+
+搜索测试：
+
+- 搜标准名能命中。
+- 搜 controlId 能命中。
+- 无 compliance 的旧技能不受影响。
+
+审核测试：
+
+- 新版本新增 compliance。
+- 新版本删除 compliance。
+- 新版本修改 evidence。
+- 审核详情能看到 diff。
+
+## 7. 推荐 PR 拆分
+
+### PR 1：协议、解析、校验、快照
+
+范围：
+
+- domain metadata service；
+- package validator；
+- publish snapshot；
+- `parsedMetadataJson` 结构；
+- 单元测试和发布链路测试。
+
+不包含：
+
+- UI；
+- 搜索 facet；
+- 独立 API；
+- Agent trace。
+
+### PR 2：详情页和审核展示
+
+范围：
+
+- 既有 response 增加 compliance projection；
+- 技能详情展示；
+- 审核 diff 展示；
+- 前端测试。
+
+### PR 3：轻量搜索
+
+范围：
+
+- 搜索文档增加 compliance keywords；
+- 搜索测试。
+
+不做复杂 facet。
+
+### PR 4：文档和 Runtime 集成契约
+
+范围：
+
+- 用户文档；
+- 管理员文档；
+- Runtime 引用方式；
+- `skillVersionId + complianceSnapshotDigest` 契约说明。
+
+不实现 Astron trace。
+
+## 8. 最终架构原则
+
+1. SkillHub 不执行技能，因此不记录执行 trace。
+2. SkillHub 是 skill metadata 和 version snapshot 的权威源。
+3. Agent Runtime 是 execution trace 的权威源。
+4. 合规审计通过 `skillVersionId + complianceSnapshotDigest` 把两边事实关联起来。
+5. 第一阶段不发布猜测性 API；先通过已有详情和版本投影满足内部使用。
+6. 先做稳定协议和可验证快照，再做 UI、搜索和外部集成。

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/portal/SkillController.java
@@ -23,6 +23,7 @@ import com.iflytek.skillhub.dto.SkillVersionResponse;
 import com.iflytek.skillhub.metrics.SkillHubMetrics;
 import com.iflytek.skillhub.ratelimit.RateLimit;
 import com.iflytek.skillhub.service.SkillLabelAppService;
+import com.iflytek.skillhub.service.ComplianceSnapshotProjectionService;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -50,18 +51,21 @@ public class SkillController extends BaseApiController {
     private final SkillQueryService skillQueryService;
     private final SkillDownloadService skillDownloadService;
     private final SkillLabelAppService skillLabelAppService;
+    private final ComplianceSnapshotProjectionService complianceSnapshotProjectionService;
     private final SkillHubMetrics metrics;
 
     public SkillController(
             SkillQueryService skillQueryService,
             SkillDownloadService skillDownloadService,
             SkillLabelAppService skillLabelAppService,
+            ComplianceSnapshotProjectionService complianceSnapshotProjectionService,
             SkillHubMetrics metrics,
             ApiResponseFactory responseFactory) {
         super(responseFactory);
         this.skillQueryService = skillQueryService;
         this.skillDownloadService = skillDownloadService;
         this.skillLabelAppService = skillLabelAppService;
+        this.complianceSnapshotProjectionService = complianceSnapshotProjectionService;
         this.metrics = metrics;
     }
 
@@ -138,7 +142,8 @@ public class SkillController extends BaseApiController {
                 v.getFileCount(),
                 v.getTotalSize(),
                 v.getPublishedAt(),
-                skillQueryService.isDownloadAvailable(v)
+                skillQueryService.isDownloadAvailable(v),
+                complianceSnapshotProjectionService.fromParsedMetadataJson(v.getParsedMetadataJson())
         )));
 
         return ok("response.success.read", response);
@@ -173,7 +178,8 @@ public class SkillController extends BaseApiController {
                 detail.totalSize(),
                 detail.publishedAt(),
                 detail.parsedMetadataJson(),
-                detail.manifestJson()
+                detail.manifestJson(),
+                complianceSnapshotProjectionService.fromParsedMetadataJson(detail.parsedMetadataJson())
         );
         return ok("response.success.read", response);
     }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/ComplianceEvidenceResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/ComplianceEvidenceResponse.java
@@ -1,0 +1,8 @@
+package com.iflytek.skillhub.dto;
+
+public record ComplianceEvidenceResponse(
+        String type,
+        String path,
+        String url,
+        String sha256
+) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/ComplianceMappingResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/ComplianceMappingResponse.java
@@ -1,0 +1,11 @@
+package com.iflytek.skillhub.dto;
+
+import java.util.List;
+
+public record ComplianceMappingResponse(
+        String standard,
+        String version,
+        String controlId,
+        String title,
+        List<ComplianceEvidenceResponse> evidence
+) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/ComplianceSnapshotResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/ComplianceSnapshotResponse.java
@@ -1,0 +1,9 @@
+package com.iflytek.skillhub.dto;
+
+import java.util.List;
+
+public record ComplianceSnapshotResponse(
+        String schemaVersion,
+        List<ComplianceMappingResponse> items,
+        String digest
+) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillVersionDetailResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillVersionDetailResponse.java
@@ -11,5 +11,6 @@ public record SkillVersionDetailResponse(
         long totalSize,
         Instant publishedAt,
         String parsedMetadataJson,
-        String manifestJson
+        String manifestJson,
+        ComplianceSnapshotResponse complianceSnapshot
 ) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillVersionResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillVersionResponse.java
@@ -10,5 +10,6 @@ public record SkillVersionResponse(
         int fileCount,
         long totalSize,
         Instant publishedAt,
-        boolean downloadAvailable
+        boolean downloadAvailable,
+        ComplianceSnapshotResponse complianceSnapshot
 ) {}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/ComplianceSnapshotProjectionService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/ComplianceSnapshotProjectionService.java
@@ -1,0 +1,92 @@
+package com.iflytek.skillhub.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iflytek.skillhub.domain.skill.metadata.ComplianceMetadataService;
+import com.iflytek.skillhub.dto.ComplianceEvidenceResponse;
+import com.iflytek.skillhub.dto.ComplianceMappingResponse;
+import com.iflytek.skillhub.dto.ComplianceSnapshotResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ComplianceSnapshotProjectionService {
+
+    private final ObjectMapper objectMapper;
+
+    public ComplianceSnapshotProjectionService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public ComplianceSnapshotResponse fromParsedMetadataJson(String parsedMetadataJson) {
+        if (parsedMetadataJson == null || parsedMetadataJson.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(parsedMetadataJson);
+            JsonNode snapshot = root.path(ComplianceMetadataService.SNAPSHOT_FIELD_NAME);
+            if (!snapshot.isObject()) {
+                return null;
+            }
+            return toSnapshot(snapshot);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private ComplianceSnapshotResponse toSnapshot(JsonNode snapshot) {
+        return new ComplianceSnapshotResponse(
+                textOrNull(snapshot.path("schemaVersion")),
+                toMappings(snapshot.path("items")),
+                textOrNull(snapshot.path("digest"))
+        );
+    }
+
+    private List<ComplianceMappingResponse> toMappings(JsonNode items) {
+        if (!items.isArray()) {
+            return List.of();
+        }
+        List<ComplianceMappingResponse> mappings = new ArrayList<>();
+        for (JsonNode item : items) {
+            if (!item.isObject()) {
+                continue;
+            }
+            mappings.add(new ComplianceMappingResponse(
+                    textOrNull(item.path("standard")),
+                    textOrNull(item.path("version")),
+                    textOrNull(item.path("controlId")),
+                    textOrNull(item.path("title")),
+                    toEvidence(item.path("evidence"))
+            ));
+        }
+        return List.copyOf(mappings);
+    }
+
+    private List<ComplianceEvidenceResponse> toEvidence(JsonNode evidenceItems) {
+        if (!evidenceItems.isArray()) {
+            return List.of();
+        }
+        List<ComplianceEvidenceResponse> evidence = new ArrayList<>();
+        for (JsonNode item : evidenceItems) {
+            if (!item.isObject()) {
+                continue;
+            }
+            evidence.add(new ComplianceEvidenceResponse(
+                    textOrNull(item.path("type")),
+                    textOrNull(item.path("path")),
+                    textOrNull(item.path("url")),
+                    textOrNull(item.path("sha256"))
+            ));
+        }
+        return List.copyOf(evidence);
+    }
+
+    private String textOrNull(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        return node.asText();
+    }
+}

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/ReviewSkillDetailAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/ReviewSkillDetailAppService.java
@@ -34,19 +34,22 @@ public class ReviewSkillDetailAppService {
     private final RbacService rbacService;
     private final SkillQueryService skillQueryService;
     private final SkillDownloadService skillDownloadService;
+    private final ComplianceSnapshotProjectionService complianceSnapshotProjectionService;
 
     public ReviewSkillDetailAppService(ReviewTaskRepository reviewTaskRepository,
                                        NamespaceRepository namespaceRepository,
                                        ReviewService reviewService,
                                        RbacService rbacService,
                                        SkillQueryService skillQueryService,
-                                       SkillDownloadService skillDownloadService) {
+                                       SkillDownloadService skillDownloadService,
+                                       ComplianceSnapshotProjectionService complianceSnapshotProjectionService) {
         this.reviewTaskRepository = reviewTaskRepository;
         this.namespaceRepository = namespaceRepository;
         this.reviewService = reviewService;
         this.rbacService = rbacService;
         this.skillQueryService = skillQueryService;
         this.skillDownloadService = skillDownloadService;
+        this.complianceSnapshotProjectionService = complianceSnapshotProjectionService;
     }
 
     public ReviewSkillDetailResponse getReviewSkillDetail(Long reviewId,
@@ -94,7 +97,8 @@ public class ReviewSkillDetailAppService {
                         version.getTotalSize(),
                         version.getPublishedAt(),
                         version.getId().equals(snapshot.activeVersion().getId())
-                                || skillQueryService.isDownloadAvailable(version)
+                                || skillQueryService.isDownloadAvailable(version),
+                        complianceSnapshotProjectionService.fromParsedMetadataJson(version.getParsedMetadataJson())
                 ))
                 .toList();
 

--- a/server/skillhub-app/src/main/resources/messages.properties
+++ b/server/skillhub-app/src/main/resources/messages.properties
@@ -94,6 +94,7 @@ error.skill.metadata.frontmatter.missingEnd=Missing frontmatter end marker ''---
 error.skill.metadata.yaml.notMap=Frontmatter must be a YAML object
 error.skill.metadata.yaml.invalid=Invalid YAML in frontmatter: {0}
 error.skill.metadata.requiredField.missing=Missing required field: {0}
+error.skill.metadata.compliance.invalid=Invalid x-astron-compliance metadata: {0}
 error.skill.publish.publisher.notMember=Publisher is not a member of namespace: {0}
 error.skill.publish.package.invalid=Package validation failed: {0}
 error.skill.publish.skillMd.notFound=SKILL.md not found

--- a/server/skillhub-app/src/main/resources/messages_zh.properties
+++ b/server/skillhub-app/src/main/resources/messages_zh.properties
@@ -94,6 +94,7 @@ error.skill.metadata.frontmatter.missingEnd=缺少 frontmatter 结束标记 ---
 error.skill.metadata.yaml.notMap=frontmatter 必须是 YAML 对象
 error.skill.metadata.yaml.invalid=frontmatter YAML 非法：{0}
 error.skill.metadata.requiredField.missing=缺少必填字段：{0}
+error.skill.metadata.compliance.invalid=x-astron-compliance 元数据不合法：{0}
 error.skill.publish.publisher.notMember=发布者不是命名空间成员：{0}
 error.skill.publish.package.invalid=技能包校验失败：{0}
 error.skill.publish.skillMd.notFound=未找到 SKILL.md

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/ReviewPortalControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/ReviewPortalControllerTest.java
@@ -194,7 +194,7 @@ class ReviewPortalControllerTest {
                                 null,
                                 "REVIEW_TASK"
                         ),
-                        List.of(new SkillVersionResponse(100L, "1.2.0", "PENDING_REVIEW", null, 1, 10L, null, true)),
+                        List.of(new SkillVersionResponse(100L, "1.2.0", "PENDING_REVIEW", null, 1, 10L, null, true, null)),
                         List.of(new SkillFileResponse(1L, "README.md", 123L, "text/markdown", "sha")),
                         "README.md",
                         "# demo",

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/SkillControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/SkillControllerTest.java
@@ -52,6 +52,9 @@ class SkillControllerTest {
 
     @Test
     void getVersionDetailShouldReturnMetadataFields() throws Exception {
+        String parsedMetadata = """
+                {"name":"demo","complianceSnapshot":{"schemaVersion":"1.0","items":[{"standard":"mitre-attack","version":"v19.1","controlId":"T1059","evidence":[]}],"digest":"sha256:demo"}}
+                """;
         when(skillQueryService.getVersionDetail(
                 eq("team"),
                 eq("demo"),
@@ -66,7 +69,7 @@ class SkillControllerTest {
                         2,
                         128L,
                         Instant.parse("2026-03-12T12:00:00Z"),
-                        "{\"name\":\"demo\"}",
+                        parsedMetadata,
                         "[{\"path\":\"SKILL.md\"}]"
                 ));
 
@@ -74,7 +77,8 @@ class SkillControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0))
                 .andExpect(jsonPath("$.data.version").value("1.0.0"))
-                .andExpect(jsonPath("$.data.parsedMetadataJson").value("{\"name\":\"demo\"}"))
+                .andExpect(jsonPath("$.data.parsedMetadataJson").value(parsedMetadata))
+                .andExpect(jsonPath("$.data.complianceSnapshot.items[0].controlId").value("T1059"))
                 .andExpect(jsonPath("$.data.manifestJson").value("[{\"path\":\"SKILL.md\"}]"))
                 .andExpect(jsonPath("$.timestamp").isNotEmpty())
                 .andExpect(jsonPath("$.requestId").isNotEmpty());
@@ -227,6 +231,9 @@ class SkillControllerTest {
     @Test
     void listVersionsShouldExposeDownloadAvailability() throws Exception {
         SkillVersion version = new SkillVersion(1L, "1.0.0", "owner-1");
+        version.setParsedMetadataJson("""
+                {"complianceSnapshot":{"schemaVersion":"1.0","items":[{"standard":"mitre-attack","version":"v19.1","controlId":"T1059","evidence":[]}],"digest":"sha256:demo"}}
+                """);
         when(skillQueryService.listVersions(
                 eq("team"),
                 eq("demo"),
@@ -238,7 +245,8 @@ class SkillControllerTest {
 
         mockMvc.perform(get("/api/v1/skills/team/demo/versions"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.items[0].downloadAvailable").value(false));
+                .andExpect(jsonPath("$.data.items[0].downloadAvailable").value(false))
+                .andExpect(jsonPath("$.data.items[0].complianceSnapshot.items[0].standard").value("mitre-attack"));
     }
 
     @Test

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/ComplianceSnapshotProjectionServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/ComplianceSnapshotProjectionServiceTest.java
@@ -1,0 +1,59 @@
+package com.iflytek.skillhub.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ComplianceSnapshotProjectionServiceTest {
+
+    private final ComplianceSnapshotProjectionService service =
+            new ComplianceSnapshotProjectionService(new ObjectMapper());
+
+    @Test
+    void returnsNullWhenParsedMetadataIsBlankOrLegacy() {
+        assertThat(service.fromParsedMetadataJson(null)).isNull();
+        assertThat(service.fromParsedMetadataJson("")).isNull();
+        assertThat(service.fromParsedMetadataJson("{\"name\":\"legacy\"}")).isNull();
+    }
+
+    @Test
+    void returnsNullWhenParsedMetadataIsInvalidJson() {
+        assertThat(service.fromParsedMetadataJson("{not-json")).isNull();
+    }
+
+    @Test
+    void projectsComplianceSnapshotFromParsedMetadata() {
+        var snapshot = service.fromParsedMetadataJson("""
+                {
+                  "name": "demo",
+                  "complianceSnapshot": {
+                    "schemaVersion": "1.0",
+                    "items": [
+                      {
+                        "standard": "mitre-attack",
+                        "version": "v19.1",
+                        "controlId": "T1059",
+                        "title": "Command and Scripting Interpreter",
+                        "evidence": [
+                          {
+                            "type": "packaged-file",
+                            "path": "references/standards.md",
+                            "sha256": "85c516"
+                          }
+                        ]
+                      }
+                    ],
+                    "digest": "sha256:demo"
+                  }
+                }
+                """);
+
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.schemaVersion()).isEqualTo("1.0");
+        assertThat(snapshot.digest()).isEqualTo("sha256:demo");
+        assertThat(snapshot.items()).hasSize(1);
+        assertThat(snapshot.items().get(0).controlId()).isEqualTo("T1059");
+        assertThat(snapshot.items().get(0).evidence().get(0).path()).isEqualTo("references/standards.md");
+    }
+}

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/ReviewSkillDetailAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/ReviewSkillDetailAppServiceTest.java
@@ -61,7 +61,8 @@ class ReviewSkillDetailAppServiceTest {
                 reviewService,
                 rbacService,
                 skillQueryService,
-                skillDownloadService
+                skillDownloadService,
+                new ComplianceSnapshotProjectionService(new com.fasterxml.jackson.databind.ObjectMapper())
         );
     }
 
@@ -71,6 +72,9 @@ class ReviewSkillDetailAppServiceTest {
         Namespace namespace = createNamespace(20L, "team-a");
         Skill skill = createSkill(101L, 20L, "skill-a");
         SkillVersion pending = createVersion(101L, 101L, "1.2.0", SkillVersionStatus.PENDING_REVIEW);
+        pending.setParsedMetadataJson("""
+                {"complianceSnapshot":{"schemaVersion":"1.0","items":[{"standard":"mitre-attack","version":"v19.1","controlId":"T1059","evidence":[]}],"digest":"sha256:demo"}}
+                """);
         SkillVersion published = createVersion(100L, 101L, "1.1.0", SkillVersionStatus.PUBLISHED);
         SkillFile readme = createFile(1L, 101L, "README.md");
 
@@ -100,6 +104,7 @@ class ReviewSkillDetailAppServiceTest {
         assertThat(response.skill().namespace()).isEqualTo("team-a");
         assertThat(response.versions()).extracting("version").containsExactly("1.2.0", "1.1.0");
         assertThat(response.versions().get(0).downloadAvailable()).isTrue();
+        assertThat(response.versions().get(0).complianceSnapshot().items().get(0).controlId()).isEqualTo("T1059");
     }
 
     @Test

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceEvidence.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceEvidence.java
@@ -1,0 +1,11 @@
+package com.iflytek.skillhub.domain.skill.metadata;
+
+/**
+ * Normalized evidence reference attached to one compliance mapping.
+ */
+public record ComplianceEvidence(
+        String type,
+        String path,
+        String url,
+        String sha256
+) {}

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceMapping.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceMapping.java
@@ -1,0 +1,14 @@
+package com.iflytek.skillhub.domain.skill.metadata;
+
+import java.util.List;
+
+/**
+ * Version-scoped mapping from a skill to an external compliance or security standard.
+ */
+public record ComplianceMapping(
+        String standard,
+        String version,
+        String controlId,
+        String title,
+        List<ComplianceEvidence> evidence
+) {}

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceMetadataService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceMetadataService.java
@@ -1,0 +1,388 @@
+package com.iflytek.skillhub.domain.skill.metadata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.iflytek.skillhub.domain.shared.exception.DomainBadRequestException;
+import com.iflytek.skillhub.domain.skill.validation.PackageEntry;
+import com.iflytek.skillhub.domain.skill.validation.SkillPackagePolicy;
+
+import java.net.URI;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts, validates, and snapshots SkillHub/Astron compliance metadata from SKILL.md frontmatter.
+ */
+public class ComplianceMetadataService {
+
+    public static final String FIELD_NAME = "x-astron-compliance";
+    public static final String SNAPSHOT_FIELD_NAME = "complianceSnapshot";
+
+    private static final String EVIDENCE_TYPE_PACKAGED_FILE = "packaged-file";
+    private static final String EVIDENCE_TYPE_EXTERNAL_URL = "external-url";
+    private static final int MAX_MAPPINGS = 50;
+    private static final int MAX_EVIDENCE_ITEMS = 10;
+    private static final int MAX_STANDARD_LENGTH = 64;
+    private static final int MAX_VERSION_LENGTH = 64;
+    private static final int MAX_CONTROL_ID_LENGTH = 128;
+    private static final int MAX_TITLE_LENGTH = 200;
+    private static final Pattern STANDARD_PATTERN = Pattern.compile("[a-z0-9][a-z0-9._-]*");
+    private static final Pattern CONTROL_ID_PATTERN = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._:-]*");
+
+    private final ObjectMapper digestObjectMapper;
+
+    public ComplianceMetadataService() {
+        this.digestObjectMapper = new ObjectMapper()
+                .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    }
+
+    public List<String> validate(Map<String, Object> frontmatter, List<PackageEntry> entries) {
+        return parse(frontmatter, entries).errors();
+    }
+
+    public ComplianceSnapshot buildSnapshot(Map<String, Object> frontmatter, List<PackageEntry> entries) {
+        ParseResult result = parse(frontmatter, entries);
+        if (!result.errors().isEmpty()) {
+            throw new DomainBadRequestException(
+                    "error.skill.metadata.compliance.invalid",
+                    String.join(", ", result.errors()));
+        }
+        return snapshot(result.mappings());
+    }
+
+    private ParseResult parse(Map<String, Object> frontmatter, List<PackageEntry> entries) {
+        Object rawMappings = frontmatter.get(FIELD_NAME);
+        if (rawMappings == null) {
+            return new ParseResult(List.of(), List.of());
+        }
+
+        List<String> errors = new ArrayList<>();
+        if (!(rawMappings instanceof List<?> mappingItems)) {
+            return new ParseResult(List.of(), List.of(FIELD_NAME + " must be an array"));
+        }
+        if (mappingItems.size() > MAX_MAPPINGS) {
+            errors.add(FIELD_NAME + " must contain at most " + MAX_MAPPINGS + " items");
+        }
+
+        Map<String, PackageEntry> packageEntries = packageEntryMap(entries);
+        Set<String> seenMappings = new LinkedHashSet<>();
+        List<ComplianceMapping> mappings = new ArrayList<>();
+
+        for (int index = 0; index < mappingItems.size(); index++) {
+            Object rawItem = mappingItems.get(index);
+            if (!(rawItem instanceof Map<?, ?> rawMap)) {
+                errors.add(FIELD_NAME + "[" + index + "] must be an object");
+                continue;
+            }
+            Map<String, Object> item = normalizeMap(rawMap);
+            validateAllowedFields(item, index, Set.of("standard", "version", "controlId", "title", "evidence"), errors);
+
+            String standard = requiredString(item, index, "standard", MAX_STANDARD_LENGTH, errors);
+            String standardNormalized = standard == null ? null : standard.toLowerCase(Locale.ROOT);
+            if (standardNormalized != null && !STANDARD_PATTERN.matcher(standardNormalized).matches()) {
+                errors.add(FIELD_NAME + "[" + index + "].standard has an invalid format");
+            }
+
+            String version = requiredString(item, index, "version", MAX_VERSION_LENGTH, errors);
+            String controlId = requiredString(item, index, "controlId", MAX_CONTROL_ID_LENGTH, errors);
+            if (controlId != null && !CONTROL_ID_PATTERN.matcher(controlId).matches()) {
+                errors.add(FIELD_NAME + "[" + index + "].controlId has an invalid format");
+            }
+            String title = optionalString(item, index, "title", MAX_TITLE_LENGTH, errors);
+            List<ComplianceEvidence> evidence = parseEvidence(item.get("evidence"), index, packageEntries, errors);
+
+            if (standardNormalized != null && version != null && controlId != null) {
+                String duplicateKey = standardNormalized + "\u0000" + version + "\u0000" + controlId;
+                if (!seenMappings.add(duplicateKey)) {
+                    errors.add(FIELD_NAME + " contains duplicate mapping "
+                            + standardNormalized + "/" + version + "/" + controlId);
+                    continue;
+                }
+                mappings.add(new ComplianceMapping(
+                        standardNormalized,
+                        version,
+                        controlId,
+                        title,
+                        List.copyOf(evidence)));
+            }
+        }
+
+        return new ParseResult(List.copyOf(mappings), List.copyOf(errors));
+    }
+
+    private List<ComplianceEvidence> parseEvidence(Object rawEvidence,
+                                                   int mappingIndex,
+                                                   Map<String, PackageEntry> packageEntries,
+                                                   List<String> errors) {
+        if (rawEvidence == null) {
+            return List.of();
+        }
+        if (!(rawEvidence instanceof List<?> evidenceItems)) {
+            errors.add(FIELD_NAME + "[" + mappingIndex + "].evidence must be an array");
+            return List.of();
+        }
+        if (evidenceItems.size() > MAX_EVIDENCE_ITEMS) {
+            errors.add(FIELD_NAME + "[" + mappingIndex + "].evidence must contain at most "
+                    + MAX_EVIDENCE_ITEMS + " items");
+        }
+
+        List<ComplianceEvidence> evidence = new ArrayList<>();
+        for (int evidenceIndex = 0; evidenceIndex < evidenceItems.size(); evidenceIndex++) {
+            Object rawItem = evidenceItems.get(evidenceIndex);
+            if (!(rawItem instanceof Map<?, ?> rawMap)) {
+                errors.add(evidencePath(mappingIndex, evidenceIndex) + " must be an object");
+                continue;
+            }
+            Map<String, Object> item = normalizeMap(rawMap);
+            validateAllowedFields(item, mappingIndex, evidenceIndex, Set.of("type", "path", "url"), errors);
+            String type = requiredEvidenceString(item, mappingIndex, evidenceIndex, "type", 32, errors);
+            if (type == null) {
+                continue;
+            }
+            String normalizedType = type.toLowerCase(Locale.ROOT);
+            if (EVIDENCE_TYPE_PACKAGED_FILE.equals(normalizedType)) {
+                ComplianceEvidence packagedEvidence = parsePackagedFileEvidence(
+                        item, mappingIndex, evidenceIndex, packageEntries, errors);
+                if (packagedEvidence != null) {
+                    evidence.add(packagedEvidence);
+                }
+            } else if (EVIDENCE_TYPE_EXTERNAL_URL.equals(normalizedType)) {
+                ComplianceEvidence externalEvidence = parseExternalUrlEvidence(
+                        item, mappingIndex, evidenceIndex, errors);
+                if (externalEvidence != null) {
+                    evidence.add(externalEvidence);
+                }
+            } else {
+                errors.add(evidencePath(mappingIndex, evidenceIndex)
+                        + ".type must be one of packaged-file, external-url");
+            }
+        }
+        return evidence;
+    }
+
+    private ComplianceEvidence parsePackagedFileEvidence(Map<String, Object> item,
+                                                         int mappingIndex,
+                                                         int evidenceIndex,
+                                                         Map<String, PackageEntry> packageEntries,
+                                                         List<String> errors) {
+        String rawPath = requiredEvidenceString(item, mappingIndex, evidenceIndex, "path", 512, errors);
+        if (rawPath == null) {
+            return null;
+        }
+        String normalizedPath;
+        try {
+            normalizedPath = SkillPackagePolicy.normalizeEntryPath(rawPath);
+        } catch (IllegalArgumentException exception) {
+            errors.add(evidencePath(mappingIndex, evidenceIndex) + ".path " + exception.getMessage());
+            return null;
+        }
+        PackageEntry entry = packageEntries.get(normalizedPath);
+        if (entry == null) {
+            errors.add(evidencePath(mappingIndex, evidenceIndex)
+                    + ".path does not exist in package: " + normalizedPath);
+            return null;
+        }
+        return new ComplianceEvidence(
+                EVIDENCE_TYPE_PACKAGED_FILE,
+                normalizedPath,
+                null,
+                sha256(entry.content()));
+    }
+
+    private ComplianceEvidence parseExternalUrlEvidence(Map<String, Object> item,
+                                                        int mappingIndex,
+                                                        int evidenceIndex,
+                                                        List<String> errors) {
+        String url = requiredEvidenceString(item, mappingIndex, evidenceIndex, "url", 2048, errors);
+        if (url == null) {
+            return null;
+        }
+        try {
+            URI uri = URI.create(url);
+            String scheme = uri.getScheme();
+            if (scheme == null
+                    || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))
+                    || uri.getHost() == null) {
+                errors.add(evidencePath(mappingIndex, evidenceIndex) + ".url must be an http or https URL");
+                return null;
+            }
+        } catch (IllegalArgumentException exception) {
+            errors.add(evidencePath(mappingIndex, evidenceIndex) + ".url must be an http or https URL");
+            return null;
+        }
+        return new ComplianceEvidence(EVIDENCE_TYPE_EXTERNAL_URL, null, url, null);
+    }
+
+    private ComplianceSnapshot snapshot(List<ComplianceMapping> mappings) {
+        Map<String, Object> payload = Map.of(
+                "schemaVersion", ComplianceSnapshot.CURRENT_SCHEMA_VERSION,
+                "items", mappings.stream().map(this::mappingPayload).toList());
+        String digest = "sha256:" + sha256(toJsonBytes(payload));
+        return new ComplianceSnapshot(ComplianceSnapshot.CURRENT_SCHEMA_VERSION, List.copyOf(mappings), digest);
+    }
+
+    private Map<String, Object> mappingPayload(ComplianceMapping mapping) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("standard", mapping.standard());
+        payload.put("version", mapping.version());
+        payload.put("controlId", mapping.controlId());
+        if (mapping.title() != null) {
+            payload.put("title", mapping.title());
+        }
+        payload.put("evidence", mapping.evidence().stream().map(this::evidencePayload).toList());
+        return payload;
+    }
+
+    private Map<String, Object> evidencePayload(ComplianceEvidence evidence) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("type", evidence.type());
+        if (evidence.path() != null) {
+            payload.put("path", evidence.path());
+        }
+        if (evidence.url() != null) {
+            payload.put("url", evidence.url());
+        }
+        if (evidence.sha256() != null) {
+            payload.put("sha256", evidence.sha256());
+        }
+        return payload;
+    }
+
+    private Map<String, Object> normalizeMap(Map<?, ?> rawMap) {
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+            if (entry.getKey() != null) {
+                normalized.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+        }
+        return normalized;
+    }
+
+    private Map<String, PackageEntry> packageEntryMap(List<PackageEntry> entries) {
+        Map<String, PackageEntry> packageEntries = new LinkedHashMap<>();
+        for (PackageEntry entry : entries) {
+            try {
+                packageEntries.putIfAbsent(SkillPackagePolicy.normalizeEntryPath(entry.path()), entry);
+            } catch (IllegalArgumentException ignored) {
+                // Structural path errors are reported by SkillPackageValidator. Compliance validation should
+                // continue so the caller can see all package problems in one response.
+            }
+        }
+        return packageEntries;
+    }
+
+    private String requiredString(Map<String, Object> item,
+                                  int index,
+                                  String fieldName,
+                                  int maxLength,
+                                  List<String> errors) {
+        Object rawValue = item.get(fieldName);
+        if (!(rawValue instanceof String value) || value.isBlank()) {
+            errors.add(FIELD_NAME + "[" + index + "]." + fieldName + " is required");
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > maxLength) {
+            errors.add(FIELD_NAME + "[" + index + "]." + fieldName
+                    + " must be at most " + maxLength + " characters");
+            return null;
+        }
+        return trimmed;
+    }
+
+    private String optionalString(Map<String, Object> item,
+                                  int index,
+                                  String fieldName,
+                                  int maxLength,
+                                  List<String> errors) {
+        Object rawValue = item.get(fieldName);
+        if (rawValue == null) {
+            return null;
+        }
+        if (!(rawValue instanceof String value) || value.isBlank()) {
+            errors.add(FIELD_NAME + "[" + index + "]." + fieldName + " must be a non-empty string");
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > maxLength) {
+            errors.add(FIELD_NAME + "[" + index + "]." + fieldName
+                    + " must be at most " + maxLength + " characters");
+            return null;
+        }
+        return trimmed;
+    }
+
+    private String requiredEvidenceString(Map<String, Object> item,
+                                          int mappingIndex,
+                                          int evidenceIndex,
+                                          String fieldName,
+                                          int maxLength,
+                                          List<String> errors) {
+        Object rawValue = item.get(fieldName);
+        if (!(rawValue instanceof String value) || value.isBlank()) {
+            errors.add(evidencePath(mappingIndex, evidenceIndex) + "." + fieldName + " is required");
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > maxLength) {
+            errors.add(evidencePath(mappingIndex, evidenceIndex) + "." + fieldName
+                    + " must be at most " + maxLength + " characters");
+            return null;
+        }
+        return trimmed;
+    }
+
+    private void validateAllowedFields(Map<String, Object> item,
+                                       int mappingIndex,
+                                       Set<String> allowedFields,
+                                       List<String> errors) {
+        for (String fieldName : item.keySet()) {
+            if (!allowedFields.contains(fieldName)) {
+                errors.add(FIELD_NAME + "[" + mappingIndex + "]." + fieldName + " is not allowed");
+            }
+        }
+    }
+
+    private void validateAllowedFields(Map<String, Object> item,
+                                       int mappingIndex,
+                                       int evidenceIndex,
+                                       Set<String> allowedFields,
+                                       List<String> errors) {
+        for (String fieldName : item.keySet()) {
+            if (!allowedFields.contains(fieldName)) {
+                errors.add(evidencePath(mappingIndex, evidenceIndex) + "." + fieldName + " is not allowed");
+            }
+        }
+    }
+
+    private String evidencePath(int mappingIndex, int evidenceIndex) {
+        return FIELD_NAME + "[" + mappingIndex + "].evidence[" + evidenceIndex + "]";
+    }
+
+    private byte[] toJsonBytes(Map<String, Object> payload) {
+        try {
+            return digestObjectMapper.writeValueAsBytes(payload);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to serialize compliance snapshot", exception);
+        }
+    }
+
+    private String sha256(byte[] content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(content));
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to calculate SHA-256", exception);
+        }
+    }
+
+    private record ParseResult(List<ComplianceMapping> mappings, List<String> errors) {}
+}

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceSnapshot.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceSnapshot.java
@@ -1,0 +1,14 @@
+package com.iflytek.skillhub.domain.skill.metadata;
+
+import java.util.List;
+
+/**
+ * Immutable normalized compliance metadata bound to a single skill version.
+ */
+public record ComplianceSnapshot(
+        String schemaVersion,
+        List<ComplianceMapping> items,
+        String digest
+) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+}

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillPublishService.java
@@ -16,6 +16,8 @@ import com.iflytek.skillhub.domain.security.SecurityScanService;
 import com.iflytek.skillhub.domain.shared.exception.DomainBadRequestException;
 import com.iflytek.skillhub.domain.shared.exception.DomainForbiddenException;
 import com.iflytek.skillhub.domain.skill.*;
+import com.iflytek.skillhub.domain.skill.metadata.ComplianceMetadataService;
+import com.iflytek.skillhub.domain.skill.metadata.ComplianceSnapshot;
 import com.iflytek.skillhub.domain.skill.metadata.SkillMetadata;
 import com.iflytek.skillhub.domain.skill.metadata.SkillMetadataParser;
 import com.iflytek.skillhub.domain.skill.validation.PackageEntry;
@@ -84,6 +86,7 @@ public class SkillPublishService {
     private final ObjectStorageService objectStorageService;
     private final SkillPackageValidator skillPackageValidator;
     private final SkillMetadataParser skillMetadataParser;
+    private final ComplianceMetadataService complianceMetadataService = new ComplianceMetadataService();
     private final PrePublishValidator prePublishValidator;
     private final ObjectMapper objectMapper;
     private final ReviewTaskRepository reviewTaskRepository;
@@ -462,9 +465,11 @@ public class SkillPublishService {
             version.setStatus(SkillVersionStatus.PENDING_REVIEW);
         }
 
+        ComplianceSnapshot complianceSnapshot = complianceMetadataService.buildSnapshot(metadata.frontmatter(), entries);
+
         // Store metadata as JSON
         try {
-            String metadataJson = objectMapper.writeValueAsString(metadata);
+            String metadataJson = objectMapper.writeValueAsString(buildParsedMetadata(metadata, complianceSnapshot));
             version.setParsedMetadataJson(metadataJson);
             version.setManifestJson(objectMapper.writeValueAsString(buildManifest(entries)));
         } catch (Exception e) {
@@ -726,6 +731,17 @@ public class SkillPublishService {
                         "size", entry.size(),
                         "contentType", entry.contentType()))
                 .toList();
+    }
+
+    private Map<String, Object> buildParsedMetadata(SkillMetadata metadata, ComplianceSnapshot complianceSnapshot) {
+        Map<String, Object> parsedMetadata = new LinkedHashMap<>();
+        parsedMetadata.put("name", metadata.name());
+        parsedMetadata.put("description", metadata.description());
+        parsedMetadata.put("version", metadata.version());
+        parsedMetadata.put("body", metadata.body());
+        parsedMetadata.put("frontmatter", metadata.frontmatter());
+        parsedMetadata.put(ComplianceMetadataService.SNAPSHOT_FIELD_NAME, complianceSnapshot);
+        return parsedMetadata;
     }
 
     private byte[] buildBundle(List<PackageEntry> entries) {

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidator.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidator.java
@@ -1,6 +1,8 @@
 package com.iflytek.skillhub.domain.skill.validation;
 
 import com.iflytek.skillhub.domain.shared.exception.LocalizedDomainException;
+import com.iflytek.skillhub.domain.skill.metadata.ComplianceMetadataService;
+import com.iflytek.skillhub.domain.skill.metadata.SkillMetadata;
 import com.iflytek.skillhub.domain.skill.metadata.SkillMetadataParser;
 
 import java.util.ArrayList;
@@ -18,6 +20,7 @@ public class SkillPackageValidator {
     private static final Pattern YAML_LINE_COLUMN = Pattern.compile("line\\s+(\\d+),\\s+column\\s+(\\d+)");
 
     private final SkillMetadataParser metadataParser;
+    private final ComplianceMetadataService complianceMetadataService;
     private final int maxFileCount;
     private final long maxSingleFileSize;
     private final long maxTotalPackageSize;
@@ -26,6 +29,7 @@ public class SkillPackageValidator {
     public SkillPackageValidator(SkillMetadataParser metadataParser) {
         this(
                 metadataParser,
+                new ComplianceMetadataService(),
                 SkillPackagePolicy.MAX_FILE_COUNT,
                 SkillPackagePolicy.MAX_SINGLE_FILE_SIZE,
                 SkillPackagePolicy.MAX_TOTAL_PACKAGE_SIZE,
@@ -38,7 +42,24 @@ public class SkillPackageValidator {
                                  long maxSingleFileSize,
                                  long maxTotalPackageSize,
                                  Set<String> allowedExtensions) {
+        this(
+                metadataParser,
+                new ComplianceMetadataService(),
+                maxFileCount,
+                maxSingleFileSize,
+                maxTotalPackageSize,
+                allowedExtensions
+        );
+    }
+
+    public SkillPackageValidator(SkillMetadataParser metadataParser,
+                                 ComplianceMetadataService complianceMetadataService,
+                                 int maxFileCount,
+                                 long maxSingleFileSize,
+                                 long maxTotalPackageSize,
+                                 Set<String> allowedExtensions) {
         this.metadataParser = metadataParser;
+        this.complianceMetadataService = complianceMetadataService;
         this.maxFileCount = maxFileCount;
         this.maxSingleFileSize = maxSingleFileSize;
         this.maxTotalPackageSize = maxTotalPackageSize;
@@ -89,7 +110,8 @@ public class SkillPackageValidator {
         // 2. Validate frontmatter
         try {
             String content = new String(skillMd.content());
-            metadataParser.parse(content);
+            SkillMetadata metadata = metadataParser.parse(content);
+            errors.addAll(complianceMetadataService.validate(metadata.frontmatter(), entries));
         } catch (LocalizedDomainException e) {
             errors.add("Invalid SKILL.md frontmatter: " + formatMetadataError(e));
         }

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceMetadataServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/metadata/ComplianceMetadataServiceTest.java
@@ -1,0 +1,129 @@
+package com.iflytek.skillhub.domain.skill.metadata;
+
+import com.iflytek.skillhub.domain.shared.exception.DomainBadRequestException;
+import com.iflytek.skillhub.domain.skill.validation.PackageEntry;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ComplianceMetadataServiceTest {
+
+    private final ComplianceMetadataService service = new ComplianceMetadataService();
+
+    @Test
+    void buildsEmptySnapshotWhenFieldIsMissing() {
+        ComplianceSnapshot snapshot = service.buildSnapshot(Map.of(), List.of(skillMdEntry()));
+
+        assertEquals("1.0", snapshot.schemaVersion());
+        assertTrue(snapshot.items().isEmpty());
+        assertTrue(snapshot.digest().startsWith("sha256:"));
+    }
+
+    @Test
+    void normalizesMappingAndHashesPackagedEvidence() {
+        Map<String, Object> frontmatter = Map.of(
+                ComplianceMetadataService.FIELD_NAME,
+                List.of(Map.of(
+                        "standard", "MITRE-ATTACK",
+                        "version", "v19.1",
+                        "controlId", "T1059",
+                        "title", "Command and Scripting Interpreter",
+                        "evidence", List.of(
+                                Map.of("type", "packaged-file", "path", "references/standards.md"),
+                                Map.of("type", "external-url", "url", "https://attack.mitre.org/techniques/T1059/")
+                        )
+                ))
+        );
+        PackageEntry standards = new PackageEntry(
+                "references/standards.md",
+                "MITRE evidence".getBytes(StandardCharsets.UTF_8),
+                "MITRE evidence".getBytes(StandardCharsets.UTF_8).length,
+                "text/markdown");
+
+        ComplianceSnapshot snapshot = service.buildSnapshot(frontmatter, List.of(skillMdEntry(), standards));
+
+        assertEquals(1, snapshot.items().size());
+        ComplianceMapping mapping = snapshot.items().get(0);
+        assertEquals("mitre-attack", mapping.standard());
+        assertEquals("v19.1", mapping.version());
+        assertEquals("T1059", mapping.controlId());
+        assertEquals("Command and Scripting Interpreter", mapping.title());
+        assertEquals(2, mapping.evidence().size());
+        assertEquals("packaged-file", mapping.evidence().get(0).type());
+        assertEquals("references/standards.md", mapping.evidence().get(0).path());
+        assertEquals("85c516832d12f0c1c86675c2751bd37dcdbdd0573b5a8da74a1bb022089e73d3",
+                mapping.evidence().get(0).sha256());
+        assertEquals("external-url", mapping.evidence().get(1).type());
+        assertEquals("https://attack.mitre.org/techniques/T1059/", mapping.evidence().get(1).url());
+        assertTrue(snapshot.digest().startsWith("sha256:"));
+    }
+
+    @Test
+    void rejectsDuplicateMappings() {
+        Map<String, Object> frontmatter = Map.of(
+                ComplianceMetadataService.FIELD_NAME,
+                List.of(
+                        Map.of("standard", "mitre-attack", "version", "v19.1", "controlId", "T1059"),
+                        Map.of("standard", "MITRE-ATTACK", "version", "v19.1", "controlId", "T1059")
+                )
+        );
+
+        DomainBadRequestException exception = assertThrows(
+                DomainBadRequestException.class,
+                () -> service.buildSnapshot(frontmatter, List.of(skillMdEntry()))
+        );
+
+        assertEquals("error.skill.metadata.compliance.invalid", exception.messageCode());
+        assertTrue(String.valueOf(exception.messageArgs()[0]).contains("duplicate mapping"));
+    }
+
+    @Test
+    void rejectsMissingPackagedEvidencePath() {
+        Map<String, Object> frontmatter = Map.of(
+                ComplianceMetadataService.FIELD_NAME,
+                List.of(Map.of(
+                        "standard", "nist-csf",
+                        "version", "2.0",
+                        "controlId", "GV.OC-03",
+                        "evidence", List.of(Map.of("type", "packaged-file", "path", "references/missing.md"))
+                ))
+        );
+
+        List<String> errors = service.validate(frontmatter, List.of(skillMdEntry()));
+
+        assertTrue(errors.stream().anyMatch(error -> error.contains("does not exist in package")));
+    }
+
+    @Test
+    void rejectsInvalidExternalUrlScheme() {
+        Map<String, Object> frontmatter = Map.of(
+                ComplianceMetadataService.FIELD_NAME,
+                List.of(Map.of(
+                        "standard", "soc2",
+                        "version", "2017",
+                        "controlId", "CC6.1",
+                        "evidence", List.of(Map.of("type", "external-url", "url", "file:///tmp/evidence.md"))
+                ))
+        );
+
+        List<String> errors = service.validate(frontmatter, List.of(skillMdEntry()));
+
+        assertTrue(errors.stream().anyMatch(error -> error.contains("http or https URL")));
+    }
+
+    private PackageEntry skillMdEntry() {
+        byte[] content = """
+                ---
+                name: test-skill
+                description: Test skill
+                version: 1.0.0
+                ---
+                Body
+                """.getBytes(StandardCharsets.UTF_8);
+        return new PackageEntry("SKILL.md", content, content.length, "text/markdown");
+    }
+}

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillPublishServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillPublishServiceTest.java
@@ -1,6 +1,7 @@
 package com.iflytek.skillhub.domain.skill.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.iflytek.skillhub.domain.event.ReviewSubmittedEvent;
 import com.iflytek.skillhub.domain.event.SkillPublishedEvent;
 import com.iflytek.skillhub.domain.namespace.Namespace;
@@ -209,6 +210,168 @@ class SkillPublishServiceTest {
         assertTrue(String.valueOf(exception.messageArgs()[0]).contains("Disallowed file extension: malware.exe"));
         assertTrue(String.valueOf(exception.messageArgs()[0]).contains("looks like a secret or token"));
         verify(skillVersionRepository, never()).save(any(SkillVersion.class));
+    }
+
+    @Test
+    void testPublishFromEntries_ShouldPersistComplianceSnapshot() throws Exception {
+        String namespaceSlug = "test-ns";
+        String publisherId = "user-100";
+        String skillMdContent = """
+                ---
+                name: test-skill
+                description: Test
+                version: 1.0.0
+                x-astron-compliance:
+                  - standard: mitre-attack
+                    version: v19.1
+                    controlId: T1059
+                    title: Command and Scripting Interpreter
+                    evidence:
+                      - type: packaged-file
+                        path: references/standards.md
+                ---
+                Body
+                """;
+        PackageEntry skillMd = new PackageEntry(
+                "SKILL.md",
+                skillMdContent.getBytes(StandardCharsets.UTF_8),
+                skillMdContent.getBytes(StandardCharsets.UTF_8).length,
+                "text/markdown");
+        PackageEntry standards = new PackageEntry(
+                "references/standards.md",
+                "MITRE evidence".getBytes(StandardCharsets.UTF_8),
+                "MITRE evidence".getBytes(StandardCharsets.UTF_8).length,
+                "text/markdown");
+        List<PackageEntry> entries = List.of(skillMd, standards);
+
+        Namespace namespace = new Namespace(namespaceSlug, "Test NS", "user-1");
+        setId(namespace, 1L);
+        NamespaceMember member = mock(NamespaceMember.class);
+        Map<String, Object> frontmatter = Map.of(
+                "name", "test-skill",
+                "description", "Test",
+                "version", "1.0.0",
+                "x-astron-compliance", List.of(Map.of(
+                        "standard", "mitre-attack",
+                        "version", "v19.1",
+                        "controlId", "T1059",
+                        "title", "Command and Scripting Interpreter",
+                        "evidence", List.of(Map.of(
+                                "type", "packaged-file",
+                                "path", "references/standards.md"
+                        ))
+                ))
+        );
+        SkillMetadata metadata = new SkillMetadata("test-skill", "Test", "1.0.0", "Body", frontmatter);
+        Skill skill = new Skill(1L, "test-skill", publisherId, SkillVisibility.PUBLIC);
+        setId(skill, 1L);
+
+        when(namespaceRepository.findBySlug(namespaceSlug)).thenReturn(Optional.of(namespace));
+        when(namespaceMemberRepository.findByNamespaceIdAndUserId(any(), eq(publisherId))).thenReturn(Optional.of(member));
+        when(skillPackageValidator.validate(entries)).thenReturn(ValidationResult.pass());
+        when(skillMetadataParser.parse(skillMdContent)).thenReturn(metadata);
+        when(prePublishValidator.validate(any())).thenReturn(ValidationResult.pass());
+        when(skillRepository.findByNamespaceIdAndSlug(any(), eq("test-skill"))).thenReturn(List.of(skill));
+        when(skillRepository.findByNamespaceIdAndSlugAndOwnerId(any(), eq("test-skill"), eq(publisherId))).thenReturn(Optional.of(skill));
+        when(skillVersionRepository.findBySkillIdAndVersion(any(), eq("1.0.0"))).thenReturn(Optional.empty());
+        when(skillVersionRepository.save(any(SkillVersion.class))).thenAnswer(invocation -> {
+            SkillVersion saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                setId(saved, 10L);
+            }
+            return saved;
+        });
+        when(skillRepository.save(any())).thenReturn(skill);
+
+        SkillPublishService.PublishResult result = service.publishFromEntries(
+                namespaceSlug,
+                entries,
+                publisherId,
+                SkillVisibility.PUBLIC,
+                Set.of()
+        );
+
+        JsonNode parsedMetadata = objectMapper.readTree(result.version().getParsedMetadataJson());
+        JsonNode complianceSnapshot = parsedMetadata.get("complianceSnapshot");
+        assertNotNull(complianceSnapshot);
+        assertEquals("1.0", complianceSnapshot.get("schemaVersion").asText());
+        assertTrue(complianceSnapshot.get("digest").asText().startsWith("sha256:"));
+        assertEquals("mitre-attack", complianceSnapshot.get("items").get(0).get("standard").asText());
+        assertEquals("T1059", complianceSnapshot.get("items").get(0).get("controlId").asText());
+        assertEquals("references/standards.md",
+                complianceSnapshot.get("items").get(0).get("evidence").get(0).get("path").asText());
+        assertEquals("85c516832d12f0c1c86675c2751bd37dcdbdd0573b5a8da74a1bb022089e73d3",
+                complianceSnapshot.get("items").get(0).get("evidence").get(0).get("sha256").asText());
+    }
+
+    @Test
+    void testPublishFromEntries_ShouldRejectInvalidComplianceSnapshotBeforePersisting() throws Exception {
+        String namespaceSlug = "test-ns";
+        String publisherId = "user-100";
+        String skillMdContent = """
+                ---
+                name: test-skill
+                description: Test
+                version: 1.0.0
+                x-astron-compliance:
+                  - standard: mitre-attack
+                    version: v19.1
+                    controlId: T1059
+                    evidence:
+                      - type: packaged-file
+                        path: references/missing.md
+                ---
+                Body
+                """;
+        PackageEntry skillMd = new PackageEntry(
+                "SKILL.md",
+                skillMdContent.getBytes(StandardCharsets.UTF_8),
+                skillMdContent.getBytes(StandardCharsets.UTF_8).length,
+                "text/markdown");
+        List<PackageEntry> entries = List.of(skillMd);
+
+        Namespace namespace = new Namespace(namespaceSlug, "Test NS", "user-1");
+        setId(namespace, 1L);
+        NamespaceMember member = mock(NamespaceMember.class);
+        Map<String, Object> frontmatter = Map.of(
+                "name", "test-skill",
+                "description", "Test",
+                "version", "1.0.0",
+                "x-astron-compliance", List.of(Map.of(
+                        "standard", "mitre-attack",
+                        "version", "v19.1",
+                        "controlId", "T1059",
+                        "evidence", List.of(Map.of(
+                                "type", "packaged-file",
+                                "path", "references/missing.md"
+                        ))
+                ))
+        );
+        SkillMetadata metadata = new SkillMetadata("test-skill", "Test", "1.0.0", "Body", frontmatter);
+        Skill skill = new Skill(1L, "test-skill", publisherId, SkillVisibility.PUBLIC);
+        setId(skill, 1L);
+
+        when(namespaceRepository.findBySlug(namespaceSlug)).thenReturn(Optional.of(namespace));
+        when(namespaceMemberRepository.findByNamespaceIdAndUserId(any(), eq(publisherId))).thenReturn(Optional.of(member));
+        when(skillPackageValidator.validate(entries)).thenReturn(ValidationResult.pass());
+        when(skillMetadataParser.parse(skillMdContent)).thenReturn(metadata);
+        when(prePublishValidator.validate(any())).thenReturn(ValidationResult.pass());
+        when(skillRepository.findByNamespaceIdAndSlug(any(), eq("test-skill"))).thenReturn(List.of(skill));
+        when(skillRepository.findByNamespaceIdAndSlugAndOwnerId(any(), eq("test-skill"), eq(publisherId))).thenReturn(Optional.of(skill));
+        when(skillVersionRepository.findBySkillIdAndVersion(any(), eq("1.0.0"))).thenReturn(Optional.empty());
+
+        DomainBadRequestException exception = assertThrows(DomainBadRequestException.class, () -> service.publishFromEntries(
+                namespaceSlug,
+                entries,
+                publisherId,
+                SkillVisibility.PUBLIC,
+                Set.of()
+        ));
+
+        assertEquals("error.skill.metadata.compliance.invalid", exception.messageCode());
+        assertTrue(String.valueOf(exception.messageArgs()[0]).contains("references/missing.md"));
+        verify(skillVersionRepository, never()).save(any(SkillVersion.class));
+        verify(objectStorageService, never()).putObject(anyString(), any(), anyLong(), anyString());
     }
 
     @Test

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
@@ -343,6 +343,64 @@ class SkillPackageValidatorTest {
         assertTrue(result.passed());
     }
 
+    @Test
+    void acceptsSkillWithAstronComplianceEvidence() {
+        String skillMdContent = """
+            ---
+            name: test-skill
+            description: A test skill
+            version: 1.0.0
+            x-astron-compliance:
+              - standard: mitre-attack
+                version: v19.1
+                controlId: T1059
+                evidence:
+                  - type: packaged-file
+                    path: references/standards.md
+            ---
+            Body
+            """;
+        byte[] skillMdBytes = skillMdContent.getBytes();
+        byte[] standardsBytes = "standards".getBytes();
+        List<PackageEntry> entries = List.of(
+                new PackageEntry("SKILL.md", skillMdBytes, skillMdBytes.length, "text/markdown"),
+                new PackageEntry("references/standards.md", standardsBytes, standardsBytes.length, "text/markdown")
+        );
+
+        ValidationResult result = validator.validate(entries);
+
+        assertTrue(result.passed());
+        assertTrue(result.errors().isEmpty());
+    }
+
+    @Test
+    void rejectsSkillWithMissingAstronComplianceEvidenceFile() {
+        String skillMdContent = """
+            ---
+            name: test-skill
+            description: A test skill
+            version: 1.0.0
+            x-astron-compliance:
+              - standard: mitre-attack
+                version: v19.1
+                controlId: T1059
+                evidence:
+                  - type: packaged-file
+                    path: references/missing.md
+            ---
+            Body
+            """;
+        byte[] skillMdBytes = skillMdContent.getBytes();
+        List<PackageEntry> entries = List.of(
+                new PackageEntry("SKILL.md", skillMdBytes, skillMdBytes.length, "text/markdown")
+        );
+
+        ValidationResult result = validator.validate(entries);
+
+        assertFalse(result.passed());
+        assertTrue(result.errors().stream().anyMatch(error -> error.contains("does not exist in package")));
+    }
+
     private PackageEntry skillMdEntry() {
         String skillMdContent = """
             ---

--- a/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildService.java
+++ b/server/skillhub-search/src/main/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildService.java
@@ -14,6 +14,7 @@ import com.iflytek.skillhub.domain.skill.SkillRepository;
 import com.iflytek.skillhub.domain.skill.SkillStatus;
 import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVersionRepository;
+import com.iflytek.skillhub.domain.skill.metadata.ComplianceMetadataService;
 import com.iflytek.skillhub.search.SearchIndexService;
 import com.iflytek.skillhub.search.SearchRebuildService;
 import com.iflytek.skillhub.search.SearchTextTokenizer;
@@ -127,9 +128,13 @@ public class PostgresSearchRebuildService implements SearchRebuildService {
         Set<String> keywords = new TreeSet<>();
         resolveLatestVersion(skill)
                 .map(this::extractParsedMetadata)
-                .map(metadata -> metadata.get("frontmatter"))
-                .map(this::asMap)
-                .ifPresent(frontmatter -> appendFrontmatter(frontmatter, keywords, searchParts));
+                .ifPresent(metadata -> {
+                    appendFrontmatter(asMap(metadata.get("frontmatter")), keywords, searchParts);
+                    appendComplianceSnapshot(
+                            asMap(metadata.get(ComplianceMetadataService.SNAPSHOT_FIELD_NAME)),
+                            keywords,
+                            searchParts);
+                });
         appendLabelKeywords(skill.getId(), keywords);
 
         return new SearchIndexPayload(
@@ -195,6 +200,29 @@ public class PostgresSearchRebuildService implements SearchRebuildService {
                 flattenToStrings(value).forEach(text -> addPart(searchParts, text));
             }
         }
+    }
+
+    private void appendComplianceSnapshot(Map<String, Object> snapshot,
+                                          Set<String> keywords,
+                                          List<String> searchParts) {
+        Object rawItems = snapshot.get("items");
+        if (!(rawItems instanceof Collection<?> items)) {
+            return;
+        }
+        for (Object rawItem : items) {
+            Map<String, Object> item = asMap(rawItem);
+            appendComplianceSearchValue(item.get("standard"), keywords, searchParts);
+            appendComplianceSearchValue(item.get("version"), keywords, searchParts);
+            appendComplianceSearchValue(item.get("controlId"), keywords, searchParts);
+            appendComplianceSearchValue(item.get("title"), keywords, searchParts);
+        }
+    }
+
+    private void appendComplianceSearchValue(Object value, Set<String> keywords, List<String> searchParts) {
+        flattenToStrings(value).forEach(text -> {
+            addKeyword(keywords, text);
+            addPart(searchParts, text);
+        });
     }
 
     private List<String> flattenToStrings(Object value) {

--- a/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildServiceTest.java
+++ b/server/skillhub-search/src/test/java/com/iflytek/skillhub/search/postgres/PostgresSearchRebuildServiceTest.java
@@ -159,6 +159,75 @@ class PostgresSearchRebuildServiceTest {
     }
 
     @Test
+    void rebuildBySkill_shouldAppendComplianceSnapshotMappingsIntoSearchDocument() {
+        SkillRepository skillRepository = mock(SkillRepository.class);
+        NamespaceRepository namespaceRepository = mock(NamespaceRepository.class);
+        SkillVersionRepository skillVersionRepository = mock(SkillVersionRepository.class);
+        SearchIndexService searchIndexService = mock(SearchIndexService.class);
+
+        Skill skill = new Skill(7L, "terminal-agent", "owner-1", SkillVisibility.PUBLIC);
+        skill.setDisplayName("Terminal Agent");
+        skill.setSummary("Runs shell workflows safely");
+        skill.setLatestVersionId(104L);
+
+        Namespace namespace = new Namespace("team-ai", "Team AI", "owner-1");
+        SkillVersion version = new SkillVersion(1L, "1.7.0", "owner-1");
+        version.setParsedMetadataJson("""
+                {
+                  "frontmatter": {
+                    "keywords": ["shell"]
+                  },
+                  "complianceSnapshot": {
+                    "schemaVersion": "1",
+                    "digest": "sha256:abc123",
+                    "items": [
+                      {
+                        "standard": "mitre-attack",
+                        "version": "15",
+                        "controlId": "T1059",
+                        "title": "Command and Scripting Interpreter",
+                        "evidence": [
+                          {
+                            "type": "packaged-file",
+                            "path": "docs/security.md",
+                            "sha256": "sha256:def456"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """);
+
+        when(skillRepository.findById(1L)).thenReturn(Optional.of(skill));
+        when(namespaceRepository.findById(7L)).thenReturn(Optional.of(namespace));
+        when(skillVersionRepository.findById(104L)).thenReturn(Optional.of(version));
+
+        PostgresSearchRebuildService service = newService(
+                skillRepository,
+                namespaceRepository,
+                skillVersionRepository,
+                searchIndexService
+        );
+
+        service.rebuildBySkill(1L);
+
+        ArgumentCaptor<SkillSearchDocument> captor = ArgumentCaptor.forClass(SkillSearchDocument.class);
+        verify(searchIndexService).index(captor.capture());
+
+        SkillSearchDocument document = captor.getValue();
+        assertThat(document.keywords()).contains("shell");
+        assertThat(document.keywords()).contains("mitre-attack");
+        assertThat(document.keywords()).contains("T1059");
+        assertThat(document.keywords()).contains("Command and Scripting Interpreter");
+        assertThat(document.searchText()).contains("mitre-attack");
+        assertThat(document.searchText()).contains("T1059");
+        assertThat(document.searchText()).contains("Command and Scripting Interpreter");
+        assertThat(document.searchText()).doesNotContain("docs/security.md");
+        assertThat(document.searchText()).doesNotContain("sha256:def456");
+    }
+
+    @Test
     void rebuildBySkill_shouldIgnoreNullFrontmatterValues() {
         SkillRepository skillRepository = mock(SkillRepository.class);
         NamespaceRepository namespaceRepository = mock(NamespaceRepository.class);

--- a/web/src/api/generated/schema.d.ts
+++ b/web/src/api/generated/schema.d.ts
@@ -4147,6 +4147,24 @@ export interface components {
             timestamp?: string;
             requestId?: string;
         };
+        ComplianceEvidenceResponse: {
+            type?: string;
+            path?: string;
+            url?: string;
+            sha256?: string;
+        };
+        ComplianceMappingResponse: {
+            standard?: string;
+            version?: string;
+            controlId?: string;
+            title?: string;
+            evidence?: components["schemas"]["ComplianceEvidenceResponse"][];
+        };
+        ComplianceSnapshotResponse: {
+            schemaVersion?: string;
+            items?: components["schemas"]["ComplianceMappingResponse"][];
+            digest?: string;
+        };
         SkillVersionDetailResponse: {
             /** Format: int64 */
             id?: number;
@@ -4161,6 +4179,7 @@ export interface components {
             publishedAt?: string;
             parsedMetadataJson?: string;
             manifestJson?: string;
+            complianceSnapshot?: components["schemas"]["ComplianceSnapshotResponse"];
         };
         ApiResponseSkillVersionCompareResponse: {
             /** Format: int32 */
@@ -4252,6 +4271,7 @@ export interface components {
             /** Format: date-time */
             publishedAt?: string;
             downloadAvailable?: boolean;
+            complianceSnapshot?: components["schemas"]["ComplianceSnapshotResponse"];
         };
         ApiResponseListTagResponse: {
             /** Format: int32 */

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -211,6 +211,27 @@ export interface SkillLifecycleVersion {
   status: string
 }
 
+export interface ComplianceEvidence {
+  type?: string
+  path?: string
+  url?: string
+  sha256?: string
+}
+
+export interface ComplianceMapping {
+  standard?: string
+  version?: string
+  controlId?: string
+  title?: string
+  evidence?: ComplianceEvidence[]
+}
+
+export interface ComplianceSnapshot {
+  schemaVersion?: string
+  items?: ComplianceMapping[]
+  digest?: string
+}
+
 export interface SkillDetail {
   id: number
   slug: string
@@ -253,6 +274,7 @@ export interface SkillVersion {
   totalSize: number
   publishedAt: string
   downloadAvailable: boolean
+  complianceSnapshot?: ComplianceSnapshot
 }
 
 export interface SkillVersionDetail {
@@ -265,6 +287,7 @@ export interface SkillVersionDetail {
   publishedAt: string
   parsedMetadataJson?: string
   manifestJson?: string
+  complianceSnapshot?: ComplianceSnapshot
 }
 
 export interface SkillFile {

--- a/web/src/features/review/review-skill-detail-section.tsx
+++ b/web/src/features/review/review-skill-detail-section.tsx
@@ -7,6 +7,7 @@ import { FileTree } from '@/features/skill/file-tree'
 import { FilePreviewDialog } from '@/features/skill/file-preview-dialog'
 import type { FileTreeNode } from '@/features/skill/file-tree-builder'
 import { MarkdownRenderer } from '@/features/skill/markdown-renderer'
+import { ComplianceSnapshotPanel } from '@/features/skill/compliance-snapshot-panel'
 import { Button, buttonVariants } from '@/shared/ui/button'
 import { Card } from '@/shared/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui/tabs'
@@ -169,6 +170,7 @@ export function ReviewSkillDetailSection({ detail, isLoading, hasError, reviewId
                         {version.changelog ? (
                           <p className="text-sm text-muted-foreground">{version.changelog}</p>
                         ) : null}
+                        <ComplianceSnapshotPanel snapshot={version.complianceSnapshot} />
                       </div>
                       <div className="text-sm text-muted-foreground">
                         {t('skillDetail.fileCount', { count: version.fileCount })}

--- a/web/src/features/skill/compliance-snapshot-panel.test.tsx
+++ b/web/src/features/skill/compliance-snapshot-panel.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { ComplianceSnapshotPanel } from './compliance-snapshot-panel'
+
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next')
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, values?: Record<string, number>) =>
+        key === 'compliance.mappingCount' ? `${values?.count} mappings` : key,
+    }),
+  }
+})
+
+describe('ComplianceSnapshotPanel', () => {
+  it('renders compliance mappings and evidence', () => {
+    const html = renderToStaticMarkup(
+      <ComplianceSnapshotPanel
+        snapshot={{
+          schemaVersion: '1.0',
+          digest: 'sha256:12345678901234567890',
+          items: [
+            {
+              standard: 'mitre-attack',
+              version: 'v19.1',
+              controlId: 'T1059',
+              title: 'Command and Scripting Interpreter',
+              evidence: [{ type: 'packaged-file', path: 'references/standards.md', sha256: 'abc' }],
+            },
+          ],
+        }}
+      />,
+    )
+
+    expect(html).toContain('compliance.title')
+    expect(html).toContain('1 mappings')
+    expect(html).toContain('mitre-attack')
+    expect(html).toContain('T1059')
+    expect(html).toContain('references/standards.md')
+  })
+
+  it('renders nothing when there are no compliance mappings', () => {
+    const html = renderToStaticMarkup(<ComplianceSnapshotPanel snapshot={{ schemaVersion: '1.0', items: [], digest: 'sha256:empty' }} />)
+
+    expect(html).toBe('')
+  })
+})

--- a/web/src/features/skill/compliance-snapshot-panel.tsx
+++ b/web/src/features/skill/compliance-snapshot-panel.tsx
@@ -1,0 +1,78 @@
+import { ExternalLink, ShieldCheck } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { ComplianceSnapshot } from '@/api/types'
+import { cn } from '@/shared/lib/utils'
+
+interface ComplianceSnapshotPanelProps {
+  snapshot?: ComplianceSnapshot | null
+  className?: string
+}
+
+function shortDigest(digest?: string) {
+  if (!digest) {
+    return '—'
+  }
+  if (digest.length <= 20) {
+    return digest
+  }
+  return `${digest.slice(0, 17)}…`
+}
+
+export function ComplianceSnapshotPanel({ snapshot, className }: ComplianceSnapshotPanelProps) {
+  const { t } = useTranslation()
+  const items = snapshot?.items?.filter((item) => item.standard || item.controlId) ?? []
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={cn('rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-4', className)}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <ShieldCheck className="h-4 w-4 text-emerald-500" />
+          {t('compliance.title')}
+          <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+            {t('compliance.mappingCount', { count: items.length })}
+          </span>
+        </div>
+        <div className="font-mono text-xs text-muted-foreground" title={snapshot?.digest}>
+          {shortDigest(snapshot?.digest)}
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {items.map((item, index) => (
+          <div key={`${item.standard ?? 'standard'}-${item.version ?? 'version'}-${item.controlId ?? index}`} className="rounded-xl border border-border/60 bg-background/70 p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full bg-secondary px-2 py-0.5 font-mono text-xs text-secondary-foreground">
+                {item.standard ?? t('compliance.unknownStandard')}
+              </span>
+              {item.version ? (
+                <span className="font-mono text-xs text-muted-foreground">{item.version}</span>
+              ) : null}
+              <span className="font-mono text-sm font-semibold text-foreground">{item.controlId ?? '—'}</span>
+            </div>
+            {item.title ? (
+              <div className="mt-1 text-sm text-muted-foreground">{item.title}</div>
+            ) : null}
+            {item.evidence && item.evidence.length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {item.evidence.map((evidence, evidenceIndex) => (
+                  <span
+                    key={`${evidence.type ?? 'evidence'}-${evidence.path ?? evidence.url ?? evidenceIndex}`}
+                    className="inline-flex items-center gap-1 rounded-full border border-border/60 px-2 py-0.5 text-xs text-muted-foreground"
+                    title={evidence.sha256}
+                  >
+                    {evidence.url ? <ExternalLink className="h-3 w-3" /> : null}
+                    {evidence.path ?? evidence.url ?? evidence.type ?? t('compliance.evidence')}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,4 +1,10 @@
 {
+  "compliance": {
+    "title": "Compliance mappings",
+    "mappingCount": "{{count}} items",
+    "unknownStandard": "Unknown standard",
+    "evidence": "Evidence"
+  },
   "nav": {
     "landing": "Home",
     "home": "Skill Center",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1,4 +1,10 @@
 {
+  "compliance": {
+    "title": "合规映射",
+    "mappingCount": "{{count}} 项",
+    "unknownStandard": "未知标准",
+    "evidence": "证据"
+  },
   "nav": {
     "landing": "首页",
     "home": "技能中心",

--- a/web/src/pages/skill-detail.tsx
+++ b/web/src/pages/skill-detail.tsx
@@ -12,6 +12,7 @@ import type { SkillFile } from '@/api/types'
 import { InstallCommand } from '@/features/skill/install-command'
 import { ShareButton } from '@/features/skill/share-button'
 import { SkillLabelPanel } from '@/features/skill/skill-label-panel'
+import { ComplianceSnapshotPanel } from '@/features/skill/compliance-snapshot-panel'
 import {
   getOverviewCollapseMaxHeight,
   OVERVIEW_COLLAPSE_DESKTOP_MAX_HEIGHT,
@@ -1061,6 +1062,7 @@ export function SkillDetailPage() {
                       {version.changelog && (
                         <p className="text-sm text-muted-foreground leading-relaxed">{version.changelog}</p>
                       )}
+                      <ComplianceSnapshotPanel snapshot={version.complianceSnapshot} className="mt-3" />
                       <div className="text-xs text-muted-foreground mt-2 flex items-center gap-3">
                         <span>{t('skillDetail.fileCount', { count: version.fileCount })}</span>
                         <span className="w-1 h-1 rounded-full bg-muted-foreground/40" />


### PR DESCRIPTION
## Summary

Closes #556.

This PR adds optional SkillHub/Astron compliance metadata for skill versions:

- validates optional `x-astron-compliance` frontmatter during publish;
- snapshots normalized mappings into version `parsedMetadataJson.complianceSnapshot`;
- exposes the snapshot in version list/detail and review detail responses;
- renders a compact compliance mapping panel in skill/review version views;
- indexes `standard`, `version`, `controlId`, and `title` so searches like `T1059` can find mapped skills.

Out of scope:

- no required compliance field;
- no independent compliance API;
- no runtime execution trace responsibility inside SkillHub;
- no dedicated compliance filter UI yet.

## Validation

- Backend targeted tests:
  - `ComplianceMetadataServiceTest`
  - `SkillPackageValidatorTest`
  - `SkillPublishServiceTest`
  - `ComplianceSnapshotProjectionServiceTest`
  - `ReviewSkillDetailAppServiceTest`
  - `SkillControllerTest`
  - `ReviewPortalControllerTest`
  - `PostgresSearchRebuildServiceTest`
- Frontend:
  - `pnpm --dir web exec vitest run src/features/skill/compliance-snapshot-panel.test.tsx src/features/review/review-skill-detail-section.test.tsx`
  - `pnpm --dir web run typecheck`
  - `pnpm --dir web run lint`
- OpenAPI:
  - `TMPDIR=<private-run-dir> ./scripts/check-openapi-generated.sh`
- Local containerized staging:
  - built `skillhub-server:staging`
  - built web production assets
  - ran `scripts/smoke-test.sh http://localhost:8080`: 15 passed, 0 failed
- Runtime business check on staging:
  - published a zip package with `x-astron-compliance`
  - version detail returned `complianceSnapshot.items[0].controlId = T1059`
  - version list returned `complianceSnapshot`
  - search `T1059` returned `compliance-runtime-556`

## Notes

The local staging web container required a private compose override setting
`SKILLHUB_TRUST_FORWARDED_PROTO=false` because `docker-compose.staging.yml` uses `nginx:alpine`
directly rather than the web image default. `compose.release.yml` already carries this variable.
That staging-only gap is not changed in this PR.

