### PR TITLE
docs(weekly): publish 2026 W34 report

### DIFF
--- a/weekly/site/reports.json
+++ b/weekly/site/reports.json
@@ -1,6 +1,13 @@
 {
-  "latest": "2026-W33",
+  "latest": "2026-W34",
   "reports": [
+    {
+      "week": "2026-W34",
+      "title": "SkillHub 开源周报｜2026 年第 34 周",
+      "period": "2026-08-14—2026-08-21",
+      "snapshot": "2026-08-21 18:23 Asia/Shanghai",
+      "path": "reports/2026-W34/"
+    },
     {
       "week": "2026-W33",
       "title": "SkillHub 开源周报｜2026 年第 33 周",

--- a/weekly/site/reports/2026-W34/index.html
+++ b/weekly/site/reports/2026-W34/index.html
@@ -1,0 +1,1651 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="SkillHub 2026 年第 33 周开源周报：仓库状态、主分支迭代与生态进展。">
+  <title>SkillHub 开源周报｜2026 年第 33 周</title>
+  <script>document.documentElement.classList.add('js')</script>
+  <style data-report-theme="notion-light">
+:root {
+  color-scheme: light;
+  --page: #ffffff;
+  --paper: #ffffff;
+  --warm: #f6f5f4;
+  --ink: #0d0d0d;
+  --ink-soft: #31302e;
+  --muted: #615d59;
+  --faint: #76716c;
+  --line: #e5e3e1;
+  --line-soft: #efeeec;
+  --blue: #0075de;
+  --blue-active: #005bab;
+  --blue-soft: #f2f9ff;
+  --green: #147a33;
+  --green-soft: #e9f7ec;
+  --orange: #b84d00;
+  --orange-soft: #fdf0e3;
+  --red: #b52d25;
+  --red-soft: #fdecea;
+  --neutral-soft: #f1f0ef;
+  --focus: #097fe8;
+  --radius-sm: 8px;
+  --radius: 12px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 4%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 15px/1.65 Inter, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--blue-active);
+  text-decoration: underline;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--neutral-soft);
+  color: var(--ink-soft);
+  font-size: .92em;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 30;
+  top: 8px;
+  left: -999px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background: var(--ink-soft);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: 8px;
+}
+
+.report {
+  width: min(1200px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.masthead {
+  padding: 44px 28px 36px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 26px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: var(--ink-soft);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.brand-name {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+}
+
+.brand-tag {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--neutral-soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.utility-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 820px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(32px, 4vw, 44px);
+  line-height: 1.15;
+  letter-spacing: -.025em;
+}
+
+.report-sub {
+  margin: 8px 0 24px;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.header-grid {
+  display: grid;
+  grid-template-columns: 1.15fr .85fr;
+  gap: 16px;
+}
+
+.meta-card,
+.headline {
+  border-radius: var(--radius-sm);
+  padding: 20px 22px;
+}
+
+.meta-card {
+  background: var(--warm);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.meta-item .key,
+.headline-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--faint);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: .01em;
+}
+
+.meta-item .value {
+  color: var(--ink-soft);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.period {
+  margin: 0;
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  border: 0;
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.headline-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 7px;
+}
+
+.headline-status strong {
+  color: var(--orange);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.headline p {
+  margin: 0;
+  max-width: 60ch;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 18px;
+  border: 0;
+}
+
+.metric {
+  min-width: 0;
+  padding: 16px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.metric strong {
+  display: block;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.tabs-wrap {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+  background: rgb(255 255 255 / 97%);
+  backdrop-filter: saturate(1.1) blur(5px);
+}
+
+.tabs {
+  display: flex;
+  min-width: max-content;
+  padding: 0 28px;
+}
+
+.tab {
+  position: relative;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.tab::after {
+  position: absolute;
+  right: 14px;
+  bottom: -1px;
+  left: 14px;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.tab:hover,
+.tab[aria-selected="true"] {
+  color: var(--ink);
+}
+
+.tab[aria-selected="true"] {
+  font-weight: 600;
+}
+
+.tab[aria-selected="true"]::after {
+  background: var(--ink-soft);
+}
+
+main {
+  padding: 0 28px 48px;
+}
+
+.tab-panel {
+  padding-top: 4px;
+}
+
+.js .tab-panel[hidden] {
+  display: none;
+}
+
+.panel-intro {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.panel-intro p {
+  margin: 0;
+}
+
+section.report-section {
+  margin: 0;
+  padding: 48px 0;
+  border: 0;
+}
+
+.tab-panel > section.report-section:nth-of-type(even) {
+  background: var(--warm);
+  box-shadow: 0 0 0 100vmax var(--warm);
+  clip-path: inset(0 -100vmax);
+}
+
+section.report-section:first-of-type {
+  padding-top: 42px;
+}
+
+h2 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+h3 {
+  margin: 30px 0 12px;
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.35;
+  letter-spacing: -.01em;
+}
+
+p {
+  max-width: 75ch;
+  text-wrap: pretty;
+}
+
+.section-lead {
+  margin: -7px 0 18px;
+  color: var(--muted);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+}
+
+table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+caption {
+  padding: 10px 14px;
+  background: var(--warm);
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: #faf9f8;
+}
+
+.number {
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.status,
+.value-level {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 25px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.status::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.status.ok {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status.warn {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.status.risk {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-a {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.value-b {
+  background: var(--orange-soft);
+  color: var(--orange);
+}
+
+.value-c {
+  background: var(--blue-soft);
+  color: var(--blue-active);
+}
+
+.value-d {
+  background: var(--neutral-soft);
+  color: var(--muted);
+}
+
+.risk-note {
+  margin: 16px 0 0;
+  padding: 14px 18px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--orange-soft);
+  color: var(--ink-soft);
+}
+
+.repo-visuals {
+  display: grid;
+  grid-template-columns: minmax(280px, .85fr) minmax(0, 1.15fr);
+  gap: 18px;
+}
+
+.snapshot-list {
+  display: grid;
+  gap: 0;
+}
+
+.snapshot-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto;
+  gap: 4px 16px;
+  align-items: center;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.snapshot-row:first-child {
+  padding-top: 0;
+}
+
+.snapshot-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.snapshot-row .snapshot-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.snapshot-row strong {
+  color: var(--ink);
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.snapshot-row .snapshot-change {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.snapshot-row .snapshot-change.positive {
+  color: var(--green);
+}
+
+.snapshot-row .snapshot-change.missing {
+  color: var(--orange);
+}
+
+.chart-note {
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.ecosystem-signal {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.ecosystem-signal strong {
+  display: block;
+  color: var(--ink);
+  font-size: 24px;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ecosystem-signal span {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.ecosystem-signal-note {
+  grid-column: 1 / -1;
+  margin: -3px 0 0;
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.ecosystem-list,
+.method-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.ecosystem-list li,
+.method-list li {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.method-list li {
+  grid-template-columns: 180px 1fr;
+}
+
+.ecosystem-list strong,
+.method-list strong {
+  color: var(--ink);
+}
+
+.next-actions {
+  margin: 4px 0 30px;
+  padding: 20px 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.next-actions h2 {
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.next-actions ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.next-actions li {
+  margin: 7px 0;
+}
+
+.health-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.health-card,
+.chart-box,
+.health-note {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.health-card {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 20px 22px;
+}
+
+.health-card .top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.health-card .name {
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.health-card .health-metric {
+  color: var(--ink);
+  font-size: 27px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.health-card .health-metric small {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.health-card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.health-card .detail {
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.segbar {
+  display: flex;
+  height: 24px;
+  overflow: hidden;
+  margin: 15px 0 10px;
+  border-radius: 6px;
+  background: var(--neutral-soft);
+}
+
+.segbar > span {
+  min-width: 2px;
+  height: 100%;
+}
+
+.seg-success {
+  background: #1aae39;
+}
+
+.seg-failure {
+  background: #e16259;
+}
+
+.seg-auth {
+  background: #e8a94b;
+}
+
+.seg-skipped {
+  background: #d6d2cd;
+}
+
+.seg-cancelled {
+  background: #8e8984;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chart-legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.chart-legend b {
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.chart-box {
+  padding: 20px 22px;
+}
+
+.chart-box h3 {
+  margin: 0 0 14px;
+  font-size: 15px;
+}
+
+.bars {
+  display: grid;
+  gap: 11px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 42px;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.repo-visuals .bar-row {
+  grid-template-columns: 112px 1fr 36px;
+}
+
+.bar-label {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 16px;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--neutral-soft);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: 5px;
+  background: var(--blue);
+}
+
+.bar-fill.hot {
+  background: var(--orange);
+}
+
+.bar-value {
+  color: var(--ink-soft);
+  font-weight: 700;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.donut-layout {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 22px;
+  align-items: center;
+}
+
+.donut {
+  position: relative;
+  width: 142px;
+  height: 142px;
+  border-radius: 50%;
+  background: conic-gradient(var(--orange) 0 var(--value), #d6d2cd var(--value) 100%);
+}
+
+.donut::after {
+  position: absolute;
+  inset: 24px;
+  border-radius: 50%;
+  background: var(--paper);
+  content: "";
+}
+
+.donut-center {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.donut-center strong {
+  color: var(--ink);
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+.donut-center span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.donut-copy p {
+  margin: 0 0 9px;
+  color: var(--ink-soft);
+  font-size: 13.5px;
+}
+
+.donut-copy p:last-child {
+  margin-bottom: 0;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chart-box + .table-wrap {
+  margin-top: 18px;
+}
+
+.health-note {
+  padding: 18px;
+}
+
+.health-note h3 {
+  margin: 0 0 7px;
+  font-size: 15px;
+}
+
+.health-note p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.flow-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0 24px;
+}
+
+.flow-item {
+  padding: 16px 18px;
+  border-radius: var(--radius-sm);
+  background: var(--warm);
+}
+
+.flow-item strong {
+  display: block;
+  color: var(--ink);
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-item span {
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+details {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+summary {
+  padding: 14px 18px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.details-body {
+  padding: 0 18px 16px;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 28px 28px;
+  border-top: 1px solid var(--line);
+  background: var(--warm);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .masthead,
+  main,
+  footer {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .topline,
+  footer,
+  .panel-intro {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .header-grid,
+  .meta-grid,
+  .repo-visuals,
+  .chart-grid,
+  .health-grid,
+  .flow-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .header-grid > *,
+  .meta-item {
+    min-width: 0;
+  }
+
+  .meta-item .value {
+    overflow-wrap: anywhere;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tabs {
+    padding: 0 6px;
+  }
+
+  section.report-section {
+    padding: 38px 0;
+  }
+
+  .ecosystem-list li,
+  .method-list li {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+
+  .ecosystem-signals {
+    grid-template-columns: 1fr;
+  }
+
+  .ecosystem-signal-note {
+    grid-column: auto;
+  }
+
+  .donut-layout {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .donut-copy {
+    text-align: center;
+  }
+}
+
+@media (max-width: 430px) {
+  h1 {
+    font-size: 30px;
+    overflow-wrap: anywhere;
+  }
+
+  .bar-row {
+    grid-template-columns: 76px 1fr 32px;
+    gap: 7px;
+  }
+
+  .repo-visuals .bar-row {
+    grid-template-columns: 98px 1fr 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media print {
+  @page {
+    size: A4;
+    margin: 13mm;
+  }
+
+  body {
+    background: #fff;
+    font-size: 10px;
+  }
+
+  .report {
+    width: 100%;
+  }
+
+  .masthead,
+  main,
+  footer {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .tabs-wrap,
+  .skip-link,
+  .utility-links {
+    display: none !important;
+  }
+
+  .tab-panel[hidden] {
+    display: block !important;
+  }
+
+  .tab-panel {
+    break-before: page;
+  }
+
+  .tab-panel:first-child {
+    break-before: auto;
+  }
+
+  .tab-panel > section.report-section:nth-of-type(even) {
+    background: #fff;
+    box-shadow: none;
+    clip-path: none;
+  }
+
+  section.report-section {
+    padding: 16px 0;
+  }
+
+  h1 {
+    font-size: 27px;
+  }
+
+  h2,
+  h3,
+  tr,
+  .health-card,
+  .health-note,
+  .chart-box,
+  .next-actions {
+    break-inside: avoid;
+  }
+
+  table {
+    min-width: 0;
+    font-size: 8px;
+  }
+
+  th,
+  td {
+    padding: 5px 6px;
+  }
+
+  .health-card,
+  .health-note,
+  .chart-box {
+    box-shadow: none;
+  }
+
+  .segbar,
+  .bar-fill,
+  .donut,
+  .status,
+  .value-level,
+  .metric,
+  .headline {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}
+  </style>
+  <noscript>
+    <style>
+      .tabs-wrap { display: none !important; }
+      .tab-panel[hidden] { display: block !important; }
+    </style>
+  </noscript>
+</head>
+<body>
+  <a class="skip-link" href="#report-content">跳到报告正文</a>
+  <article class="report"
+    data-period-start="2026-08-14T00:00:00+08:00"
+    data-period-end="2026-08-21T18:20:46+08:00"
+    data-period-boundary="[)"
+    data-period-status="extended"
+    data-snapshot-at="2026-08-21T18:23:41.444491+08:00"
+    data-pr-target-branch="main"
+    data-star-evidence="current-visible-arrivals"
+    data-star-api-status="success"
+    data-star-arrivals="75"
+    data-star-observed-total="4887"
+    data-star-observed-at="2026-08-21T18:23:41.444491+08:00"
+    data-star-previous-observed-total="4910"
+    data-star-previous-observed-at="2026-08-20T14:55:22+08:00"
+    data-star-observation-delta="-23"
+    data-star-start-at=""
+    data-star-end-at="">
+    <header class="masthead">
+      <div class="topline">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">SH</span>
+          <span class="brand-name">SkillHub</span>
+          <span class="brand-tag">开源周报</span>
+        </div>
+        <nav class="utility-links" aria-label="站点链接">
+          <a href="../../archive.html">历史周报</a>
+          <a href="https://iflytek.github.io/skillhub/">项目文档</a>
+          <a href="https://github.com/iflytek/skillhub">GitHub 仓库</a>
+        </nav>
+      </div>
+      <h1>2026 年第 34 周</h1>
+      <p class="report-sub">仓库状态 · 主分支迭代 · 开源生态</p>
+      <div class="header-grid">
+        <div class="meta-card">
+          <div class="meta-grid">
+            <div class="meta-item">
+              <span class="key">统计范围</span>
+              <span class="value">2026-08-14—2026-08-21 · Asia/Shanghai</span>
+            </div>
+            <div class="meta-item">
+              <span class="key">PR 统计分支</span>
+              <span class="value"><code>main</code></span>
+            </div>
+            <div class="meta-item">
+              <span class="key">项目仓库</span>
+              <span class="value"><a href="https://github.com/iflytek/skillhub">iflytek/skillhub</a></span>
+            </div>
+            <div class="meta-item">
+              <span class="key">数据来源</span>
+              <span class="value">GitHub API（认证）· Actions · npm · Traffic</span>
+            </div>
+          </div>
+        </div>
+        <div class="headline">
+          <span class="headline-label">总体状态</span>
+          <div class="headline-status">
+            <strong>v0.2.17 已发布</strong>
+            <span class="status ok">Release 达成</span>
+          </div>
+          <p>本期面向 <code>main</code> 合并 5 个 PR，关闭 API Token、扫描事务、开发启动和发布通知问题；Issue 新增 14、关闭 5，净流入 9。Actions 有效成功率为 98.3%。8 月 21 日 18:13 发布 <a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.17">v0.2.17</a>，本期应用 / CLI Release 为 1 / 0。</p>
+        </div>
+      </div>
+      <div class="metrics" aria-label="四项核心指标">
+        <div class="metric"><strong>4,887</strong><span>Stars · 较上次观测 -23</span></div>
+        <div class="metric"><strong>789</strong><span>Forks · 仓库库存字段</span></div>
+        <div class="metric"><strong>98.3%</strong><span>Actions 有效成功率 · 114/116</span></div>
+        <div class="metric"><strong>1 / 0</strong><span>应用 / CLI Release · v0.2.17</span></div>
+      </div>
+    </header>
+
+    <div class="tabs-wrap">
+      <nav class="tabs" role="tablist" aria-label="周报视图">
+        <button class="tab" id="tab-overview" type="button" role="tab" aria-selected="true"
+          aria-controls="panel-overview" tabindex="0" data-tab="overview">总览</button>
+        <button class="tab" id="tab-health" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-health" tabindex="-1" data-tab="health">项目健康</button>
+        <button class="tab" id="tab-flow" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-flow" tabindex="-1" data-tab="flow">Issue 与 PR</button>
+        <button class="tab" id="tab-method" type="button" role="tab" aria-selected="false"
+          aria-controls="panel-method" tabindex="-1" data-tab="method">数据说明</button>
+      </nav>
+    </div>
+
+    <main id="report-content">
+      <div class="tab-panel" id="panel-overview" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-overview" data-panel="overview">
+        <div class="panel-intro">
+          <p>三分钟总览：只保留仓库、迭代和生态三类决策信息。</p>
+          <p>本期采用扩展统计范围，精确边界与数据限制见「数据说明」。</p>
+        </div>
+
+        <section class="report-section" data-module="repository-summary" aria-labelledby="repository-title">
+          <h2 id="repository-title">一、仓库关键信息</h2>
+          <div class="repo-visuals">
+            <div class="chart-box" data-module="repository-scale">
+              <h3>规模快照</h3>
+              <div class="snapshot-list">
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Stars</span>
+                  <strong>4,887</strong>
+                  <span class="snapshot-change negative">较上次观测 -23 · 本期当前可见到达 75</span>
+                </div>
+                <div class="snapshot-row">
+                  <span class="snapshot-label">Forks</span>
+                  <strong>789</strong>
+                  <span class="snapshot-change">仓库库存字段</span>
+                </div>
+              </div>
+              <p class="chart-note">认证 API 完整分页显示，本期有 75 条 <code>starred_at</code> 记录在当前列表中仍可见；这不代表周期净增长。8 月 20 日 14:55 的认证观测为 4,910，本次观测为 4,887，两个观测点之间下降 23；到达数与库存差值的时间口径不同，不能相减推断取消量。Fork 列表与仓库库存字段不一致，故不展示本期 Fork 到达数。</p>
+            </div>
+            <div class="chart-box" data-module="weekly-collaboration-chart">
+              <h3>本期协作流转</h3>
+              <div class="bars" role="img" aria-label="W34 扩展统计范围协作流转：Issue 新增 14 个、关闭 5 个；目标为 main 的 PR 新增 12 个、合并 5 个、关闭未合并 1 个">
+                <div class="bar-row"><span class="bar-label">Issue 新增</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">14</span></div>
+                <div class="bar-row"><span class="bar-label">Issue 关闭</span><span class="bar-track"><span class="bar-fill" style="width:35.7%"></span></span><span class="bar-value">5</span></div>
+                <div class="bar-row"><span class="bar-label">PR 新增</span><span class="bar-track"><span class="bar-fill" style="width:85.7%"></span></span><span class="bar-value">12</span></div>
+                <div class="bar-row"><span class="bar-label">PR 合并</span><span class="bar-track"><span class="bar-fill" style="width:35.7%"></span></span><span class="bar-value">5</span></div>
+                <div class="bar-row"><span class="bar-label">PR 关闭未合并</span><span class="bar-track"><span class="bar-fill" style="width:7.1%"></span></span><span class="bar-value">1</span></div>
+              </div>
+              <p class="chart-note">Issue 净流入 9；面向 <code>main</code> 的 PR 新增 12、合并 5、关闭未合并 1，净流入 6。输入速度仍高于完成速度，下一周期应优先收敛高价值队列。</p>
+            </div>
+          </div>
+          <p class="risk-note"><strong>数据解读：</strong>本期主要产出发生在 8 月 21 日：<a href="https://github.com/iflytek/skillhub/pull/729">#729</a>、<a href="https://github.com/iflytek/skillhub/pull/733">#733</a>、<a href="https://github.com/iflytek/skillhub/pull/721">#721</a>、<a href="https://github.com/iflytek/skillhub/pull/738">#738</a> 合入 <code>main</code> 并进入 <a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.17">v0.2.17</a>。Release 已发布，但尚无生产部署证据，不能表述为已上线。</p>
+        </section>
+
+        <section class="report-section" data-module="feature-iterations" aria-labelledby="feature-title">
+          <h2 id="feature-title">二、功能迭代信息</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>按用户价值排序的重要事项</caption>
+              <thead><tr><th>状态</th><th>事项</th><th>进展与判断</th></tr></thead>
+              <tbody>
+                <tr>
+                  <td><span class="status ok">已发布</span></td>
+                  <td><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.17">应用 v0.2.17</a></td>
+                  <td>8 月 21 日 18:13 发布，标签提交为 <code>15ce199e</code>。Release 覆盖合规元数据可见性、管理员命名空间治理，以及 API Token、扫描事务、开发启动和发布订阅通知修复。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">已发布</span></td>
+                  <td>本期三项高影响修复</td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/729">#729</a> 补齐 API Token 策略并关闭 <a href="https://github.com/iflytek/skillhub/issues/713">#713</a>；<a href="https://github.com/iflytek/skillhub/pull/733">#733</a> 修复扫描任务事务竞态并关闭 <a href="https://github.com/iflytek/skillhub/issues/612">#612</a>；<a href="https://github.com/iflytek/skillhub/pull/721">#721</a> 修复开发启动脚本并关闭 <a href="https://github.com/iflytek/skillhub/issues/709">#709</a>。三项均在本期合入并由 v0.2.17 发布。</td>
+                </tr>
+                <tr>
+                  <td><span class="status ok">已发布</span></td>
+                  <td>发布订阅通知</td>
+                  <td>窄范围修复 <a href="https://github.com/iflytek/skillhub/pull/738">#738</a> 于本期 17:52 合入 <code>main</code>，并随 v0.2.17 发布，恢复私有技能确认发布后的事件通知并关闭 <a href="https://github.com/iflytek/skillhub/issues/731">#731</a>；权限感知的扩展方案 <a href="https://github.com/iflytek/skillhub/pull/735">#735</a> 仍为开放草稿。</td>
+                </tr>
+                <tr>
+                  <td><span class="status warn">待评审</span></td>
+                  <td>RISC-V 镜像支持</td>
+                  <td><a href="https://github.com/iflytek/skillhub/pull/725">#725</a> 提交首批 RISC-V 镜像支持，相关检查已通过；截至当前快照仍未合并。</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="ecosystem-progress" aria-labelledby="ecosystem-title">
+          <h2 id="ecosystem-title">三、生态相关进展</h2>
+          <div class="ecosystem-signals" data-module="ecosystem-signals" role="img"
+            aria-label="W34 扩展统计范围开源生态参与信号：新增 Issue 作者 12 位、面向 main 的新增 PR 作者 6 位、合并外部 PR 0 个；仓库 Fork 库存 789；SkillHub CLI 可用 UTC 日桶下载 704 次">
+            <div class="ecosystem-signal"><strong>12 / 6 / 0</strong><span>新增 Issue 作者 / PR 作者 / 合并外部 PR</span></div>
+            <div class="ecosystem-signal"><strong>789</strong><span>Fork 仓库库存</span></div>
+            <div class="ecosystem-signal"><strong>704</strong><span>CLI 下载 · 可用 UTC 日桶</span></div>
+            <p class="ecosystem-signal-note">以上为独立参与信号，不构成转化漏斗。</p>
+          </div>
+          <ul class="ecosystem-list">
+            <li><strong>外部贡献输入</strong><span>本期 12 个新增 PR 中有 4 位外部作者，代表事项包括 <a href="https://github.com/iflytek/skillhub/pull/724">#724 CLI 命名空间工作区同步</a>与 <a href="https://github.com/iflytek/skillhub/pull/734">#734 OIDC 登录图标</a>；本期外部 PR 合并数仍为 0。</span></li>
+            <li><strong>架构与平台提案</strong><span><a href="https://github.com/iflytek/skillhub/issues/715">#715 Skill Suites</a>、<a href="https://github.com/iflytek/skillhub/issues/718">#718 Knowledge 包类型</a>、<a href="https://github.com/iflytek/skillhub/issues/720">#720 技能评论</a>与 <a href="https://github.com/iflytek/skillhub/issues/732">#732 团队维护者</a>形成一批高投入需求，适合先拆分边界再排期。</span></li>
+            <li><strong>安全生态连接</strong><span><a href="https://github.com/iflytek/skillhub/issues/727">#727 HOL Guard 扫描后端</a>与 <a href="https://github.com/iflytek/skillhub/issues/728">#728 Starter 插件</a>进入讨论；#727 当前标记为 P1、high risk、needs-info，尚不构成交付承诺。</span></li>
+            <li><strong>报告基础设施</strong><span><a href="https://github.com/iflytek/skillhub/pull/736">#736</a> 将经审核的 W33 周报镜像到 SkillHub Pages，属于文档与生态运营能力，不计为产品功能 Release。</span></li>
+            <li><strong>访问与获取</strong><span>可用 GitHub Traffic 日桶记录 5,879 次浏览、5,570 次克隆；npm 可用日桶记录 CLI 下载 704 次。两类日桶与本次 Asia/Shanghai 扩展范围不完全对齐，仅作生态观察。</span></li>
+          </ul>
+          <p class="chart-note"><strong>数据解读：</strong>社区输入覆盖产品、平台、安全和架构方向，但外部贡献尚未转化为合并结果。维护重点应从“接收更多输入”转向“明确范围、反馈与合并路径”。</p>
+        </section>
+
+        <aside class="next-actions" data-module="next-actions" aria-labelledby="next-title">
+          <h2 id="next-title">下周关注</h2>
+          <ul class="next-list">
+            <li>针对 <a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.17">v0.2.17</a> 验证 API Token、扫描任务、开发启动和发布通知四条关键路径；Release 已发布，但尚无生产部署证据。</li>
+            <li>明确开放草稿 <a href="https://github.com/iflytek/skillhub/pull/735">#735</a> 是否仍需承载权限感知扩展，避免与已发布的 <a href="https://github.com/iflytek/skillhub/pull/738">#738</a> 长期并行。</li>
+            <li>优先反馈外部贡献 <a href="https://github.com/iflytek/skillhub/pull/724">#724</a>、<a href="https://github.com/iflytek/skillhub/pull/734">#734</a>，给出补充、合并或关闭结论。</li>
+          </ul>
+        </aside>
+      </div>
+
+      <div class="tab-panel" id="panel-health" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-health" data-panel="health" hidden>
+        <div class="panel-intro">
+          <p>项目健康详情：区分扩展统计范围内的流量与 8 月 21 日当前快照。</p>
+          <p>流水线成功不等同于公开漏洞数量为 0。</p>
+        </div>
+
+        <section class="report-section" data-module="health-summary" aria-labelledby="health-summary-title">
+          <h2 id="health-summary-title">项目健康状态</h2>
+          <div class="health-cards">
+            <article class="health-card">
+              <div class="top"><span class="name">工程稳定性</span><span class="status warn">有失败项</span></div>
+              <div class="health-metric">98.3% <small>114/116</small></div>
+              <p>有效运行中有 2 次失败。</p>
+              <div class="detail">本期 Actions 共 189 条，另有 42 次等待授权、22 次跳过、8 次取消和 1 次运行中。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">安全流水线</span><span class="status warn">授权门禁</span></div>
+              <div class="health-metric">23 / 23 <small>有效运行成功</small></div>
+              <p>Security 另有 13 次等待授权。</p>
+              <div class="detail">只说明已执行工作流的结果，不代表漏洞数量为 0。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">自动化运营</span><span class="status warn">有两处失败</span></div>
+              <div class="health-metric">30 / 31 <small>Backlog Rescore</small></div>
+              <p>Issue Triage 成功 27 次。</p>
+              <div class="detail">Backlog Rescore 有 1 次失败且后续已恢复；DeepWiki Documentation Crawler 有 1 次失败。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Release 交付</span><span class="status ok">达成</span></div>
+              <div class="health-metric">1 / 0 <small>应用 / CLI</small></div>
+              <p><a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.17">v0.2.17</a> 于本期 18:13 发布。</p>
+              <div class="detail">包含合规元数据、命名空间治理与本期四项高影响修复；没有生产部署证据。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">Issue 治理</span><span class="status warn">净流入</span></div>
+              <div class="health-metric">+9 <small>本期净流量</small></div>
+              <p>新增 14、关闭 5；当前开放 46 个。</p>
+              <div class="detail">当前 16 个需补充信息，16 个已开放至少 30 天。</div>
+            </article>
+            <article class="health-card">
+              <div class="top"><span class="name">PR 治理</span><span class="status warn">净流入</span></div>
+              <div class="health-metric">+6 <small>本期净流量</small></div>
+              <p>面向 <code>main</code>：新增 12、合并 5、关闭未合并 1。</p>
+              <div class="detail">当前开放 16 个；本期外部 PR 合并数为 0。</div>
+            </article>
+          </div>
+        </section>
+
+        <section class="report-section" data-module="workflow-execution" aria-labelledby="actions-title">
+          <h2 id="actions-title">CI 与自动化执行</h2>
+          <p class="section-lead">本期 189 条 Actions 记录：成功 114、失败 2、等待授权 42、跳过 22、取消 8、运行中 1。</p>
+          <div class="chart-box" data-module="actions-outcome-chart">
+            <h3>Actions 结果构成</h3>
+            <div class="segbar" role="img" aria-label="W34 扩展统计范围 Actions 共 189 条记录：成功 114，失败 2，等待授权 42，条件跳过 22，取消 8，运行中 1">
+              <span class="seg-success" style="width:60.32%"></span>
+              <span class="seg-failure" style="width:1.06%"></span>
+              <span class="seg-auth" style="width:22.22%"></span>
+              <span class="seg-skipped" style="width:11.64%"></span>
+              <span class="seg-cancelled" style="width:4.76%"></span>
+            </div>
+            <div class="chart-legend" aria-hidden="true">
+              <span><i class="seg-success"></i>成功 <b>114</b></span>
+              <span><i class="seg-failure"></i>失败 <b>2</b></span>
+              <span><i class="seg-auth"></i>等待授权 <b>42</b></span>
+              <span><i class="seg-skipped"></i>跳过 <b>22</b></span>
+              <span><i class="seg-cancelled"></i>取消 8 · 运行中 <b>1</b></span>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <caption>主要工作流执行明细</caption>
+              <thead><tr><th>工作流</th><th class="number">总记录</th><th class="number">成功</th><th class="number">失败</th><th class="number">等待授权</th><th class="number">跳过/取消/运行中</th></tr></thead>
+              <tbody>
+                <tr><td>Issue Triage</td><td class="number">47</td><td class="number">27</td><td class="number">0</td><td class="number">0</td><td class="number">20</td></tr>
+                <tr><td>Security</td><td class="number">36</td><td class="number">23</td><td class="number">0</td><td class="number">13</td><td class="number">0</td></tr>
+                <tr><td>Issue Backlog Rescore</td><td class="number">31</td><td class="number">30</td><td class="number">1</td><td class="number">0</td><td class="number">0</td></tr>
+                <tr><td>PR Tests</td><td class="number">30</td><td class="number">16</td><td class="number">0</td><td class="number">13</td><td class="number">1</td></tr>
+                <tr><td>PR E2E Tests</td><td class="number">26</td><td class="number">11</td><td class="number">0</td><td class="number">11</td><td class="number">4</td></tr>
+                <tr><td>PR Scripts</td><td class="number">5</td><td class="number">2</td><td class="number">0</td><td class="number">3</td><td class="number">0</td></tr>
+                <tr><td>PR CLI</td><td class="number">3</td><td class="number">1</td><td class="number">0</td><td class="number">2</td><td class="number">0</td></tr>
+                <tr><td>其他工作流</td><td class="number">11</td><td class="number">4</td><td class="number">1</td><td class="number">0</td><td class="number">6</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>数据解读：</strong>有效成功率为 <code>114 / (114 + 2) = 98.3%</code>。失败来自 Issue Backlog Rescore 与 DeepWiki Documentation Crawler；前者后续运行已恢复，后者尚无恢复记录。42 次等待授权不进入成功率分母，但说明外部 PR 的完整检查覆盖仍受门禁影响。</p>
+        </section>
+
+        <section class="report-section" data-module="backlog-health" aria-labelledby="backlog-title">
+          <h2 id="backlog-title">当前存量健康</h2>
+          <p class="section-lead">以下为 8 月 21 日 18:23 快照，不参与本期流量计算。</p>
+          <h3>Issue 健康</h3>
+          <div class="chart-grid">
+            <div class="chart-box" data-module="issue-age-chart">
+              <h3>开放 Issue 年龄结构</h3>
+              <div class="bars" role="img" aria-label="当前开放 Issue 46 个：不足 7 天 9 个，7 到 13 天 8 个，14 到 29 天 13 个，30 天以上 16 个">
+                <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:56.3%"></span></span><span class="bar-value">9</span></div>
+                <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:50%"></span></span><span class="bar-value">8</span></div>
+                <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:81.3%"></span></span><span class="bar-value">13</span></div>
+                <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:100%"></span></span><span class="bar-value">16</span></div>
+              </div>
+            </div>
+            <div class="chart-box" data-module="issue-needs-info-chart">
+              <h3><code>needs-info</code> 占比</h3>
+              <div class="donut-layout">
+                <div class="donut" style="--value:34.8%" role="img" aria-label="当前开放 Issue 中 16 个带 triage/needs-info 标签，占 46 个开放 Issue 的 34.8%">
+                  <div class="donut-center"><strong>34.8%</strong><span>16 / 46</span></div>
+                </div>
+                <div class="donut-copy"><p><strong>16 个</strong> Issue 仍需补充信息。</p><p>应集中澄清、拆解或关闭。</p></div>
+              </div>
+            </div>
+          </div>
+          <h3>PR 健康</h3>
+          <div class="chart-box" data-module="pr-age-chart">
+            <div class="bars" role="img" aria-label="当前开放 main PR 16 个：不足 7 天 6 个，7 到 13 天 3 个，14 到 29 天 5 个，30 天以上 2 个">
+              <div class="bar-row"><span class="bar-label">&lt; 7 天</span><span class="bar-track"><span class="bar-fill" style="width:100%"></span></span><span class="bar-value">6</span></div>
+              <div class="bar-row"><span class="bar-label">7—13 天</span><span class="bar-track"><span class="bar-fill" style="width:50%"></span></span><span class="bar-value">3</span></div>
+              <div class="bar-row"><span class="bar-label">14—29 天</span><span class="bar-track"><span class="bar-fill" style="width:83.3%"></span></span><span class="bar-value">5</span></div>
+              <div class="bar-row"><span class="bar-label">≥ 30 天</span><span class="bar-track"><span class="bar-fill hot" style="width:33.3%"></span></span><span class="bar-value">2</span></div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-flow" role="tabpanel" tabindex="0"
+        aria-labelledby="tab-flow" data-panel="flow" hidden>
+        <div class="panel-intro">
+          <p>先看本期流转，再看需要优先判断的高价值输入。</p>
+          <p>价值级别是治理判断，不替代仓库标签。</p>
+        </div>
+
+        <section class="report-section" data-module="weekly-flow" aria-labelledby="flow-title">
+          <h2 id="flow-title">本期 Issue 与 PR 流转</h2>
+          <div class="flow-summary">
+            <div class="flow-item"><strong>Issue +14 / -5</strong><span>净流入 9 · 当前开放 46</span></div>
+            <div class="flow-item"><strong>PR +12 / 完成 6</strong><span>合并 5 + 关闭未合并 1 · 净流入 6 · 当前开放 16</span></div>
+          </div>
+          <p class="risk-note"><strong>数据解读：</strong>PR 仅统计目标分支 <code>main</code>。“完成 6”是维护流转量，不是 6 项功能发布；本期应用 Release 为 1（v0.2.17），CLI Release 为 0。</p>
+
+          <h3>新增 Issue（按价值排序）</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W34 新增 Issue 价值排序</caption>
+              <thead><tr><th>价值</th><th>Issue</th><th>判断</th><th>当前状态</th></tr></thead>
+              <tbody>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/713">#713 API Token 策略缺口</a></td><td>直接影响 API Token 可用性，问题边界明确。</td><td>本期由 <a href="https://github.com/iflytek/skillhub/pull/729">#729</a> 关闭并随 v0.2.17 发布。</td></tr>
+                <tr><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/issues/731">#731 发布订阅通知缺失</a></td><td>影响订阅者收到发布更新，当前标记为 P1/high risk。</td><td>本期由 <a href="https://github.com/iflytek/skillhub/pull/738">#738</a> 关闭并随 v0.2.17 发布；<a href="https://github.com/iflytek/skillhub/pull/735">#735</a> 仍为开放草稿。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/727">#727 HOL Guard 扫描后端</a></td><td>安全生态价值高，但接入边界、运行模型和风险责任仍需澄清。</td><td>开放，P1/high risk/needs-info。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/715">#715 Skill Suites</a> / <a href="https://github.com/iflytek/skillhub/issues/718">#718 Knowledge</a> / <a href="https://github.com/iflytek/skillhub/issues/732">#732 团队维护者</a></td><td>均涉及核心模型或治理边界，价值高但投入与迁移风险较大。</td><td>开放，建议先拆分最小可交付范围。</td></tr>
+                <tr><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/issues/720">#720 技能评论与评价</a></td><td>补充用户反馈闭环，但需同时设计治理、审核和滥用控制。</td><td>开放，P2/high risk。</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>关键 PR 流转</h3>
+          <div class="table-wrap">
+            <table>
+              <caption class="sr-only">W34 关键 PR 流转</caption>
+              <thead><tr><th>类型</th><th>价值</th><th>PR</th><th>结果与判断</th></tr></thead>
+              <tbody>
+                <tr><td>合入 main</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/729">#729</a> / <a href="https://github.com/iflytek/skillhub/pull/733">#733</a> / <a href="https://github.com/iflytek/skillhub/pull/721">#721</a></td><td>分别关闭 API Token 策略、扫描事务竞态和开发启动问题；本期均随 v0.2.17 发布。</td></tr>
+                <tr><td>文档交付</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/736">#736</a></td><td>W33 周报镜像已进入 Pages；属于文档与生态运营能力，不是产品功能 Release。</td></tr>
+                <tr><td>合入 main</td><td><span class="value-level value-a">A</span></td><td><a href="https://github.com/iflytek/skillhub/pull/738">#738</a> / <a href="https://github.com/iflytek/skillhub/pull/735">#735</a></td><td>#738 于本期合并并随 v0.2.17 发布；#735 仍为开放草稿，需明确是否继续。</td></tr>
+                <tr><td>新增待审</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/725">#725 RISC-V</a> / <a href="https://github.com/iflytek/skillhub/pull/724">#724 CLI 同步</a> / <a href="https://github.com/iflytek/skillhub/pull/730">#730 列表标签</a></td><td>覆盖镜像生态、CLI 工作流与 API 表达；截至当前快照仍未合并。</td></tr>
+                <tr><td>关闭未合并</td><td><span class="value-level value-b">B</span></td><td><a href="https://github.com/iflytek/skillhub/pull/717">#717 头像降级</a></td><td>本期关闭但未合并，计入维护流转，不计入交付结果。</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="panel-method" role="tabpanel" tabindex="-1"
+        aria-labelledby="tab-method" data-panel="method" hidden>
+        <div class="panel-intro">
+          <p>这里说明时间边界、数据来源与缺失项。</p>
+          <p>未取得的维度不以 0 或上期数值替代。</p>
+        </div>
+
+        <section class="report-section" data-module="metric-definitions" aria-labelledby="method-title">
+          <h2 id="method-title">统计口径</h2>
+          <ul class="method-list">
+            <li><strong>统计周期</strong><span>本期展示为 2026-08-14—2026-08-21，Asia/Shanghai；程序过滤采用半开区间 <code>[2026-08-14 00:00:00, 2026-08-21 18:20:46)</code>，对应 UTC 为 <code>[2026-08-13 16:00:00, 2026-08-21 10:20:46)</code>。</span></li>
+            <li><strong>扩展统计范围</strong><span>本期显式纳入 8 月 21 日 18:20:46 之前的事件，因此比标准 7 天周期多 18 小时 20 分 46 秒。下一周期应从该排他终点开始，以避免重复统计。</span></li>
+            <li><strong>统计时点</strong><span>2026-08-21 18:23:41（Asia/Shanghai）；仓库库存、开放队列与年龄结构取该时点。统计边界至统计时点之间的事件不计入本期流量。</span></li>
+            <li><strong>Issue 与 PR 的区分</strong><span>GitHub Issues API 会同时返回 PR。Issue 流量剔除带 <code>pull_request</code> 字段的条目；PR 流量使用 Pull Requests 端点独立计算。</span></li>
+            <li><strong>Star 证据</strong><span>证据等级为 <code>current-visible-arrivals</code>：75 为 <code>starred_at</code> 落入本期且在 8 月 21 日查询时仍可见的记录数，不代表周期净增长。与上次认证观测（8 月 20 日 14:55，4,910）相比，本次（4,887）变化为 -23，仅表示两个观测点之间的库存差值。</span></li>
+            <li><strong>PR 统计分支</strong><span>仅统计目标为 <code>main</code> 的 PR；不计入 <code>big-main</code> 或其他集成分支。</span></li>
+            <li><strong>Release</strong><span>按 <code>published_at</code> 过滤，本期应用 Release 为 1、CLI Release 为 0。<a href="https://github.com/iflytek/skillhub/releases/tag/v0.2.17">v0.2.17</a> 于 8 月 21 日 18:13 发布；标签提交 <code>15ce199e</code> 已核验包含 #721、#729、#733 和 #738。</span></li>
+            <li><strong>交付状态用词</strong><span>“已发布”要求存在包含该改动的 Release；“主分支待发布”只表示提交可从 <code>main</code> 到达。没有生产部署证据，因此不使用“已上线”。</span></li>
+            <li><strong>Actions 成功率</strong><span><code>success / (success + failure)</code>；等待授权、条件跳过和取消不进入分母，但单独展示。</span></li>
+            <li><strong>当前存量</strong><span>开放 Issue/PR、年龄结构和 <code>needs-info</code> 是 8 月 21 日快照，不代表本期期末库存，也不参与周流量计算。</span></li>
+          </ul>
+        </section>
+
+        <section class="report-section" data-module="source-coverage" aria-labelledby="source-title">
+          <h2 id="source-title">数据来源与限制</h2>
+          <div class="table-wrap">
+            <table>
+              <caption>来源覆盖</caption>
+              <thead><tr><th>指标</th><th>取值</th><th>来源与覆盖</th></tr></thead>
+              <tbody>
+                <tr><td>Stars 库存</td><td>4,887</td><td>GitHub REST <code>/repos/iflytek/skillhub</code>，统计时点快照。</td></tr>
+                <tr><td>Star 本期当前可见到达</td><td>75</td><td>认证 Stargazer 列表完整分页并按 <code>starred_at</code> 过滤；非净增长。</td></tr>
+                <tr><td>Forks 库存</td><td>789</td><td>仓库库存字段；Fork 列表分页返回 1,052 条，来源不一致，因此不展示本期到达数。</td></tr>
+                <tr><td>Issue 新增 / 关闭</td><td>14 / 5</td><td>Issues 端点完整分页，按 <code>created_at</code>、<code>closed_at</code> 过滤并剔除 PR 条目。</td></tr>
+                <tr><td>PR 新增 / 合并 / 关闭未合并</td><td>12 / 5 / 1</td><td>Pulls 端点完整分页，按事件时间过滤，仅含目标分支 <code>main</code>。</td></tr>
+                <tr><td>应用 / CLI Release</td><td>1 / 0</td><td>Releases 端点按 <code>published_at</code> 过滤；本期应用 Release 为 v0.2.17。</td></tr>
+                <tr><td>Actions 运行</td><td>189</td><td>完整分页后按 <code>created_at</code> 过滤；成功 114、失败 2、等待授权 42、跳过 22、取消 8、运行中 1。</td></tr>
+                <tr><td>CLI 下载</td><td>704</td><td>npm Downloads API 的可用 UTC 日桶；8 月 14、20、21 日桶为零或未稳定，不作为完整周期总量。</td></tr>
+                <tr><td>Views / Clones</td><td>5,879 / 5,570</td><td>GitHub Traffic API 的 7 个 UTC 日桶；与 Asia/Shanghai 扩展范围不完全对齐，仅作生态观察。</td></tr>
+                <tr><td>当前开放 Issue / main PR</td><td>46 / 16</td><td>8 月 21 日认证 API 快照；与本期流量分开。</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="risk-note"><strong>未取得：</strong>周期起止两份可比 Star/Fork 库存快照、可信 Fork 到达数、生产实例可用率与延迟、生产扫描成功率、私有安全告警，以及文章、直播、社区分享和合作项目链接。以上缺口不以 0 或推断值替代。</p>
+        </section>
+      </div>
+    </main>
+
+    <footer>
+      <span>SkillHub Open Source Weekly · 2026-W34</span>
+      <span>公开报告 · 维护者治理视图</span>
+    </footer>
+  </article>
+
+  <script>
+    (function () {
+      var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
+      var panels = Array.prototype.slice.call(document.querySelectorAll('[role="tabpanel"]'));
+
+      function activate(name, moveFocus, updateHash) {
+        var nextTab = tabs.find(function (tab) { return tab.dataset.tab === name; }) || tabs[0];
+        tabs.forEach(function (tab) {
+          var selected = tab === nextTab;
+          tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+          tab.tabIndex = selected ? 0 : -1;
+        });
+        panels.forEach(function (panel) {
+          panel.hidden = panel.dataset.panel !== nextTab.dataset.tab;
+        });
+        if (moveFocus) nextTab.focus();
+        if (updateHash && history.replaceState) {
+          history.replaceState(null, '', '#' + nextTab.dataset.tab);
+        }
+      }
+
+      tabs.forEach(function (tab, index) {
+        tab.addEventListener('click', function () {
+          activate(tab.dataset.tab, false, true);
+        });
+        tab.addEventListener('keydown', function (event) {
+          var nextIndex = index;
+          if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+          else if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+          else if (event.key === 'Home') nextIndex = 0;
+          else if (event.key === 'End') nextIndex = tabs.length - 1;
+          else return;
+          event.preventDefault();
+          activate(tabs[nextIndex].dataset.tab, true, true);
+        });
+      });
+
+      window.addEventListener('hashchange', function () {
+        activate(location.hash.replace('#', ''), false, false);
+      });
+      activate(location.hash.replace('#', ''), false, false);
+    }());
+  </script>
+</body>
+</html>

--- a/weekly/source.json
+++ b/weekly/source.json
@@ -1,4 +1,4 @@
 {
   "repository": "https://github.com/XiaoSeS/skillhub-weekly.git",
-  "commit": "124022316176676c8006a58d7db23f9e093d0c93"
+  "commit": "55a0fca8027d44a34811255b405b08d19b6e0606"
 }


### PR DESCRIPTION
## What

- mirror the reviewed 2026-W34 weekly report into the official documentation site
- update the weekly report index and approved source commit

## Why

Publish the reviewed Aug 14–Aug 21 SkillHub weekly report on the iflytek GitHub Pages site.

## How

The official mirror was generated from XiaoSeS/skillhub-weekly commit 55a0fca8027d44a34811255b405b08d19b6e0606. The mirror tool verified byte and mode parity for site, assets, and scripts.

## Testing

- python3 weekly/scripts/build_site.py --source weekly/site --output docs/skillhub/.vitepress/dist/weekly
- python3 weekly/scripts/validate_site.py docs/skillhub/.vitepress/dist/weekly
- npm ci and npm run build in docs/skillhub
- official assembly check: 6 reports, latest 2026-W34, routes valid

## Impact

Documentation and weekly Pages content only. No application code, API, dependency, or local Skill changes.