### PR TITLE
fix(publish): emit event on confirm publish

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillReviewSubmitService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillReviewSubmitService.java
@@ -1,5 +1,6 @@
 package com.iflytek.skillhub.domain.skill.service;
 
+import com.iflytek.skillhub.domain.event.SkillPublishedEvent;
 import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
 import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.review.ReviewTask;
@@ -145,6 +146,9 @@ public class SkillReviewSubmitService {
         skill.setLatestVersionId(versionId);
         skill.setUpdatedBy(actorUserId);
         skillRepository.save(skill);
+
+        eventPublisher.publishEvent(new SkillPublishedEvent(
+                skill.getId(), version.getId(), actorUserId));
     }
 
     private void assertCanManageLifecycle(Skill skill, String actorUserId, Map<Long, NamespaceRole> userNamespaceRoles) {

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillReviewSubmitServiceTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/service/SkillReviewSubmitServiceTest.java
@@ -1,5 +1,6 @@
 package com.iflytek.skillhub.domain.skill.service;
 
+import com.iflytek.skillhub.domain.event.SkillPublishedEvent;
 import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.review.ReviewTask;
 import com.iflytek.skillhub.domain.review.ReviewTaskRepository;
@@ -180,7 +181,16 @@ class SkillReviewSubmitServiceTest {
             assertEquals(SkillVersionStatus.PUBLISHED, version.getStatus());
             assertNotNull(version.getPublishedAt());
             assertEquals(versionId, skill.getLatestVersionId());
+            verify(skillVersionRepository).save(version);
             verify(skillRepository).save(skill);
+
+            ArgumentCaptor<SkillPublishedEvent> eventCaptor =
+                    ArgumentCaptor.forClass(SkillPublishedEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            SkillPublishedEvent event = eventCaptor.getValue();
+            assertEquals(skillId, event.skillId());
+            assertEquals(versionId, event.versionId());
+            assertEquals(userId, event.publisherId());
         }
 
         @Test
@@ -225,6 +235,7 @@ class SkillReviewSubmitServiceTest {
             // When/Then
             assertThrows(DomainBadRequestException.class,
                     () -> service.confirmPublish(skillId, versionId, userId, Map.of()));
+            verify(eventPublisher, never()).publishEvent(any());
         }
 
         @Test
@@ -244,6 +255,31 @@ class SkillReviewSubmitServiceTest {
             // When/Then
             assertThrows(DomainBadRequestException.class,
                     () -> service.confirmPublish(skillId, versionId, userId, Map.of()));
+            verify(eventPublisher, never()).publishEvent(any());
+        }
+
+        @Test
+        @DisplayName("should not publish event when skill persistence fails")
+        void shouldNotPublishEventWhenSkillPersistenceFails() {
+            // Given
+            Long skillId = 1L;
+            Long versionId = 100L;
+            String userId = "user-1";
+
+            Skill skill = createSkill(skillId, userId, 10L, SkillVisibility.PRIVATE);
+            SkillVersion version = createVersion(versionId, skillId, SkillVersionStatus.UPLOADED);
+            RuntimeException persistenceFailure = new RuntimeException("skill save failed");
+
+            when(skillRepository.findById(skillId)).thenReturn(Optional.of(skill));
+            when(skillVersionRepository.findById(versionId)).thenReturn(Optional.of(version));
+            when(skillRepository.save(skill)).thenThrow(persistenceFailure);
+
+            // When/Then
+            RuntimeException thrown = assertThrows(RuntimeException.class,
+                    () -> service.confirmPublish(skillId, versionId, userId, Map.of()));
+            assertSame(persistenceFailure, thrown);
+            verify(skillVersionRepository).save(version);
+            verify(eventPublisher, never()).publishEvent(any());
         }
     }
 


### PR DESCRIPTION
## Summary
- emit `SkillPublishedEvent` after `confirmPublish` successfully publishes a private skill version
- cover the success path and failure/no-event paths in `SkillReviewSubmitServiceTest`

## Scope
- narrow fix for #731
- does not change subscription permission filtering, frontend behavior, API contract, or scanner behavior

## Verification
- `git diff --check origin/main...HEAD`
- `./mvnw --settings=.mvn/settings.xml -pl skillhub-domain -am -Dtest=SkillReviewSubmitServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw --settings=.mvn/settings.xml -pl skillhub-app -am test`
- local exact-SHA release Compose preview smoke: 10 passed, 0 failed

Closes #731