### PR TITLE
fix(security): 扫描任务改为事务提交后发布 (Closes #612)

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/security/SecurityScanService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/security/SecurityScanService.java
@@ -12,8 +12,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -86,21 +84,9 @@ public class SecurityScanService {
                 System.currentTimeMillis(),
                 Map.of("scannerType", ScannerType.SKILL_SCANNER.getValue())
         );
-        // Publish the scan task only after this transaction commits, so the
-        // stream consumer cannot observe the task before the skill_version /
-        // security_audit rows are visible (issue #612). On rollback the task
-        // is never published. Fall back to inline publish if somehow called
-        // outside a transaction.
-        if (TransactionSynchronizationManager.isSynchronizationActive()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    scanTaskProducer.publishScanTask(scanTask);
-                }
-            });
-        } else {
-            scanTaskProducer.publishScanTask(scanTask);
-        }
+        // The stream consumer must not observe this task before skill_version /
+        // security_audit rows are committed and visible.
+        TransactionCommitCallbacks.afterCommitOrNow(() -> scanTaskProducer.publishScanTask(scanTask));
         // Only transition to SCANNING if the version is not already published (auto-publish flow)
         if (version.getStatus() != SkillVersionStatus.PUBLISHED) {
             version.setStatus(SkillVersionStatus.SCANNING);

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/security/SecurityScanService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/security/SecurityScanService.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -75,7 +77,7 @@ public class SecurityScanService {
         }
         // Always create a new audit record — supports multiple rounds per version
         auditRepository.save(new SecurityAudit(versionId, ScannerType.SKILL_SCANNER));
-        scanTaskProducer.publishScanTask(new ScanTask(
+        final ScanTask scanTask = new ScanTask(
                 UUID.randomUUID().toString(),
                 versionId,
                 packagePath,
@@ -83,7 +85,22 @@ public class SecurityScanService {
                 publisherId,
                 System.currentTimeMillis(),
                 Map.of("scannerType", ScannerType.SKILL_SCANNER.getValue())
-        ));
+        );
+        // Publish the scan task only after this transaction commits, so the
+        // stream consumer cannot observe the task before the skill_version /
+        // security_audit rows are visible (issue #612). On rollback the task
+        // is never published. Fall back to inline publish if somehow called
+        // outside a transaction.
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    scanTaskProducer.publishScanTask(scanTask);
+                }
+            });
+        } else {
+            scanTaskProducer.publishScanTask(scanTask);
+        }
         // Only transition to SCANNING if the version is not already published (auto-publish flow)
         if (version.getStatus() != SkillVersionStatus.PUBLISHED) {
             version.setStatus(SkillVersionStatus.SCANNING);

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/security/TransactionCommitCallbacks.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/security/TransactionCommitCallbacks.java
@@ -1,0 +1,31 @@
+package com.iflytek.skillhub.domain.security;
+
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Keeps Spring transaction callback plumbing out of domain workflows.
+ */
+final class TransactionCommitCallbacks {
+
+    private TransactionCommitCallbacks() {
+    }
+
+    /**
+     * Runs the callback after the current transaction commits, or immediately when no transaction
+     * synchronization is active.
+     */
+    static void afterCommitOrNow(Runnable callback) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            callback.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                callback.run();
+            }
+        });
+    }
+}

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/security/SecurityScanServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/security/SecurityScanServiceTest.java
@@ -5,21 +5,26 @@ import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVersionRepository;
 import com.iflytek.skillhub.domain.skill.SkillVersionStatus;
 import com.iflytek.skillhub.domain.skill.validation.PackageEntry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +51,13 @@ class SecurityScanServiceTest {
                 "local",
                 true
         );
