### PR TITLE
feat: add initial RISC-V image support

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,9 +13,6 @@ permissions:
   contents: read
   packages: write
 
-env:
-  DOCKER_PLATFORMS: linux/amd64,linux/arm64
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -31,16 +28,19 @@ jobs:
           - name: server
             context: ./server
             dockerfile: ./server/Dockerfile
+            platforms: linux/amd64,linux/arm64,linux/riscv64
             image: ghcr.io/${{ github.repository_owner }}/skillhub-server
             mirror_image: skillhub-server
           - name: web
             context: ./web
             dockerfile: ./web/Dockerfile
+            platforms: linux/amd64,linux/arm64,linux/riscv64
             image: ghcr.io/${{ github.repository_owner }}/skillhub-web
             mirror_image: skillhub-web
           - name: scanner
             context: ./scanner
             dockerfile: ./scanner/Dockerfile
+            platforms: linux/amd64,linux/arm64
             image: ghcr.io/${{ github.repository_owner }}/skillhub-scanner
             mirror_image: skillhub-scanner
 
@@ -109,7 +109,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          platforms: ${{ env.DOCKER_PLATFORMS }}
+          platforms: ${{ matrix.platforms }}
           push: true
           provenance: false
           sbom: false

--- a/.github/workflows/riscv64-images.yml
+++ b/.github/workflows/riscv64-images.yml
@@ -1,0 +1,64 @@
+name: RISC-V Images
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/riscv64-images.yml'
+      - 'server/**'
+      - 'web/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }} (linux/riscv64)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: server
+            context: ./server
+            dockerfile: ./server/Dockerfile
+          - name: web
+            context: ./web
+            dockerfile: ./web/Dockerfile
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build RISC-V image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/riscv64
+          load: true
+          tags: skillhub-${{ matrix.name }}:riscv64-ci
+          cache-from: type=gha,scope=riscv64-${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=riscv64-${{ matrix.name }}
+
+      - name: Verify image architecture and runtime
+        shell: bash
+        run: |
+          image="skillhub-${{ matrix.name }}:riscv64-ci"
+          test "$(docker image inspect "$image" --format '{{.Architecture}}')" = riscv64
+          case "${{ matrix.name }}" in
+            server)
+              docker run --rm --platform linux/riscv64 --entrypoint java "$image" -version
+              ;;
+            web)
+              docker run --rm --platform linux/riscv64 --entrypoint nginx "$image" -v
+              ;;
+          esac

--- a/.github/workflows/riscv64-images.yml
+++ b/.github/workflows/riscv64-images.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/riscv64-images.yml'
+      - '.github/workflows/publish-images.yml'
       - 'server/**'
       - 'web/**'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -236,7 +236,9 @@ frontend schema, and fails if the checked-in SDK is stale.
 Published runtime images are built by GitHub Actions and pushed to GHCR.
 This is the supported path for anyone who wants a ready-to-use local
 environment without building the backend or frontend on their machine.
-Published images target both `linux/amd64` and `linux/arm64`.
+Published server and web images target `linux/amd64`, `linux/arm64`, and
+`linux/riscv64`; the scanner image currently targets `linux/amd64` and
+`linux/arm64`.
 
 **Quick deployment with curl:**
 

--- a/docs/01-system-architecture.md
+++ b/docs/01-system-architecture.md
@@ -136,7 +136,8 @@ skillhub/
 
 - 开发路径：`make dev-all`。前后端在宿主机运行，`docker-compose.yml` 只负责 PostgreSQL、Redis、MinIO。
 - 交付路径：GitHub Actions 构建并发布 `server` / `web` 镜像；用户通过 `compose.release.yml` 在本地一键拉起前后端容器和基础服务。
-- 发布镜像为多架构 manifest，至少覆盖 `linux/amd64` 与 `linux/arm64`。
+- 发布镜像为多架构 manifest：`server` / `web` 覆盖 `linux/amd64`、`linux/arm64` 与
+  `linux/riscv64`；`scanner` 暂保持 `linux/amd64` 与 `linux/arm64`。
 
 单机运行时统一入口：
 - `http://localhost/` → Web 容器（Nginx）
@@ -169,7 +170,8 @@ skillhub/
 - 数据库迁移：Flyway
 - 认证：Spring Security OAuth2 Client（一期 GitHub）
 - 镜像发布：GitHub Actions 推送至 GHCR，默认维护 `edge` 与语义化版本标签
-- 运行时兼容：发布镜像默认输出 `linux/amd64` + `linux/arm64` 多架构 manifest
+- 运行时兼容：`server` / `web` 发布镜像默认输出 `linux/amd64` + `linux/arm64` +
+  `linux/riscv64` 多架构 manifest，`scanner` 暂保持 `linux/amd64` + `linux/arm64`
 
 ## 11. Repository / Query Boundary 约定
 

