### PR TITLE
fix(i18n): disable host locale fallback

### DIFF
--- a/server/skillhub-app/src/main/resources/application.yml
+++ b/server/skillhub-app/src/main/resources/application.yml
@@ -13,6 +13,7 @@ server:
 spring:
   messages:
     basename: messages
+    fallback-to-system-locale: false
   application:
     name: skillhub
   lifecycle:

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/security/ApiAccessDeniedHandlerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/security/ApiAccessDeniedHandlerTest.java
@@ -38,6 +38,7 @@ class ApiAccessDeniedHandlerTest {
     @BeforeEach
     void setUp() {
         ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setFallbackToSystemLocale(false);
         messageSource.setBasename("messages");
         messageSource.setDefaultEncoding("UTF-8");
         RequestIdAccessor requestIdAccessor = new RequestIdAccessor();


### PR DESCRIPTION
## Summary

- disable Spring's host system locale fallback so explicit client locale selection is deterministic
- align the access-denied handler regression fixture with production message-source behavior

Fixes #740

## Testing

- `mvnw.cmd -pl skillhub-app -am -Dtest=ApiAccessDeniedHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test` (3 tests passed)
- `mvnw.cmd -pl skillhub-app -am test` attempted on Windows with JDK 21; the suite exceeded the 10-minute local limit without a final Maven result, so remote CI is the full-suite authority