### PR TITLE
fix(auth): close API token policy gaps against the authorization list

### DIFF
--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistry.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistry.java
@@ -34,9 +34,15 @@ public class RouteSecurityPolicyRegistry {
             RouteAuthorizationPolicy.permitAll(null, "/.well-known/**"),
             RouteAuthorizationPolicy.roles(null, "/actuator/prometheus", "SUPER_ADMIN", "AUDITOR"),
             RouteAuthorizationPolicy.authenticated(HttpMethod.GET, "/api/v1/skills/*/star"),
+            RouteAuthorizationPolicy.authenticated(HttpMethod.PUT, "/api/v1/skills/*/star"),
+            RouteAuthorizationPolicy.authenticated(HttpMethod.DELETE, "/api/v1/skills/*/star"),
             RouteAuthorizationPolicy.authenticated(HttpMethod.GET, "/api/v1/skills/*/rating"),
+            RouteAuthorizationPolicy.authenticated(HttpMethod.PUT, "/api/v1/skills/*/rating"),
             RouteAuthorizationPolicy.authenticated(HttpMethod.GET, "/api/web/skills/*/star"),
+            RouteAuthorizationPolicy.authenticated(HttpMethod.PUT, "/api/web/skills/*/star"),
+            RouteAuthorizationPolicy.authenticated(HttpMethod.DELETE, "/api/web/skills/*/star"),
             RouteAuthorizationPolicy.authenticated(HttpMethod.GET, "/api/web/skills/*/rating"),
+            RouteAuthorizationPolicy.authenticated(HttpMethod.PUT, "/api/web/skills/*/rating"),
             RouteAuthorizationPolicy.permitAll(HttpMethod.GET, "/api/v1/skills"),
             RouteAuthorizationPolicy.permitAll(HttpMethod.GET, "/api/v1/skills/*/*"),
             RouteAuthorizationPolicy.permitAll(HttpMethod.GET, "/api/v1/skills/*/*/versions"),
@@ -89,6 +95,7 @@ public class RouteSecurityPolicyRegistry {
     private static final List<ApiTokenPolicy> API_TOKEN_POLICIES = List.of(
             ApiTokenPolicy.allow(null, "/api/v1/health"),
             ApiTokenPolicy.allow(null, "/api/v1/auth/providers"),
+            ApiTokenPolicy.allow(null, "/api/v1/auth/methods"),
             ApiTokenPolicy.allow(null, "/api/v1/auth/me"),
             ApiTokenPolicy.allow(null, "/api/v1/auth/device/**"),
             ApiTokenPolicy.allow(null, "/api/v1/check"),
@@ -98,12 +105,21 @@ public class RouteSecurityPolicyRegistry {
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/v1/skills/**"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/web/skills"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/web/skills/**"),
+            ApiTokenPolicy.allow(HttpMethod.GET, "/api/v1/labels"),
+            ApiTokenPolicy.allow(HttpMethod.GET, "/api/web/labels"),
+            ApiTokenPolicy.allow(HttpMethod.PUT, "/api/v1/skills/*/star"),
+            ApiTokenPolicy.allow(HttpMethod.DELETE, "/api/v1/skills/*/star"),
+            ApiTokenPolicy.allow(HttpMethod.PUT, "/api/v1/skills/*/rating"),
+            ApiTokenPolicy.allow(HttpMethod.PUT, "/api/web/skills/*/star"),
+            ApiTokenPolicy.allow(HttpMethod.DELETE, "/api/web/skills/*/star"),
+            ApiTokenPolicy.allow(HttpMethod.PUT, "/api/web/skills/*/rating"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/v1/namespaces"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/v1/namespaces/*"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/web/namespaces"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/web/namespaces/*"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/v1/resolve/**"),
             ApiTokenPolicy.allow(HttpMethod.GET, "/api/v1/download"),
+            ApiTokenPolicy.allow(HttpMethod.GET, "/api/v1/download/**"),
             ApiTokenPolicy.allow(null, "/.well-known/**"),
             ApiTokenPolicy.allow(null, "/actuator/health"),
             ApiTokenPolicy.allow(null, "/v3/api-docs/**"),
@@ -126,10 +142,44 @@ public class RouteSecurityPolicyRegistry {
             ApiTokenPolicy.require(HttpMethod.POST, "/api/cli/v1/skills/*/publish/validate", "skill:publish")
     );
 
+    /**
+     * Authorization routes that intentionally have no API-token counterpart, keyed as
+     * {@code "<METHOD|ANY> <pattern>"} to match {@link #routeKey(HttpMethod, String)}.
+     *
+     * <p>These are browser-session surfaces: the interactive login flows, the admin console,
+     * and skill deletion through the web surface, which goes through {@code /api/v1} or
+     * {@code /api/cli/v1} with the {@code skill:delete} scope instead. Bearer tokens are
+     * deliberately rejected on exactly these routes and nowhere else &mdash; anything else the
+     * authorization list opens must also be reachable with a token holding the required scope.</p>
+     */
+    private static final Set<String> SESSION_ONLY_ROUTES = Set.of(
+            "ANY /api/v1/auth/session/bootstrap",
+            "ANY /api/v1/auth/direct/login",
+            "ANY /api/v1/auth/local/**",
+            "ANY /api/v1/admin/**",
+            "DELETE /api/web/skills/id/*",
+            "DELETE /api/web/skills/*/*"
+    );
+
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     public List<RouteAuthorizationPolicy> authorizationPolicies() {
         return AUTHORIZATION_POLICIES;
+    }
+
+    /**
+     * Authorization routes that are deliberately unreachable with an API token.
+     */
+    public Set<String> sessionOnlyRoutes() {
+        return SESSION_ONLY_ROUTES;
+    }
+
+    /**
+     * Stable key for a route in the authorization list, used to pair it with
+     * {@link #sessionOnlyRoutes()}.
+     */
+    public static String routeKey(HttpMethod method, String pattern) {
+        return (method == null ? "ANY" : method.name()) + " " + pattern;
     }
 
     public ApiTokenAuthorizationDecision authorizeApiToken(String method, String path, Set<String> tokenScopes) {

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistryTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistryTest.java
@@ -5,10 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.springframework.http.HttpMethod;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class RouteSecurityPolicyRegistryTest {
+
+    private static final Set<String> ALL_SCOPES =
+            Set.of("skill:read", "skill:publish", "skill:delete", "token:manage");
 
     private final RouteSecurityPolicyRegistry registry = new RouteSecurityPolicyRegistry();
 
@@ -129,5 +134,84 @@ class RouteSecurityPolicyRegistryTest {
     void shouldProjectRequestContext_onlyForApiRoutes() {
         assertTrue(registry.shouldProjectRequestContext("/api/web/namespaces/team-a"));
         assertFalse(registry.shouldProjectRequestContext("/assets/index.css"));
+    }
+
+    @Test
+    void authorizeApiToken_allowsPublicLabelCatalogue() {
+        assertTrue(registry.authorizeApiToken("GET", "/api/v1/labels", Set.of()).allowed());
+        assertTrue(registry.authorizeApiToken("GET", "/api/web/labels", Set.of()).allowed());
+    }
+
+    @Test
+    void authorizeApiToken_allowsStarAndRatingWritesWithoutSkillDeleteScope() {
+        assertTrue(registry.authorizeApiToken("PUT", "/api/v1/skills/42/star", Set.of("skill:read")).allowed());
+        assertTrue(registry.authorizeApiToken("DELETE", "/api/v1/skills/42/star", Set.of("skill:read")).allowed());
+        assertTrue(registry.authorizeApiToken("PUT", "/api/v1/skills/42/rating", Set.of("skill:read")).allowed());
+    }
+
+    @Test
+    void authorizationPolicies_declareStarAndRatingWritesBeforeTheSuperAdminDeleteRule() {
+        int unstar = indexOf(HttpMethod.DELETE, "/api/v1/skills/*/star");
+        int hardDelete = indexOf(HttpMethod.DELETE, "/api/v1/skills/*/*");
+
+        assertTrue(unstar >= 0, "un-star must have its own authorization policy");
+        assertTrue(hardDelete >= 0);
+        assertTrue(unstar < hardDelete, "un-star must be matched before the SUPER_ADMIN hard-delete rule");
+    }
+
+    @Test
+    void authorizeApiToken_allowsDownloadsBelowTheDownloadRoot() {
+        assertTrue(registry.authorizeApiToken("GET", "/api/v1/download/global/demo-skill", Set.of()).allowed());
+    }
+
+    @Test
+    void apiTokenPolicies_coverEveryTokenReachableAuthorizationRoute() {
+        List<String> gaps = new ArrayList<>();
+
+        for (RouteSecurityPolicyRegistry.RouteAuthorizationPolicy policy : registry.authorizationPolicies()) {
+            if (policy.accessLevel() == RouteSecurityPolicyRegistry.AccessLevel.ROLE_PROTECTED) {
+                continue;
+            }
+            if (!policy.pattern().startsWith("/api/")) {
+                continue;
+            }
+            String key = RouteSecurityPolicyRegistry.routeKey(policy.method(), policy.pattern());
+            if (registry.sessionOnlyRoutes().contains(key)) {
+                continue;
+            }
+
+            String method = policy.method() == null ? "GET" : policy.method().name();
+            String path = samplePath(policy.pattern());
+            if (!registry.authorizeApiToken(method, path, ALL_SCOPES).allowed()) {
+                gaps.add(key);
+            }
+        }
+
+        assertTrue(gaps.isEmpty(),
+                "Authorization routes with no API-token policy and no session-only declaration: " + gaps);
+    }
+
+    @Test
+    void sessionOnlyRoutes_areRejectedForApiTokens() {
+        for (String route : registry.sessionOnlyRoutes()) {
+            String[] parts = route.split(" ", 2);
+            String method = "ANY".equals(parts[0]) ? "POST" : parts[0];
+            assertFalse(registry.authorizeApiToken(method, samplePath(parts[1]), ALL_SCOPES).allowed(),
+                    "session-only route must stay closed to API tokens: " + route);
+        }
+    }
+
+    private int indexOf(HttpMethod method, String pattern) {
+        List<RouteSecurityPolicyRegistry.RouteAuthorizationPolicy> policies = registry.authorizationPolicies();
+        for (int i = 0; i < policies.size(); i++) {
+            if (policies.get(i).method() == method && pattern.equals(policies.get(i).pattern())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String samplePath(String pattern) {
+        return pattern.replace("/**", "/sample/leaf").replace("*", "sample");
     }
 }


### PR DESCRIPTION
## Summary

- **What changed?** `RouteSecurityPolicyRegistry` keeps two independent policy lists — `AUTHORIZATION_POLICIES` (session/cookie) and `API_TOKEN_POLICIES` (Bearer token) — and nothing keeps them in step. Any route the authorization list opens but the token list never registers falls through to the catch-all and answers `API token cannot access endpoint: <path>`. This registers the missing routes and adds a test that fails when the two lists drift again.
- **Why is this needed?** Closes #713. To answer the question in the issue directly: it was **not** deliberate — `/api/v1/labels` was simply never added to the token list.

### Routes reported in #713

| Route | Before | After |
|---|---|---|
| `GET /api/v1/labels` | `API token cannot access endpoint` | allowed (public catalogue, matches its `permitAll` authorization policy) |
| `PUT/DELETE /api/v1/skills/{id}/star` | rejected, or wrongly demanded `skill:delete` | allowed |
| `PUT /api/v1/skills/{id}/rating` | `API token cannot access endpoint` | allowed |

### Same-class gaps found while auditing

- `GET /api/v1/auth/methods` — public discovery endpoint next to `/auth/providers`, which was registered; this one was not.
- `GET /api/v1/download/**` — the token list registered only the bare `/api/v1/download`, so every actual download path below it was refused.

### A separate authorization bug this surfaced

`DELETE /api/v1/skills/{id}/star` also matched `roles(DELETE, "/api/v1/skills/*/*", "SUPER_ADMIN")`, because `/api/v1/skills/42/star` fits that two-segment wildcard. Un-starring a skill through `/api/v1` therefore required `SUPER_ADMIN` **on the session path as well**, not just for tokens. Star and rating writes now carry their own `authenticated` entries placed ahead of that rule, so the hard-delete policy no longer swallows them.

### Keeping the lists in step

The two lists are allowed to diverge on exactly one set of routes, now declared explicitly rather than by omission:

```java
private static final Set<String> SESSION_ONLY_ROUTES = Set.of(
        "ANY /api/v1/auth/session/bootstrap",
        "ANY /api/v1/auth/direct/login",
        "ANY /api/v1/auth/local/**",
        "ANY /api/v1/admin/**",
        "DELETE /api/web/skills/id/*",
        "DELETE /api/web/skills/*/*"
);
```

Interactive login flows, the admin console, and skill deletion through the browser surface — token clients delete through `/api/v1` or `/api/cli/v1` with `skill:delete`. `apiTokenPolicies_coverEveryTokenReachableAuthorizationRoute` walks `AUTHORIZATION_POLICIES` and fails the build when a non-role-protected `/api/**` route is neither token-reachable nor listed above, so the next endpoint added to one list has to be considered for the other.

Entries are method-keyed (`"<METHOD|ANY> <pattern>"`), which matters here: `/api/web/skills/*/*` is session-only for `DELETE` while still readable with a token over `GET`.

## Validation

- [ ] Backend tests passed
- [ ] Frontend typecheck/build passed (not applicable: no frontend changes)
- [x] OpenAPI SDK regenerated or checked when API contracts changed (no contract change — routes and payloads are unchanged, only who may reach them)
- [ ] Smoke test run when relevant (not applicable)

**I could not run `mvn test` — no JDK is available on the machine this was written on, so CI is the first real execution.** To avoid pushing an unverified guard, the policy tables and the guard logic were replayed outside the JVM with a script that parses both lists straight out of the Java source and reproduces `AntPathMatcher` semantics for the pattern shapes used here (`*` = one segment, trailing `/**` = one or more):

```
authorization policies: 74  api-token policies: 47
drift gaps:               none
session-only leaks:       none
issue #713 regressions:   none
un-star index 19 < hard-delete index 58: True
```

Please treat that as a sanity check on the data, not as a substitute for the suite.

## Risk

- **User-facing impact:** API tokens can now read the label catalogue and manage star/rating state, and can download below `/api/v1/download`. Un-starring over `/api/v1` starts working for ordinary accounts. No route becomes anonymously reachable — `AUTHORIZATION_POLICIES` still gates authentication, and the new star/rating entries are `authenticated`.
- **Deployment or migration impact:** none. No schema, config, or contract change.
- **Rollback approach:** revert the commit; the lists return to their previous contents.

## Notes

- Related issue: #713
- Follow-up work: skill label attach/detach (`PUT`/`DELETE /api/v1/skills/*/*/labels/*`) is still token-unreachable. It is not covered by `AUTHORIZATION_POLICIES`, so the new guard does not catch it, and picking a scope for it (`skill:publish`?) is a product decision I did not want to make inside a bug fix.
- Docs or operator runbooks updated when behavior changed: `docs/03-authentication-design.md` documents the four scopes, which are unchanged.
