### PR TITLE
fix(dashboard): remove encoding from slug params

### DIFF
--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -144,7 +144,7 @@ export function DashboardPage() {
                       <Link
                         key={skill.id}
                         to="/space/$namespace/$slug"
-                        params={{ namespace: skill.namespace, slug: encodeURIComponent(skill.slug) }}
+                        params={{ namespace: skill.namespace, slug: skill.slug }}
                         className="rounded-lg border border-border/60 px-3 py-3 transition-colors hover:bg-accent/40"
                       >
                         <div className="truncate text-sm font-medium">{skill.displayName}</div>


### PR DESCRIPTION
## What

Remove explicit encoding from slug parameters in dashboard page.

## Why

The router handles parameter encoding automatically. Explicitly encoding the slug results in double-encoded characters in the URL.

## How

Remove the `encodeURIComponent` call when passing slug to router navigation.

## Testing

- Navigate to dashboard and click on skill items
- Verify URL parameters are correctly encoded (not double-encoded)
- Test with Chinese characters in skill names

## Impact

- Fixes URL encoding issue for skills with special characters in names
- No breaking changes