+    }
+
+    @AfterEach
+    void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test
@@ -122,6 +134,54 @@ class SecurityScanServiceTest {
         assertThat(task.versionId()).isEqualTo(42L);
         assertThat(task.skillPath()).isNull();
         assertThat(task.bundleKey()).isEqualTo("packages/8/42/bundle.zip");
+    }
+
+    @Test
+    void triggerScan_defersTaskPublishingUntilTransactionCommit() throws Exception {
+        SkillVersion version = new SkillVersion(8L, "1.0.0", "publisher-1");
+        setId(version, 42L);
+        PackageEntry entry = new PackageEntry(
+                "README.md",
+                "# demo".getBytes(),
+                6L,
+                "text/markdown"
+        );
+
+        given(skillVersionRepository.findById(42L)).willReturn(Optional.of(version));
+        TransactionSynchronizationManager.initSynchronization();
+
+        service.triggerScan(42L, List.of(entry), "publisher-1");
+
+        verify(auditRepository).save(any(SecurityAudit.class));
+        verify(skillVersionRepository).save(version);
+        verify(scanTaskProducer, never()).publishScanTask(any(ScanTask.class));
+        assertThat(version.getStatus()).isEqualTo(SkillVersionStatus.SCANNING);
+
+        commitRegisteredSynchronizations();
+
+        ArgumentCaptor<ScanTask> taskCaptor = ArgumentCaptor.forClass(ScanTask.class);
+        verify(scanTaskProducer).publishScanTask(taskCaptor.capture());
+        assertThat(taskCaptor.getValue().versionId()).isEqualTo(42L);
+    }
+
+    @Test
+    void triggerScan_doesNotPublishTaskWhenTransactionNeverCommits() throws Exception {
+        SkillVersion version = new SkillVersion(8L, "1.0.0", "publisher-1");
+        setId(version, 42L);
+        PackageEntry entry = new PackageEntry(
+                "README.md",
+                "# demo".getBytes(),
+                6L,
+                "text/markdown"
+        );
+
+        given(skillVersionRepository.findById(42L)).willReturn(Optional.of(version));
+        TransactionSynchronizationManager.initSynchronization();
+
+        service.triggerScan(42L, List.of(entry), "publisher-1");
+
+        verify(auditRepository).save(any(SecurityAudit.class));
+        verify(scanTaskProducer, never()).publishScanTask(any(ScanTask.class));
     }
 
     @Test
@@ -263,5 +323,11 @@ class SecurityScanServiceTest {
         Field field = target.getClass().getDeclaredField("id");
         field.setAccessible(true);
         field.set(target, id);
+    }
+
+    private void commitRegisteredSynchronizations() {
+        for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+            synchronization.afterCommit();
+        }
     }
 }


### PR DESCRIPTION
Closes #612

感谢 @XiaoSeS 的分析，根因和定位都很准确。这个 PR 按 issue 指出的方向修复。

## 问题

`SecurityScanService.triggerScan` 是 `@Transactional`，但 `scanTaskProducer.publishScanTask(...)` 在**事务提交前**就把扫描任务发到了 Redis Stream。消费者可能在 `skill_version` / `security_audit` 行对其他连接可见之前就收到任务，于是抛 `SkillVersion not found` / `SecurityAudit not found`；而 `AbstractStreamConsumer` 会立即重试并 ack 掉失败消息，**重试可能在发布事务还没提交时就耗尽**，最终让已提交的版本卡在 `SCANNING`。

## 修复

把发布延迟到事务**提交之后**再执行：

```java
if (TransactionSynchronizationManager.isSynchronizationActive()) {
    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
        @Override
        public void afterCommit() {
            scanTaskProducer.publishScanTask(scanTask);
        }
    });
} else {
    scanTaskProducer.publishScanTask(scanTask);
}
```

- 消费者只会在 `skill_version` / `security_audit` 行**已提交且可见之后**看到任务，从根上消除竞态。
- 事务**回滚时任务永不发布**（旧代码在回滚场景下已经把任务发出去了，会产生一个指向不存在版本的幽灵任务）。
- `isSynchronizationActive()` 兜底：万一在事务外被调用，退化为原来的内联发布，行为不变。

改动仅限 `SecurityScanService.triggerScan`（+16/-2），审计记录的保存、状态流转、`ScanTask` 内容均不变。

## 说明

- 本机没有 Maven 环境，未能本地跑构建，依赖仓库 CI 编译/测试验证——改动是标准的 Spring `TransactionSynchronization` afterCommit 模式，仅新增两个 `org.springframework.transaction.support.*` import。
- 这是 #612–#617 这组并发/事务问题里最自包含的一个；其余几个（并发发布竞态 #617、审计失败提交 #615、陈旧会话 #614、并发 OAuth 绑定 #613）我没有一并动，等 @XiaoSeS / 维护者对方向的意见——如果你们更希望自己来修这一组，我这个也请随意调整或接手。
