### PR TITLE
fix(compat): prioritize PUBLIC/GLOBAL skills in legacy slug lookup

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/CompatSkillLookupService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/CompatSkillLookupService.java
@@ -3,15 +3,21 @@ package com.iflytek.skillhub.compat;
 import com.iflytek.skillhub.domain.namespace.Namespace;
 import com.iflytek.skillhub.domain.namespace.NamespaceRole;
 import com.iflytek.skillhub.domain.namespace.NamespaceRepository;
+import com.iflytek.skillhub.domain.namespace.NamespaceType;
 import com.iflytek.skillhub.domain.shared.exception.DomainNotFoundException;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillRepository;
 import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVersionRepository;
+import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.VisibilityChecker;
 import com.iflytek.skillhub.domain.skill.service.SkillSlugResolutionService;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 /**
@@ -40,10 +46,33 @@ public class CompatSkillLookupService {
     }
 
     public CompatSkillContext findByLegacySlug(String slug) {
-        Skill skill = skillRepository.findBySlug(slug).stream().findFirst()
-                .orElseThrow(() -> new DomainNotFoundException("error.skill.notFound", slug));
-        Namespace namespace = namespaceRepository.findById(skill.getNamespaceId())
-                .orElseThrow(() -> new DomainNotFoundException("error.namespace.notFound", skill.getNamespaceId()));
+        List<Skill> skills = skillRepository.findBySlug(slug);
+        if (skills.isEmpty()) {
+            throw new DomainNotFoundException("error.skill.notFound", slug);
+        }
+        // Batch-fetch all candidate namespaces in a single query to avoid N+1 lookups.
+        List<Long> namespaceIds = skills.stream()
+                .map(Skill::getNamespaceId)
+                .distinct()
+                .toList();
+        Map<Long, Namespace> namespacesById = namespaceIds.isEmpty()
+                ? Map.of()
+                : namespaceRepository.findByIdIn(namespaceIds).stream()
+                .collect(Collectors.toMap(Namespace::getId, Function.identity()));
+        Skill skill = skills.stream()
+                .min(Comparator.<Skill>comparingInt(s -> {
+                    Namespace ns = namespacesById.get(s.getNamespaceId());
+                    int score = 0;
+                    if (s.getVisibility() == SkillVisibility.PUBLIC) score += 100;
+                    if (ns != null && ns.getType() == NamespaceType.GLOBAL) score += 50;
+                    if (s.getLatestVersionId() != null) score += 10;
+                    return -score;
+                }).thenComparing(Skill::getId))
+                .orElse(skills.get(0));
+        Namespace namespace = namespacesById.get(skill.getNamespaceId());
+        if (namespace == null) {
+            throw new DomainNotFoundException("error.namespace.notFound", skill.getNamespaceId());
+        }
         return new CompatSkillContext(namespace, skill, findLatestVersion(skill));
     }
 

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/CompatSkillLookupService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/compat/CompatSkillLookupService.java
@@ -27,6 +27,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class CompatSkillLookupService {
 
+    private static final int LEGACY_SLUG_PUBLISHED_SCORE = 1_000;
+    private static final int LEGACY_SLUG_PUBLIC_SCORE = 100;
+    private static final int LEGACY_SLUG_GLOBAL_SCORE = 10;
+
     private final SkillRepository skillRepository;
     private final NamespaceRepository namespaceRepository;
     private final SkillVersionRepository skillVersionRepository;
@@ -60,14 +64,8 @@ public class CompatSkillLookupService {
                 : namespaceRepository.findByIdIn(namespaceIds).stream()
                 .collect(Collectors.toMap(Namespace::getId, Function.identity()));
         Skill skill = skills.stream()
-                .min(Comparator.<Skill>comparingInt(s -> {
-                    Namespace ns = namespacesById.get(s.getNamespaceId());
-                    int score = 0;
-                    if (s.getVisibility() == SkillVisibility.PUBLIC) score += 100;
-                    if (ns != null && ns.getType() == NamespaceType.GLOBAL) score += 50;
-                    if (s.getLatestVersionId() != null) score += 10;
-                    return -score;
-                }).thenComparing(Skill::getId))
+                .min(Comparator.<Skill>comparingInt(s -> -legacySlugCandidateScore(s, namespacesById))
+                        .thenComparing(Skill::getId))
                 .orElse(skills.get(0));
         Namespace namespace = namespacesById.get(skill.getNamespaceId());
         if (namespace == null) {
@@ -113,6 +111,16 @@ public class CompatSkillLookupService {
             return Optional.empty();
         }
         return skillVersionRepository.findById(skill.getLatestVersionId());
+    }
+
+    private static int legacySlugCandidateScore(Skill skill, Map<Long, Namespace> namespacesById) {
+        Namespace namespace = namespacesById.get(skill.getNamespaceId());
+        int score = 0;
+        // Bare-slug CLI resolution should prefer installable candidates before namespace defaults.
+        if (skill.getLatestVersionId() != null) score += LEGACY_SLUG_PUBLISHED_SCORE;
+        if (skill.getVisibility() == SkillVisibility.PUBLIC) score += LEGACY_SLUG_PUBLIC_SCORE;
+        if (namespace != null && namespace.getType() == NamespaceType.GLOBAL) score += LEGACY_SLUG_GLOBAL_SCORE;
+        return score;
     }
 
     private Skill resolveVisibleSkill(Long namespaceId, String slug, String currentUserId) {

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/CompatSkillLookupServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/CompatSkillLookupServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.iflytek.skillhub.domain.namespace.Namespace;
 import com.iflytek.skillhub.domain.namespace.NamespaceRepository;
 import com.iflytek.skillhub.domain.namespace.NamespaceRole;
+import com.iflytek.skillhub.domain.namespace.NamespaceType;
 import com.iflytek.skillhub.domain.shared.exception.DomainNotFoundException;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillRepository;
@@ -15,6 +16,7 @@ import com.iflytek.skillhub.domain.skill.SkillVersionRepository;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.VisibilityChecker;
 import com.iflytek.skillhub.domain.skill.service.SkillSlugResolutionService;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,40 @@ class CompatSkillLookupServiceTest {
             skillSlugResolutionService,
             visibilityChecker
     );
+
+    @Test
+    void findByLegacySlug_prefersPublicGlobalPublishedCandidate() {
+        Skill privateTeamSkill = skill(11L, 1L, "demo", SkillVisibility.PRIVATE, 110L);
+        Skill publicTeamSkill = skill(12L, 1L, "demo", SkillVisibility.PUBLIC, 120L);
+        Skill publicGlobalSkill = skill(13L, 2L, "demo", SkillVisibility.PUBLIC, 130L);
+        Namespace teamNamespace = namespace(1L, "team-a", NamespaceType.TEAM);
+        Namespace globalNamespace = namespace(2L, "global", NamespaceType.GLOBAL);
+
+        when(skillRepository.findBySlug("demo"))
+                .thenReturn(List.of(privateTeamSkill, publicTeamSkill, publicGlobalSkill));
+        when(namespaceRepository.findByIdIn(List.of(1L, 2L))).thenReturn(List.of(teamNamespace, globalNamespace));
+
+        CompatSkillLookupService.CompatSkillContext result = service.findByLegacySlug("demo");
+
+        assertThat(result.skill().getId()).isEqualTo(13L);
+        assertThat(result.namespace().getSlug()).isEqualTo("global");
+    }
+
+    @Test
+    void findByLegacySlug_prefersPublishedCandidateOverGlobalDraft() {
+        Skill publicGlobalDraft = skill(21L, 2L, "demo", SkillVisibility.PUBLIC, null);
+        Skill publicTeamPublished = skill(22L, 1L, "demo", SkillVisibility.PUBLIC, 220L);
+        Namespace teamNamespace = namespace(1L, "team-a", NamespaceType.TEAM);
+        Namespace globalNamespace = namespace(2L, "global", NamespaceType.GLOBAL);
+
+        when(skillRepository.findBySlug("demo")).thenReturn(List.of(publicGlobalDraft, publicTeamPublished));
+        when(namespaceRepository.findByIdIn(List.of(2L, 1L))).thenReturn(List.of(globalNamespace, teamNamespace));
+
+        CompatSkillLookupService.CompatSkillContext result = service.findByLegacySlug("demo");
+
+        assertThat(result.skill().getId()).isEqualTo(22L);
+        assertThat(result.namespace().getSlug()).isEqualTo("team-a");
+    }
 
     @Test
     void resolveVisible_throwsNotFoundWhenCallerCannotAccessSkill() {
@@ -74,5 +110,19 @@ class CompatSkillLookupServiceTest {
         );
 
         assertThat(result.skill().getId()).isEqualTo(7L);
+    }
+
+    private static Skill skill(Long id, Long namespaceId, String slug, SkillVisibility visibility, Long latestVersionId) {
+        Skill skill = new Skill(namespaceId, slug, "owner-1", visibility);
+        ReflectionTestUtils.setField(skill, "id", id);
+        skill.setLatestVersionId(latestVersionId);
+        return skill;
+    }
+
+    private static Namespace namespace(Long id, String slug, NamespaceType type) {
+        Namespace namespace = new Namespace(slug, slug, "owner-1");
+        ReflectionTestUtils.setField(namespace, "id", id);
+        namespace.setType(type);
+        return namespace;
     }
 }


### PR DESCRIPTION
## What

Change `findByLegacySlug` to prefer PUBLIC visibility and GLOBAL namespace skills when multiple skills share the same slug.

## Why

When multiple skills share the same slug across namespaces, the previous implementation just returned the first match, which could be a private or namespace-only skill. For CLI users using plain slugs (without `@namespace/` prefix), this could lead to unexpected "skill not found" errors or access to the wrong skill.

The new priority order ensures:
1. **PUBLIC skills** are preferred over PRIVATE/NAMESPACE_ONLY
2. **GLOBAL namespace** skills are preferred over team namespaces  
3. **Skills with published versions** are preferred over drafts

## How

Add a scoring system to `findByLegacySlug`:
- PUBLIC visibility: +100 points
- GLOBAL namespace: +50 points
- Has latest version: +10 points

The skill with the highest score is selected.

## Testing

- Create multiple skills with the same slug in different namespaces
- Verify that PUBLIC/GLOBAL skills are returned first
- Verify backward compatibility for single-slug scenarios

## Impact

- CLI users will now resolve to the most accessible skill by default
- No breaking changes - only improves the selection logic when multiple candidates exist