--- a/docs/09-deployment.md
+++ b/docs/09-deployment.md
@@ -10,7 +10,8 @@
 - 单机交付环境：`docker compose --env-file .env.release -f compose.release.yml up -d`
   - 前端和后端都运行在容器内
 - 使用 GitHub Actions 发布到 GHCR 的镜像
-- 默认发布 `linux/amd64` 与 `linux/arm64` 多架构镜像
+- 默认发布多架构镜像：`server` / `web` 覆盖 `linux/amd64`、`linux/arm64` 与
+  `linux/riscv64`，`scanner` 暂保持 `linux/amd64` 与 `linux/arm64`
   - PostgreSQL、Redis 与应用容器一起通过 Compose 启动
 
 不再维护本地构建整套 demo 容器的中间模式，也不再保留 `docker-compose.prod.yml`。
@@ -205,7 +206,8 @@ Sentinel 配置优先于 Cluster 和单机 `host`/`port`。在 Kubernetes 等 Se
    - `ghcr.io/iflytek/skillhub-server`
    - `ghcr.io/iflytek/skillhub-web`
 5. 写入 `edge` / `vX.Y.Z` / `latest` / `sha-*` 标签
-6. 同时发布 `linux/amd64` 与 `linux/arm64` manifest，避免 Apple Silicon / ARM 主机依赖模拟层
+6. 同时发布多架构 manifest：`server` / `web` 覆盖 `linux/amd64`、`linux/arm64` 与
+   `linux/riscv64`，`scanner` 暂保持 `linux/amd64` 与 `linux/arm64`
 
 ## 7 配置管理
 

