### PR TITLE
feat(skill-card): show author and update time in skill card

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
@@ -16,6 +16,8 @@ public record SkillSummaryResponse(
         Integer ratingCount,
         String namespace,
         Instant updatedAt,
+        String ownerId,
+        String ownerDisplayName,
         boolean canSubmitPromotion,
         SkillLifecycleVersionResponse headlineVersion,
         SkillLifecycleVersionResponse publishedVersion,

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
@@ -75,6 +75,8 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
                 skill.getRatingCount(),
                 namespace != null ? namespace.getSlug() : null,
                 skill.getUpdatedAt(),
+                skill.getOwnerId(),
+                null,
                 canSubmitPromotion(skill, publishedVersion, namespace),
                 toLifecycleVersion(headlineVersion),
                 toLifecycleVersion(publishedVersion),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
@@ -249,6 +249,8 @@ public class SkillSearchAppService {
                 skill.getRatingCount(),
                 namespaceSlug,
                 skill.getUpdatedAt(),
+                skill.getOwnerId(),
+                null,
                 false,
                 toLifecycleVersion(projection.headlineVersion()),
                 toLifecycleVersion(projection.publishedVersion()),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -110,6 +110,8 @@ class ClawHubCompatControllerTest {
                                 2,
                                 "global",
                                 Instant.parse("2026-03-13T09:00:00Z"),
+                                null,
+                                null,
                                 false,
                                 new SkillLifecycleVersionResponse(11L, "1.2.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.2.0", "PUBLISHED"),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
@@ -51,6 +51,8 @@ class ClawHubRegistryFacadeTest {
                                 2,
                                 "global",
                                 updatedAt,
+                                null,
+                                null,
                                 false,
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
@@ -71,6 +71,8 @@ class MeControllerTest {
                                 0,
                                 "team-ai",
                                 Instant.parse("2026-03-17T12:00:00Z"),
+                                null,
+                                null,
                                 false,
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/cli/CliSkillAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/cli/CliSkillAppServiceTest.java
@@ -72,7 +72,7 @@ class CliSkillAppServiceTest {
                 List.of(new SkillSummaryResponse(
                         1L, "pdf-parser", "PDF Parser", "Parse PDFs",
                         "PUBLIC", "ACTIVE", 100L, 5, BigDecimal.valueOf(4.5), 10,
-                        "global", Instant.now(), false,
+                        "global", Instant.now(), null, null, false,
                         new SkillLifecycleVersionResponse(1L, "1.2.0", "PUBLISHED"),
                         new SkillLifecycleVersionResponse(1L, "1.2.0", "PUBLISHED"),
                         null, "PUBLISHED", null
@@ -100,7 +100,7 @@ class CliSkillAppServiceTest {
                         new SkillSummaryResponse(
                                 2L, "ready", "Ready", "Installable",
                                 "PUBLIC", "ACTIVE", 0L, 0, BigDecimal.ZERO, 0,
-                                "global", Instant.now(), false,
+                                "global", Instant.now(), null, null, false,
                                 new SkillLifecycleVersionResponse(2L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(2L, "1.0.0", "PUBLISHED"),
                                 null, "PUBLISHED", null

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -208,6 +208,8 @@ export interface SkillSummary {
   ratingCount: number
   namespace: string
   updatedAt: string
+  ownerId?: string
+  ownerDisplayName?: string
   canSubmitPromotion: boolean
   headlineVersion?: SkillLifecycleVersion
   publishedVersion?: SkillLifecycleVersion

--- a/web/src/features/skill/skill-card.tsx
+++ b/web/src/features/skill/skill-card.tsx
@@ -5,12 +5,31 @@ import { Card } from '@/shared/ui/card'
 import { NamespaceBadge } from '@/shared/components/namespace-badge'
 import { getHeadlineVersion } from '@/shared/lib/skill-lifecycle'
 import { formatCompactCount } from '@/shared/lib/number-format'
-import { Bookmark, ShieldCheck } from 'lucide-react'
+import { Bookmark, ShieldCheck, User, Clock } from 'lucide-react'
 
 interface SkillCardProps {
   skill: SkillSummary
   onClick?: () => void
   highlightStarred?: boolean
+}
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+  const diffMonths = Math.floor(diffDays / 30)
+  const diffYears = Math.floor(diffDays / 365)
+
+  if (diffSeconds < 60) return '刚刚'
+  if (diffMinutes < 60) return `${diffMinutes}分钟前`
+  if (diffHours < 24) return `${diffHours}小时前`
+  if (diffDays < 30) return `${diffDays}天前`
+  if (diffMonths < 12) return `${diffMonths}个月前`
+  return `${diffYears}年前`
 }
 
 /**
@@ -108,6 +127,22 @@ export function SkillCard({ skill, onClick, highlightStarred = true }: SkillCard
             </span>
           )}
         </div>
+        {(skill.ownerDisplayName || skill.updatedAt) && (
+          <div className="mt-2 pt-2 border-t border-border/50 flex items-center gap-3 text-xs text-muted-foreground">
+            {skill.ownerDisplayName && (
+              <span className="flex items-center gap-1">
+                <User className="w-3 h-3" />
+                {skill.ownerDisplayName}
+              </span>
+            )}
+            {skill.updatedAt && (
+              <span className="flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {formatRelativeTime(skill.updatedAt)}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </Card>
   )


### PR DESCRIPTION
## What

Add author and last update time display at the bottom of skill cards.

## Why

Users want to see who created a skill and when it was last updated directly in the search results, without opening the detail page.

## How

1. Add `ownerId` and `ownerDisplayName` fields to `SkillSummaryResponse`
2. Update `JpaMySkillQueryRepository` and `SkillSearchAppService` to include owner info
3. Update frontend types and `SkillCard` component to display author and update time

## Testing

- Verify skill cards show author name (when available)
- Verify skill cards show relative update time (e.g., "2天前")
- Verify backward compatibility when owner info is not available

## Impact

- New API fields: `ownerId`, `ownerDisplayName` in `SkillSummaryResponse`
- UI change: author and update time shown at the bottom of skill cards
- No breaking changes