### PR TITLE
fix(web): keep select poppers inside collision bounds

### DIFF
--- a/web/src/shared/ui/select.test.ts
+++ b/web/src/shared/ui/select.test.ts
@@ -48,6 +48,11 @@ describe('shared select contract', () => {
     expect(SELECT_CONTENT_CLASS_NAME).toContain('overflow-x-hidden')
   })
 
+  it('does not move popper content with static translate utilities', () => {
+    expect(SELECT_CONTENT_CLASS_NAME).not.toContain('translate-y-1')
+    expect(SELECT_CONTENT_CLASS_NAME).not.toContain('translate-x-1')
+  })
+
   it('uses pointer cursors for expanded select interactions', () => {
     expect(SELECT_ITEM_CLASS_NAME).toContain('cursor-pointer')
     expect(SELECT_SCROLL_BUTTON_CLASS_NAME).toContain('cursor-pointer')

--- a/web/src/shared/ui/select.tsx
+++ b/web/src/shared/ui/select.tsx
@@ -89,16 +89,15 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
+>(({ className, children, position = 'popper', sideOffset = 4, ...props }, ref) => (
   // No Portal: Content stays in the React tree with its trigger so route/Dialog
   // unmount cannot orphan a body/#skillhub-portals node (removeChild).
   <SelectPrimitive.Content
     ref={ref}
     translate="no"
+    sideOffset={sideOffset}
     className={cn(
       SELECT_CONTENT_CLASS_NAME,
-      position === 'popper'
-        && 'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
       className
     )}
     position={position}


### PR DESCRIPTION
## What

Keep shared Select popper content inside Radix collision bounds on small viewports.

## Why

The previous shared Select fix added viewport-based max height, but the component still applied Tailwind translate utilities after Radix calculated the collision boundary. On short browser windows, that static transform could move the menu a few pixels outside the viewport.

This is visible in long Select menus such as the publish namespace picker.

## How

- Move the default popper gap to Radix `sideOffset={4}`.
- Remove static `translate-*` side transforms from `SelectContent`.
- Add a contract test so the shared Select does not reintroduce static popper transforms.

## Testing

- `pnpm exec vitest run src/shared/ui/select.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- Local release Compose preview built and started from the exact SHA.
- Manual validation passed on the publish namespace picker with 30 seeded namespaces.

## Impact

- Frontend-only shared UI fix.
- No API, schema, backend, scanner, migration, or deployment-chain change.
