### PR TITLE
fix(security): harden CSP policy and hide nginx server tokens

### DIFF
--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/config/SecurityConfig.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/config/SecurityConfig.java
@@ -45,11 +45,11 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 public class SecurityConfig {
     private static final String CONTENT_SECURITY_POLICY = String.join("; ",
             "default-src 'self'",
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+            "script-src 'self'",
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
             "img-src 'self' data: blob: https:",
             "font-src 'self' data: https://fonts.gstatic.com",
-            "connect-src 'self' ws: wss: http://localhost:* https://localhost:*",
+            "connect-src 'self'",
             "object-src 'none'",
             "base-uri 'self'",
             "frame-ancestors 'none'",

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -1,3 +1,4 @@
+server_tokens off;
 server {
     listen 80;
     server_name _;


### PR DESCRIPTION
## What

Harden Content Security Policy (CSP) and hide nginx server version information.

## Why

**CSP Hardening:**
- `'unsafe-inline'` and `'unsafe-eval'` in script-src allow inline scripts and eval(), which can enable XSS attacks
- `ws: wss: http://localhost:* https://localhost:*` in connect-src allows WebSocket and localhost connections that may not be needed in production

**Nginx Server Tokens:**
- By default, nginx exposes its version in HTTP response headers (`Server: nginx/x.x.x`)
- This information can help attackers identify known vulnerabilities

## How

1. Remove `'unsafe-inline' 'unsafe-eval'` from script-src directive
2. Restrict connect-src to `'self'` only
3. Add `server_tokens off;` to nginx configuration

## Testing

- Verify the application still works correctly with the stricter CSP
- Check nginx response headers do not contain version information

## Impact

- May break functionality that relies on inline scripts or eval() - needs testing
- WebSocket connections from frontend will be blocked - verify if this is intentional
- Nginx version will no longer be exposed in Server header