### PR TITLE
fix(dev): use bash for backend launchers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dev-all: ## 一键启动本地开发环境（依赖 + scanner + 后端 + 前端�
 		echo "Backend already running with PID $$(cat $(DEV_SERVER_PID))"; \
 	else \
 		echo "Starting backend..."; \
-		$(DEV_PROCESS) start --pid-file $(DEV_SERVER_PID) --log-file $(DEV_SERVER_LOG) --cwd server -- /bin/sh -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)' >/dev/null; \
+		$(DEV_PROCESS) start --pid-file $(DEV_SERVER_PID) --log-file $(DEV_SERVER_LOG) --cwd server -- bash -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)' >/dev/null; \
 	fi
 	@if $(DEV_PROCESS) status --pid-file $(DEV_WEB_PID) >/dev/null 2>&1; then \
 		echo "Frontend already running with PID $$(cat $(DEV_WEB_PID))"; \
@@ -69,7 +69,7 @@ dev-all: ## 一键启动本地开发环境（依赖 + scanner + 后端 + 前端�
 			echo "Backend did not become ready on attempt $$attempt. Restarting..."; \
 			$(DEV_PROCESS) stop --pid-file $(DEV_SERVER_PID); \
 			sleep 2; \
-			$(DEV_PROCESS) start --pid-file $(DEV_SERVER_PID) --log-file $(DEV_SERVER_LOG) --cwd server -- /bin/sh -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)' >/dev/null; \
+			$(DEV_PROCESS) start --pid-file $(DEV_SERVER_PID) --log-file $(DEV_SERVER_LOG) --cwd server -- bash -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)' >/dev/null; \
 		fi; \
 	done; \
 		if [ "$$backend_ready" -ne 1 ]; then \
@@ -127,12 +127,12 @@ dev-all: ## 一键启动本地开发环境（依赖 + scanner + 后端 + 前端�
 	@echo "  Frontend: $(DEV_WEB_LOG)"
 
 dev-server: ## 启动后端开发服务器
-	cd server && /bin/sh -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)'
+	cd server && bash -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)'
 
 dev-server-restart: ## 重启后端开发服务器
 	@mkdir -p $(DEV_DIR)
 	@$(DEV_PROCESS) stop --pid-file $(DEV_SERVER_PID)
-	@$(DEV_PROCESS) start --pid-file $(DEV_SERVER_PID) --log-file $(DEV_SERVER_LOG) --cwd server -- /bin/sh -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)' >/dev/null
+	@$(DEV_PROCESS) start --pid-file $(DEV_SERVER_PID) --log-file $(DEV_SERVER_LOG) --cwd server -- bash -lc '$(DEV_SERVER_PREPARE) && exec env $(DEV_SERVER_SCANNER_ENV) $(DEV_SERVER_CMD)' >/dev/null
 	@echo "Waiting for backend on $(DEV_API_URL) ..."
 	@for i in $$(seq 1 30); do \
 		if curl -sf $(DEV_API_URL)/actuator/health >/dev/null; then \

--- a/scripts/tests/dev-web-host-test.sh
+++ b/scripts/tests/dev-web-host-test.sh
@@ -15,8 +15,18 @@ grep -Eq '^DEV_WEB_HOST[[:space:]]*\?=[[:space:]]*127\.0\.0\.1$' "$MAKEFILE" \
 grep -Fq 'pnpm exec vite --host $(DEV_WEB_HOST)' "$MAKEFILE" \
   || fail "dev web startup must pass DEV_WEB_HOST to vite"
 
-grep -Fq "cd server && /bin/sh -lc '\$(DEV_SERVER_PREPARE) && exec env \$(DEV_SERVER_SCANNER_ENV) \$(DEV_SERVER_CMD)'" "$MAKEFILE" \
+grep -Fq "cd server && bash -lc '\$(DEV_SERVER_PREPARE) && exec env \$(DEV_SERVER_SCANNER_ENV) \$(DEV_SERVER_CMD)'" "$MAKEFILE" \
   || fail "dev-server must inject scanner upload environment"
+
+if grep -Fq "/bin/sh -lc '\$(DEV_SERVER_PREPARE)" "$MAKEFILE"; then
+  fail "backend dev launchers must use bash for bash-compatible login profiles"
+fi
+
+make -C "$REPO_ROOT" --no-print-directory dev-server \
+  DEV_SERVER_PREPARE='grep -q ready <(printf ready)' \
+  DEV_SERVER_SCANNER_ENV= \
+  DEV_SERVER_CMD=true >/dev/null \
+  || fail "dev-server must execute bash-compatible preparation commands"
 
 if grep -Fq 'pnpm exec vite --host 0.0.0.0' "$MAKEFILE"; then
   fail "dev web startup must not bind Vite to 0.0.0.0 by default"


### PR DESCRIPTION
## Summary

- Replace the four backend development launchers that use /bin/sh -lc with bash -lc.
- Keep DEV_SERVER_PREPARE, scanner environment injection, restart behavior, and process supervision unchanged.
- Extend the existing PR scripts regression to reject the legacy shell and execute a Bash process-substitution preparation command.

The reported WSL failure happens while dash evaluates a Bash-oriented login profile generated by mise, before run-dev-app.sh starts. The repository's development scripts already require Bash, so using Bash for the login command matches the existing runtime contract.

Fixes #709.

## Validation

- [x] Backend tests passed
- [x] Frontend typecheck/build passed
- [x] OpenAPI SDK regenerated or checked when API contracts changed (no API change)
- [x] Smoke test run when relevant

Local checks:

- git diff --check
- static assertion: exactly four backend launchers use bash -lc
- static assertion: no backend launcher retains /bin/sh -lc
- regression script contains a Bash process-substitution execution case

GitHub validation:

- Script Regression Tests passed, including scripts/tests/dev-web-host-test.sh
- Server Unit Tests and Web Build And Test passed
- CLI passed on Ubuntu, macOS, and Windows
- Dependency Review, DCO, and CLA passed
- E2E (Real Services) started the full dev stack successfully and passed the complete Playwright suite

The real-services workflow directly exercises the make dev-all startup path on Ubuntu, covering the Linux/Bash behavior reported in #709.

## Risk

- User-facing impact: make dev-all, make dev-server, and make dev-server-restart now invoke the Bash already required by repository scripts.
- Deployment or migration impact: none; production images and runtime configuration are unchanged.
- Rollback approach: revert this commit to restore the previous launcher shell.

## Notes

- Related issue: #709
- Follow-up work: none expected.
- Docs or operator runbooks updated when behavior changed: no user command or configuration changed.
