### PR TITLE
fix(web): keep select menus within viewport

### DIFF
--- a/web/src/shared/ui/select.test.ts
+++ b/web/src/shared/ui/select.test.ts
@@ -40,6 +40,14 @@ describe('shared select contract', () => {
     expect(SELECT_ITEM_CLASS_NAME).toContain('rounded-md')
   })
 
+  it('keeps long option lists inside the available viewport', () => {
+    expect(SELECT_CONTENT_CLASS_NAME).toContain(
+      'max-h-[var(--radix-select-content-available-height)]'
+    )
+    expect(SELECT_CONTENT_CLASS_NAME).toContain('overflow-y-auto')
+    expect(SELECT_CONTENT_CLASS_NAME).toContain('overflow-x-hidden')
+  })
+
   it('uses pointer cursors for expanded select interactions', () => {
     expect(SELECT_ITEM_CLASS_NAME).toContain('cursor-pointer')
     expect(SELECT_SCROLL_BUTTON_CLASS_NAME).toContain('cursor-pointer')

--- a/web/src/shared/ui/select.tsx
+++ b/web/src/shared/ui/select.tsx
@@ -12,7 +12,7 @@ export const SELECT_TRIGGER_CLASS_NAME = cn(
 )
 
 export const SELECT_CONTENT_CLASS_NAME = cn(
-  'z-50 overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-md',
+  'z-50 max-h-[var(--radix-select-content-available-height)] overflow-x-hidden overflow-y-auto rounded-lg border border-border bg-popover text-popover-foreground shadow-md',
   // In-tree (no Portal): avoids React 19 removeChild races on route unmount.
   // No exit animations: delayed unmount still races commits when Content was portaled.
   'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',


### PR DESCRIPTION
## Summary

- Cap the shared Radix select content to `--radix-select-content-available-height`.
- Enable vertical scrolling while preventing horizontal overflow for long option lists.
- Add a shared component regression test for the viewport-height and overflow contract.

This fixes the truncated action filter on the audit-log page and the truncated role list inside the user-role dialog. Because the change is in the shared select primitive, it also covers the other dropdowns reported in the issue.

Closes #714.

## Validation

- [ ] Backend tests passed (not applicable: frontend-only change)
- [x] Frontend typecheck/build passed
- [x] OpenAPI SDK regenerated or checked when API contracts changed (not applicable: no API change)
- [ ] Smoke test run when relevant (not applicable: shared styling change)

Commands run:

```bash
pnpm exec vitest run src/shared/ui/select.test.ts
pnpm run typecheck
pnpm run lint
pnpm run build
git diff --check
```

Results: 7 select tests passed; typecheck, ESLint, and the production Vite build passed.

## Risk

- User-facing impact: long select menus stay within the visible viewport and become vertically scrollable.
- Deployment or migration impact: none.
- Rollback approach: revert the single commit.

## Notes

- Related issue: #714
- Follow-up work: none.
- Docs or operator runbooks updated when behavior changed: not needed for this UI bug fix.