### PR TITLE
fix(web): avatar falls back to user initials when image fails to load

### DIFF
--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -7,6 +7,7 @@ import { canViewGovernanceCenter } from '@/shared/lib/governance-access'
 import { getHeadlineVersion } from '@/shared/lib/skill-lifecycle'
 import { TokenList } from '@/features/token/token-list'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card'
+import { UserAvatar } from '@/shared/components/user-avatar'
 import { APP_SHELL_PAGE_CLASS_NAME } from '@/app/page-shell-style'
 import { limitPreviewItems } from './dashboard-preview'
 
@@ -42,11 +43,12 @@ export function DashboardPage() {
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="flex items-center gap-5">
-            {user?.avatarUrl && (
-              <img
+            {user && (
+              <UserAvatar
                 src={user.avatarUrl}
-                alt={user.displayName}
+                name={user.displayName}
                 className="h-20 w-20 rounded-2xl border-2 border-border/60 shadow-card"
+                textClassName="text-2xl font-semibold"
               />
             )}
             <div className="space-y-1.5">

--- a/web/src/pages/settings/profile.tsx
+++ b/web/src/pages/settings/profile.tsx
@@ -9,6 +9,7 @@ import { toast } from '@/shared/lib/toast'
 import { Button } from '@/shared/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card'
 import { Input } from '@/shared/ui/input'
+import { UserAvatar } from '@/shared/components/user-avatar'
 
 /** Regex matching allowed display name characters: Chinese, English, digits, spaces, underscore, hyphen. */
 const DISPLAY_NAME_PATTERN = /^[\u4e00-\u9fa5a-zA-Z0-9_ -]+$/
@@ -197,12 +198,13 @@ export function ProfileSettingsPage() {
         </CardHeader>
         <CardContent className="space-y-6">
           {/* Avatar (read-only) */}
-          {effectiveAvatarUrl ? (
+          {effectiveDisplayName ? (
             <div className="flex items-center gap-4">
-              <img
+              <UserAvatar
                 src={effectiveAvatarUrl}
-                alt={effectiveDisplayName}
+                name={effectiveDisplayName}
                 className="h-16 w-16 rounded-2xl border-2 border-border/60 shadow-card"
+                textClassName="text-xl font-semibold"
               />
             </div>
           ) : null}

--- a/web/src/shared/components/user-avatar.test.tsx
+++ b/web/src/shared/components/user-avatar.test.tsx
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { UserAvatar } from './user-avatar'
+
+describe('UserAvatar', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the image when a src is provided', () => {
+    render(<UserAvatar src="https://example.com/avatar.png" name="Ada Lovelace" />)
+    const img = screen.getByRole('img', { name: 'Ada Lovelace' })
+    expect(img.tagName).toBe('IMG')
+    expect(img.getAttribute('src')).toBe('https://example.com/avatar.png')
+  })
+
+  it('renders initials when no src is provided', () => {
+    render(<UserAvatar name="Ada Lovelace" />)
+    const fallback = screen.getByRole('img', { name: 'Ada Lovelace' })
+    expect(fallback.tagName).toBe('DIV')
+    expect(fallback.textContent).toBe('AL')
+  })
+
+  it('falls back to initials when the image fails to load', () => {
+    render(<UserAvatar src="https://example.com/broken.png" name="Grace Hopper" />)
+    const img = screen.getByRole('img', { name: 'Grace Hopper' })
+
+    fireEvent.error(img)
+
+    const fallback = screen.getByRole('img', { name: 'Grace Hopper' })
+    expect(fallback.tagName).toBe('DIV')
+    expect(fallback.textContent).toBe('GH')
+  })
+
+  it('derives a two-letter initial from a single-word name', () => {
+    render(<UserAvatar name="madonna" />)
+    expect(screen.getByRole('img', { name: 'madonna' }).textContent).toBe('MA')
+  })
+})

--- a/web/src/shared/components/user-avatar.tsx
+++ b/web/src/shared/components/user-avatar.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+import { cn } from '@/shared/lib/utils'
+
+interface UserAvatarProps {
+  /** Avatar image URL. Some OIDC providers (e.g. Microsoft Entra) return a
+   *  `picture` claim that points at an authenticated endpoint the browser
+   *  cannot fetch directly, so this can fail to load even when set. */
+  src?: string | null
+  /** Display name used to derive fallback initials and the accessible label. */
+  name: string
+  /** Applied to both the <img> and the fallback element, so callers keep
+   *  full control over size/shape (e.g. `w-8 h-8 rounded-full`). */
+  className?: string
+  /** Font size/weight for the fallback initials. Defaults to a size that
+   *  works for small (~32px) avatars; pass a larger size for bigger ones. */
+  textClassName?: string
+}
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) {
+    return '?'
+  }
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase()
+  }
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+/**
+ * Renders a user's avatar image, falling back to a badge with their
+ * initials when there is no image URL or the image fails to load.
+ */
+export function UserAvatar({ src, name, className, textClassName = 'text-sm font-semibold' }: UserAvatarProps) {
+  const [failed, setFailed] = useState(false)
+
+  // Reset the failure flag when the source changes, e.g. after re-login
+  // with a different provider or a profile update.
+  useEffect(() => {
+    setFailed(false)
+  }, [src])
+
+  if (!src || failed) {
+    return (
+      <div
+        role="img"
+        aria-label={name}
+        className={cn(
+          'flex items-center justify-center bg-muted text-muted-foreground',
+          textClassName,
+          className,
+        )}
+      >
+        {getInitials(name)}
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={src}
+      alt={name}
+      loading="lazy"
+      className={className}
+      onError={() => setFailed(true)}
+    />
+  )
+}

--- a/web/src/shared/components/user-menu.tsx
+++ b/web/src/shared/components/user-menu.tsx
@@ -9,6 +9,7 @@ import { clearSessionScopedQueries } from '@/features/notification/notification-
 import { canViewGovernanceCenter } from '@/shared/lib/governance-access'
 import { withBasePath } from '@/shared/lib/base-path'
 import { cn } from '@/shared/lib/utils'
+import { UserAvatar } from '@/shared/components/user-avatar'
 
 interface User {
   displayName: string
@@ -122,14 +123,12 @@ export function UserMenu({ user, triggerClassName }: UserMenuProps) {
         className={cn('flex items-center gap-3 text-foreground hover:opacity-80 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-md', triggerClassName)}
         onClick={() => setIsClickOpen((current) => !current)}
       >
-        {user.avatarUrl && (
-          <img
-            src={user.avatarUrl}
-            alt={user.displayName}
-            loading="lazy"
-            className="w-8 h-8 rounded-full border border-border/60"
-          />
-        )}
+        <UserAvatar
+          src={user.avatarUrl}
+          name={user.displayName}
+          className="w-8 h-8 rounded-full border border-border/60"
+          textClassName="text-xs font-semibold"
+        />
         <span className="text-sm font-medium text-inherit">
           {user.displayName}
         </span>


### PR DESCRIPTION
## Problem

When the user's `picture`/avatar claim from an OIDC identity provider points at an authenticated endpoint, the plain `<img>` tag used for the avatar cannot load it, and the browser shows the broken-image icon (plus the `alt` text) instead of any avatar.

A concrete case: **Microsoft Entra ID** returns profile photos from `https://graph.microsoft.com/v1.0/me/photo/$value`, which requires a `Bearer` access token on the request. A browser-rendered `<img src="...">` has no way to attach that header, so the request is unauthenticated and fails — even though the `avatarUrl` value itself is valid and was correctly stored/returned by the backend.

This isn't specific to Entra: the same broken-image UI shows up for any IdP whose photo URL is not directly and anonymously fetchable, or simply for any avatar URL that has gone stale/404s.

## Before / after

- **Before**: header user menu, dashboard, and profile settings all rendered a raw `<img src={avatarUrl}>`. On load failure, the browser's broken-image icon + `alt` text showed instead of the user's photo.
- **After**: a new `UserAvatar` component renders the image, and on `onError` (or when there's no avatar URL at all) falls back to a small badge with the user's initials, styled to match the existing avatar sizing/shape at each call site (rounded-full in the header menu, rounded-2xl on the dashboard and profile pages).

## Change

- Add `web/src/shared/components/user-avatar.tsx`: a small component with `src`/`name`/`className`/`textClassName` props. It tracks an `onError` flag in state (reset when `src` changes) and swaps to a `div` with initials derived from `name` when there's no `src` or the image failed to load.
- Wire it into the three places that rendered a raw `<img>` for the current user's avatar:
  - `web/src/shared/components/user-menu.tsx` (header/nav)
  - `web/src/pages/dashboard.tsx`
  - `web/src/pages/settings/profile.tsx`
- Add `web/src/shared/components/user-avatar.test.tsx` covering: image render, initials fallback with no `src`, initials fallback on `onError`, and initials derivation from a single-word name.

The project doesn't currently depend on `@radix-ui/react-avatar` (only `dialog`/`dropdown-menu`/`select` are used from Radix), so this adds a small local component instead of a new dependency, following the existing pattern of composed components under `web/src/shared/components/` (e.g. `namespace-badge.tsx`).

## Scope / non-goals

- No API or type changes — `avatarUrl` stays `string | undefined | null` everywhere.
- No new dependencies.
- Namespace avatars (`namespace-header.tsx`) are left untouched since they're not user photos and out of scope for this fix; happy to follow up if maintainers want the same treatment there.

## Testing

From `web/`:

```
pnpm install
pnpm lint       # eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0 -> clean
pnpm typecheck  # tsc --noEmit -> clean
pnpm test       # vitest run -> 193 files / 676 tests passed
pnpm build      # tsc -b && vite build -> succeeds
```