### PR TITLE
fix(deploy): correct Aliyun runtime stop URL

### DIFF
--- a/scripts/runtime.sh
+++ b/scripts/runtime.sh
@@ -119,10 +119,12 @@ done
 if [ "$USE_ALIYUN" = "true" ]; then
   SKILLHUB_RAW_BASE="${SKILLHUB_RAW_BASE:-https://imageless.oss-cn-beijing.aliyuncs.com}"
   RUNTIME_SCRIPT_URL="$SKILLHUB_RAW_BASE/runtime.sh"
+  RUNTIME_SOURCE_ARG=" --aliyun"
   echo "Using Aliyun OSS for runtime files: $SKILLHUB_RAW_BASE"
 else
   SKILLHUB_RAW_BASE="${SKILLHUB_RAW_BASE:-https://raw.githubusercontent.com/iflytek/skillhub/$SKILLHUB_REF}"
   RUNTIME_SCRIPT_URL="$SKILLHUB_RAW_BASE/scripts/runtime.sh"
+  RUNTIME_SOURCE_ARG=""
   echo "Using GitHub raw for runtime files: $SKILLHUB_RAW_BASE"
 fi
 COMPOSE_FILE="$SKILLHUB_HOME/compose.release.yml"
@@ -398,7 +400,7 @@ Web UI: $PUBLIC_URL
 Backend API: http://localhost:8080
 Runtime dir: $SKILLHUB_HOME
 Stop with:
-  curl -fsSL $RUNTIME_SCRIPT_URL | sh -s -- down$HOME_ARG
+  curl -fsSL $RUNTIME_SCRIPT_URL | sh -s -- down$RUNTIME_SOURCE_ARG$HOME_ARG
 EOF
     ;;
   down)

--- a/scripts/runtime.sh
+++ b/scripts/runtime.sh
@@ -118,9 +118,11 @@ done
 
 if [ "$USE_ALIYUN" = "true" ]; then
   SKILLHUB_RAW_BASE="${SKILLHUB_RAW_BASE:-https://imageless.oss-cn-beijing.aliyuncs.com}"
+  RUNTIME_SCRIPT_URL="$SKILLHUB_RAW_BASE/runtime.sh"
   echo "Using Aliyun OSS for runtime files: $SKILLHUB_RAW_BASE"
 else
   SKILLHUB_RAW_BASE="${SKILLHUB_RAW_BASE:-https://raw.githubusercontent.com/iflytek/skillhub/$SKILLHUB_REF}"
+  RUNTIME_SCRIPT_URL="$SKILLHUB_RAW_BASE/scripts/runtime.sh"
   echo "Using GitHub raw for runtime files: $SKILLHUB_RAW_BASE"
 fi
 COMPOSE_FILE="$SKILLHUB_HOME/compose.release.yml"
@@ -396,7 +398,7 @@ Web UI: $PUBLIC_URL
 Backend API: http://localhost:8080
 Runtime dir: $SKILLHUB_HOME
 Stop with:
-  curl -fsSL $SKILLHUB_RAW_BASE/scripts/runtime.sh | sh -s -- down$HOME_ARG
+  curl -fsSL $RUNTIME_SCRIPT_URL | sh -s -- down$HOME_ARG
 EOF
     ;;
   down)

--- a/scripts/tests/runtime-secret-test.sh
+++ b/scripts/tests/runtime-secret-test.sh
@@ -92,6 +92,19 @@ grep -Fq "Generated SKILLHUB_DOWNLOAD_ANON_COOKIE_SECRET" "$stdout_generated" \
 if grep -Fq "$generated_secret" "$stdout_generated"; then
   fail "runtime must not print the generated secret value"
 fi
