### PR TITLE
fix(auth): prevent login page redirect loop

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -123,7 +123,6 @@ export function Layout() {
           ) : (
             <Link
               to="/login"
-              search={{ returnTo: '' }}
               className="hover:opacity-80 transition-opacity"
             >
               {t('nav.login')}

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -183,8 +183,8 @@ const skillsRoute = createRoute({
 const loginRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'login',
-  validateSearch: (search: Record<string, unknown>): { returnTo: string; reason?: string } => ({
-    returnTo: typeof search.returnTo === 'string' ? search.returnTo : '',
+  validateSearch: (search: Record<string, unknown>): { returnTo?: string; reason?: string } => ({
+    returnTo: typeof search.returnTo === 'string' && search.returnTo ? search.returnTo : undefined,
     reason: typeof search.reason === 'string' ? search.reason : undefined,
   }),
   component: LoginPage,

--- a/web/src/features/auth/use-auth-methods.test.ts
+++ b/web/src/features/auth/use-auth-methods.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import * as authMethods from './use-auth-methods'
+import { getAuthMethodsQueryOptions, useAuthMethods } from './use-auth-methods'
 
-/**
- * use-auth-methods is a thin useQuery wrapper around authApi.getMethods.
- * The query key includes the returnTo parameter for proper cache isolation.
- * There are no exported pure functions or data transformations to unit-test.
- *
- * This file verifies the public API surface so that accidental export removals are caught.
- */
+describe('getAuthMethodsQueryOptions', () => {
+  it('keeps login auth-method lookup local to the page and bypasses the global 401 redirect', () => {
+    const options = getAuthMethodsQueryOptions('/dashboard')
+
+    expect(options.queryKey).toEqual(['auth', 'methods', '/dashboard'])
+    expect(options.retry).toBe(false)
+    expect(options.meta).toEqual({ skipGlobalErrorHandler: true })
+    expect(options.queryFn).toBeTypeOf('function')
+  })
+})
+
 describe('use-auth-methods module exports', () => {
   it('exports useAuthMethods hook', () => {
-    expect(authMethods.useAuthMethods).toBeTypeOf('function')
+    expect(useAuthMethods).toBeTypeOf('function')
   })
 })

--- a/web/src/features/auth/use-auth-methods.ts
+++ b/web/src/features/auth/use-auth-methods.ts
@@ -5,9 +5,17 @@ import type { AuthMethod } from '@/api/types'
 /**
  * Loads the backend-advertised authentication methods for the current entry point.
  */
-export function useAuthMethods(returnTo?: string) {
-  return useQuery<AuthMethod[]>({
+export function getAuthMethodsQueryOptions(returnTo?: string) {
+  return {
     queryKey: ['auth', 'methods', returnTo ?? ''],
     queryFn: () => authApi.getMethods(returnTo),
-  })
+    retry: false,
+    meta: {
+      skipGlobalErrorHandler: true,
+    },
+  }
+}
+
+export function useAuthMethods(returnTo?: string) {
+  return useQuery<AuthMethod[]>(getAuthMethodsQueryOptions(returnTo))
 }

--- a/web/src/pages/reset-password.tsx
+++ b/web/src/pages/reset-password.tsx
@@ -100,7 +100,7 @@ export function ResetPasswordPage() {
               <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
                 {t('resetPassword.successMessage')}
               </p>
-              <Link to="/login" search={{ returnTo: '' }} className="block text-center font-medium text-primary hover:underline">
+              <Link to="/login" className="block text-center font-medium text-primary hover:underline">
                 {t('resetPassword.backToLogin')}
               </Link>
             </div>

--- a/web/src/pages/settings/security.tsx
+++ b/web/src/pages/settings/security.tsx
@@ -72,7 +72,7 @@ export function SecuritySettingsPage() {
         clearSessionScopedQueries(queryClient)
         queryClient.setQueryData(['auth', 'me'], null)
       }
-      await navigate({ to: '/login', search: { returnTo: '' } })
+      await navigate({ to: '/login' })
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         setErrorMessage(t('security.invalidCurrentPassword'))


### PR DESCRIPTION
## 问题
登录页加载认证方式时，401 会被全局错误处理器再次导航到 `/login`，导致登录页反复刷新；同时多个入口会生成空的 `returnTo` 查询参数。

## 修复
- 认证方式查询关闭自动重试并跳过全局 401 跳转。
- 无目标地址时省略空 `returnTo`。
- 补充查询选项单测。

## 验证
- Vitest：675 tests passed
- TypeScript typecheck：passed
- ESLint：passed
- Vite production build：passed
- Docker Web image exact-SHA smoke：`/login` 连续 5 次 200，`/nginx-health` 通过

Closes #? (独立修复，未关联原 PR #623)