--- a/docs/RISCV64.md
+++ b/docs/RISCV64.md
@@ -1,0 +1,51 @@
+# RISC-V (`linux/riscv64`) support
+
+## Current scope
+
+RISC-V support is incremental. The SkillHub server and web images have
+`linux/riscv64` build and runtime paths. The security scanner and the complete
+Docker Compose deployment are not yet supported on RISC-V.
+
+| Component | `linux/riscv64` status | Notes |
+| --- | --- | --- |
+| `skillhub-server` | Supported | The architecture-neutral Java 21 JAR is built on the Buildx host and copied into the target-architecture Eclipse Temurin runtime. |
+| `skillhub-web` | Supported | Static assets are built on the Buildx host and served by a target-architecture Nginx runtime. |
+| `skillhub-scanner` | Not yet verified | Its Python dependency tree still needs a native-extension and runtime audit. |
+| PostgreSQL 16 and Redis 7 | Upstream images available | Keep these images explicitly pinned and verify them on the target board before production use. |
+| Complete Compose stack | Unsupported | `compose.release.yml` starts the unverified scanner, so do not deploy it unchanged on RISC-V. |
+
+## Build the supported images
+
+Buildx can create both images from an AMD64 or ARM64 host. Register a RISC-V
+QEMU handler before running these commands when the host is not RISC-V:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install riscv64
+docker buildx create --use --name skillhub-riscv64
+
+docker buildx build \
+  --platform linux/riscv64 \
+  --file server/Dockerfile \
+  --tag skillhub-server:riscv64 \
+  --load \
+  server
+
+docker buildx build \
+  --platform linux/riscv64 \
+  --file web/Dockerfile \
+  --tag skillhub-web:riscv64 \
+  --load \
+  web
+```
+
+The release workflow publishes `linux/amd64`, `linux/arm64`, and
+`linux/riscv64` variants for `skillhub-server` and `skillhub-web`. The scanner
+remains limited to its existing AMD64/ARM64 platform list.
+
+## Verification boundary
+
+The pull-request workflow builds both supported target images, checks their OCI
+architecture metadata, and executes the Java and Nginx runtimes under RISC-V
+emulation. This is a component-image guardrail, not a full-stack integration
+test. A native RISC-V smoke test with PostgreSQL, Redis, object storage, and a
+verified scanner remains required before claiming complete deployment support.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,8 @@
-# ---- Build Stage ----
-FROM eclipse-temurin:21-jdk-alpine AS build
+# syntax=docker/dockerfile:1
+
+# Build the architecture-neutral JAR on the Buildx host. This avoids emulating
+# the complete Maven build when the target image is linux/riscv64.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-alpine AS build
 WORKDIR /app
 
 # Cache dependencies
@@ -19,8 +22,14 @@ COPY . .
 RUN ./mvnw package -DskipTests -B
 
 # ---- Runtime Stage ----
-FROM eclipse-temurin:21-jre-alpine
-RUN addgroup -S app && adduser -S app -G app
+# The Noble variant publishes a linux/riscv64 image; the Alpine JRE currently
+# used by this project is limited to amd64 and arm64.
+FROM eclipse-temurin:21-jre-noble
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --system app && \
+    useradd --system --gid app --create-home app
 WORKDIR /app
 
 COPY --from=build /app/skillhub-app/target/*.jar app.jar

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # Build the architecture-neutral JAR on the Buildx host. This avoids emulating
 # the complete Maven build when the target image is linux/riscv64.
 FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-alpine AS build

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,9 @@
-FROM node:22-alpine AS build
+# syntax=docker/dockerfile:1
+
+# The frontend output is static and architecture-neutral. Build it on the
+# Buildx host so linux/riscv64 does not depend on a target-architecture Node.js
+# image; only the multi-architecture Nginx runtime is target-specific.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 RUN corepack enable
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # The frontend output is static and architecture-neutral. Build it on the
 # Buildx host so linux/riscv64 does not depend on a target-architecture Node.js
 # image; only the multi-architecture Nginx runtime is target-specific.


### PR DESCRIPTION
## Summary

- Add an initial, explicitly scoped `linux/riscv64` image path for the SkillHub server and web frontend.
- Publish server/web manifests for AMD64, ARM64, and RISC-V while keeping the unverified scanner on its existing AMD64/ARM64 platform list.
- Add a pull-request guardrail that builds both RISC-V images, checks OCI architecture metadata, and executes the Java and Nginx runtimes under QEMU.
- Document the supported components, build commands, and full-stack limitations.

## Why this is needed

This PR is part of the iFLYTEK community adaptation work for the [Open Source Promotion Plan 2026](https://docs2026.summer.ospp.ac.cn/help/CommunityGuide). It provides a reviewable first step toward running SkillHub on RISC-V without claiming that unverified components already work.

The current publishing workflow applies one platform list to all images. That makes it impossible to extend only the components with a valid RISC-V path. This change moves the platform list into each matrix entry so support can expand service by service.

## Design

### Server image

The Java 21 JAR is architecture-neutral, so Maven runs on the Buildx host via `FROM --platform=$BUILDPLATFORM`. The runtime moves from the AMD64/ARM64-only Alpine Temurin variant to the Noble Temurin JRE, which publishes a `linux/riscv64` variant. The runtime remains non-root and retains the existing health check.

### Web image

The Vite output is static and architecture-neutral. Node.js therefore runs on the Buildx host, while only the Nginx runtime targets RISC-V. This avoids making the target image depend on a RISC-V Node 22 builder.

### Publishing and CI

| Image | Published platforms |
| --- | --- |
| `skillhub-server` | `linux/amd64,linux/arm64,linux/riscv64` |
| `skillhub-web` | `linux/amd64,linux/arm64,linux/riscv64` |
| `skillhub-scanner` | `linux/amd64,linux/arm64` (unchanged) |

The new `RISC-V Images` workflow builds and loads both target images, verifies `.Architecture == riscv64`, and starts the target Java/Nginx binaries under QEMU.

## Validation

- [ ] Backend tests passed
- [x] Frontend typecheck/build passed
- [x] OpenAPI SDK regeneration is not required; no API contract changed
- [ ] Full staging smoke test run

Commands run locally:

```bash
pnpm install --frozen-lockfile
pnpm exec tsc --noEmit
pnpm exec tsc -b
pnpm exec vite build
git diff --check origin/main...HEAD
```

Local results:

- Frontend dependency installation, typecheck, TypeScript project build, and Vite production build passed.
- `git diff --check` passed.
- Backend tests could not run on the Windows workstation because no system Maven/JDK launcher is available.
- Full staging could not run because Docker is not installed on the workstation.
- The PR workflow is the authoritative target-architecture build/runtime check and the existing repository CI remains responsible for normal backend validation.

## Scope and limitations

This PR does **not** claim full SkillHub deployment support on RISC-V:

- `skillhub-scanner` remains unverified because its Python/native dependency tree still needs an architecture audit.
- `compose.release.yml` starts the scanner, so it must not be deployed unchanged as a supported RISC-V stack.
- PostgreSQL, Redis, object storage, and end-to-end integration still require a native-board smoke test before a full-stack support claim.
- No application behavior, database schema, or API contract changes.

## Risk

- User-facing impact: none for existing AMD64/ARM64 users; server runtime base changes from Alpine to Noble.
- Deployment impact: future server/web release manifests gain a RISC-V variant; scanner publishing is unchanged.
- Rollback: remove `linux/riscv64` from the two matrix entries and revert the Dockerfile build/runtime stage changes.

## Notes

- Documentation: `docs/RISCV64.md`
- Follow-up: audit the scanner and the complete Compose dependency stack on native RISC-V hardware.