+grep -Fq "curl -fsSL file://$REPO_ROOT/scripts/runtime.sh | sh -s -- down --home $home_generated" "$stdout_generated" \
+  || fail "GitHub runtime should print the scripts/runtime.sh stop URL"
+
+home_aliyun="$tmp/aliyun"
+stdout_aliyun="$tmp/aliyun.out"
+mkdir -p "$home_aliyun"
+run_runtime "$home_aliyun" "$bin_dir" "$stdout_aliyun" --aliyun
+
+grep -Fq "curl -fsSL file://$REPO_ROOT/runtime.sh | sh -s -- down --home $home_aliyun" "$stdout_aliyun" \
+  || fail "Aliyun runtime should print the root runtime.sh stop URL"
+if grep -Fq "file://$REPO_ROOT/scripts/runtime.sh" "$stdout_aliyun"; then
+  fail "Aliyun runtime must not print the GitHub scripts/runtime.sh path"
+fi
 
 home_preserved="$tmp/preserved"
 stdout_preserved="$tmp/preserved.out"

--- a/scripts/tests/runtime-secret-test.sh
+++ b/scripts/tests/runtime-secret-test.sh
@@ -100,8 +100,8 @@ stdout_aliyun="$tmp/aliyun.out"
 mkdir -p "$home_aliyun"
 run_runtime "$home_aliyun" "$bin_dir" "$stdout_aliyun" --aliyun
 
-grep -Fq "curl -fsSL file://$REPO_ROOT/runtime.sh | sh -s -- down --home $home_aliyun" "$stdout_aliyun" \
-  || fail "Aliyun runtime should print the root runtime.sh stop URL"
+grep -Fq "curl -fsSL file://$REPO_ROOT/runtime.sh | sh -s -- down --aliyun --home $home_aliyun" "$stdout_aliyun" \
+  || fail "Aliyun runtime should preserve the root runtime.sh URL and --aliyun source mode"
 if grep -Fq "file://$REPO_ROOT/scripts/runtime.sh" "$stdout_aliyun"; then
   fail "Aliyun runtime must not print the GitHub scripts/runtime.sh path"
 fi


### PR DESCRIPTION
## What

- Print the Aliyun OSS root-level `runtime.sh` URL in the post-install stop command.
- Keep the GitHub Raw stop command pointed at `scripts/runtime.sh`.
- Add regression assertions for both download layouts.

## Why

Aliyun publishes the runtime entry point at `/runtime.sh`, while the repository stores it at `/scripts/runtime.sh`. The shared completion message always appended `/scripts/runtime.sh`, so `runtime.sh --aliyun` printed a stop command that returned 404 even though installation and startup succeeded.

## How

Resolve `RUNTIME_SCRIPT_URL` when selecting the download source, then reuse that exact URL in the completion message.

## Testing

- `sh -n scripts/runtime.sh`
- `bash -n scripts/tests/runtime-secret-test.sh`
- `bash scripts/tests/runtime-secret-test.sh`
- `bash scripts/tests/validate-release-config-test.sh`
- `bash scripts/tests/workflow-security-test.sh`
- `bash scripts/tests/dev-web-host-test.sh`
- `bash scripts/tests/publish-cli-test.sh`
- `make typecheck-web`
- `make lint-web`
- Backend Maven regression under Java 21: 722 tests, 0 failures, 0 errors, 1 skipped

`make staging` was not run because the shared host already has unrelated services bound to the fixed staging ports 5432, 80, and 8080. Those services were left untouched.

## Impact

No installation, startup, image, configuration, or API behavior changes. This only corrects the operator-facing stop command printed after an Aliyun deployment.

## Ordinary-user validation follow-up

A clean `v0.2.16` README deployment on the open-source validation host reproduced the defect: the printed `/scripts/runtime.sh` URL returns 404, the shell pipeline exits 0, and all five containers remain running. The follow-up commit also preserves `--aliyun` in the corrected command so lifecycle operations continue using the same public distribution source instead of falling back to GitHub Raw.

The public OSS installer otherwise passed root-path install, registry pull, 15/15 administrator smoke, same-volume restart, and clean reinstall checks. The three official Dockerfiles also built from a clean public tag checkout and their resulting images passed 15/15 smoke.