### PR TITLE
fix(skill-card): resolve author display names in summaries

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
@@ -58,7 +58,7 @@ public record SkillSummaryResponse(
             String resolutionMode,
             ComplianceSnapshotResponse complianceSnapshot) {
         this(id, slug, displayName, summary, visibility, status, downloadCount, starCount, ratingAvg,
-                ratingCount, namespace, updatedAt, canSubmitPromotion, headlineVersion, publishedVersion,
+                ratingCount, namespace, updatedAt, null, null, canSubmitPromotion, headlineVersion, publishedVersion,
                 ownerPreviewVersion, resolutionMode, complianceSnapshot, null);
     }
 

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
@@ -64,7 +64,8 @@ public record SkillSummaryResponse(
 
     public SkillSummaryResponse withLabels(List<SkillLabelDto> labels) {
         return new SkillSummaryResponse(id, slug, displayName, summary, visibility, status, downloadCount,
-                starCount, ratingAvg, ratingCount, namespace, updatedAt, canSubmitPromotion, headlineVersion,
+                starCount, ratingAvg, ratingCount, namespace, updatedAt, ownerId, ownerDisplayName,
+                canSubmitPromotion, headlineVersion,
                 publishedVersion, ownerPreviewVersion, resolutionMode, complianceSnapshot, labels);
     }
 }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
@@ -62,6 +62,33 @@ public record SkillSummaryResponse(
                 ownerPreviewVersion, resolutionMode, complianceSnapshot, null);
     }
 
+    /** Summary with owner information but without an optional label projection. */
+    public SkillSummaryResponse(
+            Long id,
+            String slug,
+            String displayName,
+            String summary,
+            String visibility,
+            String status,
+            Long downloadCount,
+            Integer starCount,
+            BigDecimal ratingAvg,
+            Integer ratingCount,
+            String namespace,
+            Instant updatedAt,
+            String ownerId,
+            String ownerDisplayName,
+            boolean canSubmitPromotion,
+            SkillLifecycleVersionResponse headlineVersion,
+            SkillLifecycleVersionResponse publishedVersion,
+            SkillLifecycleVersionResponse ownerPreviewVersion,
+            String resolutionMode,
+            ComplianceSnapshotResponse complianceSnapshot) {
+        this(id, slug, displayName, summary, visibility, status, downloadCount, starCount, ratingAvg,
+                ratingCount, namespace, updatedAt, ownerId, ownerDisplayName, canSubmitPromotion,
+                headlineVersion, publishedVersion, ownerPreviewVersion, resolutionMode, complianceSnapshot, null);
+    }
+
     public SkillSummaryResponse withLabels(List<SkillLabelDto> labels) {
         return new SkillSummaryResponse(id, slug, displayName, summary, visibility, status, downloadCount,
                 starCount, ratingAvg, ratingCount, namespace, updatedAt, ownerId, ownerDisplayName,

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/dto/SkillSummaryResponse.java
@@ -18,6 +18,8 @@ public record SkillSummaryResponse(
         Integer ratingCount,
         String namespace,
         Instant updatedAt,
+        String ownerId,
+        String ownerDisplayName,
         boolean canSubmitPromotion,
         SkillLifecycleVersionResponse headlineVersion,
         SkillLifecycleVersionResponse publishedVersion,

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
@@ -75,6 +75,8 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
                 skill.getRatingCount(),
                 namespace != null ? namespace.getSlug() : null,
                 skill.getUpdatedAt(),
+                skill.getOwnerId(),
+                null,
                 canSubmitPromotion(skill, publishedVersion, namespace),
                 toLifecycleVersion(headlineVersion),
                 toLifecycleVersion(publishedVersion),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
@@ -9,6 +9,8 @@ import com.iflytek.skillhub.domain.review.ReviewTaskStatus;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillStatus;
 import com.iflytek.skillhub.domain.skill.service.SkillLifecycleProjectionService;
+import com.iflytek.skillhub.domain.user.UserAccount;
+import com.iflytek.skillhub.domain.user.UserAccountRepository;
 import com.iflytek.skillhub.dto.SkillLifecycleVersionResponse;
 import com.iflytek.skillhub.dto.SkillSummaryResponse;
 import java.util.List;
@@ -16,6 +18,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Repository;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Repository
 public class JpaMySkillQueryRepository implements MySkillQueryRepository {
@@ -23,13 +26,23 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
     private final NamespaceRepository namespaceRepository;
     private final PromotionRequestRepository promotionRequestRepository;
     private final SkillLifecycleProjectionService skillLifecycleProjectionService;
+    private final UserAccountRepository userAccountRepository;
 
     public JpaMySkillQueryRepository(NamespaceRepository namespaceRepository,
                                      PromotionRequestRepository promotionRequestRepository,
                                      SkillLifecycleProjectionService skillLifecycleProjectionService) {
+        this(namespaceRepository, promotionRequestRepository, skillLifecycleProjectionService, null);
+    }
+
+    @Autowired
+    public JpaMySkillQueryRepository(NamespaceRepository namespaceRepository,
+                                     PromotionRequestRepository promotionRequestRepository,
+                                     SkillLifecycleProjectionService skillLifecycleProjectionService,
+                                     UserAccountRepository userAccountRepository) {
         this.namespaceRepository = namespaceRepository;
         this.promotionRequestRepository = promotionRequestRepository;
         this.skillLifecycleProjectionService = skillLifecycleProjectionService;
+        this.userAccountRepository = userAccountRepository;
     }
 
     @Override
@@ -41,14 +54,19 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
                         skills.stream().map(Skill::getNamespaceId).distinct().toList())
                 .stream()
                 .collect(Collectors.toMap(Namespace::getId, Function.identity()));
+        Map<String, UserAccount> ownersById = userAccountRepository == null
+                ? Map.of()
+                : userAccountRepository.findByIdIn(skills.stream().map(Skill::getOwnerId).distinct().toList())
+                .stream().collect(Collectors.toMap(UserAccount::getId, Function.identity()));
         return skills.stream()
-                .map(skill -> toSummaryResponse(skill, currentUserId, namespacesById))
+                .map(skill -> toSummaryResponse(skill, currentUserId, namespacesById, ownersById))
                 .toList();
     }
 
     private SkillSummaryResponse toSummaryResponse(Skill skill,
                                                    String currentUserId,
-                                                   Map<Long, Namespace> namespacesById) {
+                                                   Map<Long, Namespace> namespacesById,
+                                                   Map<String, UserAccount> ownersById) {
         Namespace namespace = namespacesById.get(skill.getNamespaceId());
         SkillLifecycleProjectionService.Projection projection = skillLifecycleProjectionService.projectForViewer(
                 skill,
@@ -76,7 +94,9 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
                 namespace != null ? namespace.getSlug() : null,
                 skill.getUpdatedAt(),
                 skill.getOwnerId(),
-                null,
+                ownersById.get(skill.getOwnerId()) != null
+                        ? ownersById.get(skill.getOwnerId()).getDisplayName()
+                        : null,
                 canSubmitPromotion(skill, publishedVersion, namespace),
                 toLifecycleVersion(headlineVersion),
                 toLifecycleVersion(publishedVersion),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/repository/JpaMySkillQueryRepository.java
@@ -102,6 +102,7 @@ public class JpaMySkillQueryRepository implements MySkillQueryRepository {
                 toLifecycleVersion(publishedVersion),
                 toLifecycleVersion(ownerPreviewVersion),
                 projection.resolutionMode().name(),
+                null,
                 null
         );
     }

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
@@ -8,6 +8,8 @@ import com.iflytek.skillhub.domain.namespace.NamespaceService;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillRepository;
 import com.iflytek.skillhub.domain.skill.service.SkillLifecycleProjectionService;
+import com.iflytek.skillhub.domain.user.UserAccount;
+import com.iflytek.skillhub.domain.user.UserAccountRepository;
 import com.iflytek.skillhub.dto.SkillSummaryResponse;
 import com.iflytek.skillhub.search.SearchQuery;
 import com.iflytek.skillhub.search.SearchQueryService;
@@ -39,6 +41,7 @@ public class SkillSearchAppService {
     private final SkillLifecycleProjectionService skillLifecycleProjectionService;
     private final ComplianceSnapshotProjectionService complianceSnapshotProjectionService;
     private final RbacService rbacService;
+    private final UserAccountRepository userAccountRepository;
 
     public SkillSearchAppService(
             SearchQueryService searchQueryService,
@@ -54,7 +57,8 @@ public class SkillSearchAppService {
                 namespaceService,
                 skillLifecycleProjectionService,
                 new ComplianceSnapshotProjectionService(new com.fasterxml.jackson.databind.ObjectMapper()),
-                rbacService
+                rbacService,
+                null
         );
     }
 
@@ -66,7 +70,8 @@ public class SkillSearchAppService {
             NamespaceService namespaceService,
             SkillLifecycleProjectionService skillLifecycleProjectionService,
             ComplianceSnapshotProjectionService complianceSnapshotProjectionService,
-            RbacService rbacService) {
+            RbacService rbacService,
+            UserAccountRepository userAccountRepository) {
         this.searchQueryService = searchQueryService;
         this.skillRepository = skillRepository;
         this.namespaceRepository = namespaceRepository;
@@ -74,6 +79,7 @@ public class SkillSearchAppService {
         this.skillLifecycleProjectionService = skillLifecycleProjectionService;
         this.complianceSnapshotProjectionService = complianceSnapshotProjectionService;
         this.rbacService = rbacService;
+        this.userAccountRepository = userAccountRepository;
     }
 
     public record SearchResponse(
@@ -215,6 +221,10 @@ public class SkillSearchAppService {
                 .collect(Collectors.toMap(Namespace::getId, Function.identity()));
         Map<Long, String> namespaceSlugsById = namespacesById.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getSlug()));
+        Map<String, UserAccount> ownersById = userAccountRepository == null
+                ? Map.of()
+                : userAccountRepository.findByIdIn(matchedSkills.stream().map(Skill::getOwnerId).distinct().toList())
+                .stream().collect(Collectors.toMap(UserAccount::getId, Function.identity()));
         Map<Long, SkillLifecycleProjectionService.Projection> projectionsBySkillId =
                 skillLifecycleProjectionService.projectPublishedSummaries(matchedSkills);
 
@@ -224,6 +234,7 @@ public class SkillSearchAppService {
                 .map(skill -> toSummaryResponse(
                         skill,
                         namespaceSlugsById,
+                        ownersById,
                         projectionsBySkillId.get(skill.getId())
                 ))
                 .toList();
@@ -232,8 +243,10 @@ public class SkillSearchAppService {
     private SkillSummaryResponse toSummaryResponse(
             Skill skill,
             Map<Long, String> namespaceSlugsById,
+            Map<String, UserAccount> ownersById,
             SkillLifecycleProjectionService.Projection projection) {
         String namespaceSlug = namespaceSlugsById.get(skill.getNamespaceId());
+        UserAccount owner = ownersById.get(skill.getOwnerId());
         SkillLifecycleProjectionService.VersionProjection headlineVersion = projection.headlineVersion();
 
         return new SkillSummaryResponse(
@@ -250,7 +263,9 @@ public class SkillSearchAppService {
                 namespaceSlug,
                 skill.getUpdatedAt(),
                 skill.getOwnerId(),
-                null,
+                owner != null
+                        ? owner.getDisplayName()
+                        : null,
                 false,
                 toLifecycleVersion(projection.headlineVersion()),
                 toLifecycleVersion(projection.publishedVersion()),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
@@ -249,6 +249,8 @@ public class SkillSearchAppService {
                 skill.getRatingCount(),
                 namespaceSlug,
                 skill.getUpdatedAt(),
+                skill.getOwnerId(),
+                null,
                 false,
                 toLifecycleVersion(projection.headlineVersion()),
                 toLifecycleVersion(projection.publishedVersion()),

--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/service/SkillSearchAppService.java
@@ -273,7 +273,8 @@ public class SkillSearchAppService {
                 projection.resolutionMode().name(),
                 headlineVersion != null
                         ? complianceSnapshotProjectionService.fromParsedMetadataJson(headlineVersion.parsedMetadataJson())
-                        : null
+                        : null,
+                null
         );
     }
 

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubCompatControllerTest.java
@@ -116,6 +116,8 @@ class ClawHubCompatControllerTest {
                                 2,
                                 "global",
                                 Instant.parse("2026-03-13T09:00:00Z"),
+                                null,
+                                null,
                                 false,
                                 new SkillLifecycleVersionResponse(11L, "1.2.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.2.0", "PUBLISHED"),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/compat/ClawHubRegistryFacadeTest.java
@@ -51,6 +51,8 @@ class ClawHubRegistryFacadeTest {
                                 2,
                                 "global",
                                 updatedAt,
+                                null,
+                                null,
                                 false,
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/MeControllerTest.java
@@ -71,6 +71,8 @@ class MeControllerTest {
                                 0,
                                 "team-ai",
                                 Instant.parse("2026-03-17T12:00:00Z"),
+                                null,
+                                null,
                                 false,
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(11L, "1.0.0", "PUBLISHED"),

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/SkillSearchAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/SkillSearchAppServiceTest.java
@@ -13,6 +13,8 @@ import com.iflytek.skillhub.domain.skill.SkillVersionRepository;
 import com.iflytek.skillhub.domain.skill.SkillVersionStatus;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.service.SkillLifecycleProjectionService;
+import com.iflytek.skillhub.domain.user.UserAccount;
+import com.iflytek.skillhub.domain.user.UserAccountRepository;
 import com.iflytek.skillhub.search.SearchQuery;
 import com.iflytek.skillhub.search.SearchQueryService;
 import com.iflytek.skillhub.search.SearchResult;
@@ -59,6 +61,9 @@ class SkillSearchAppServiceTest {
     @Mock
     private RbacService rbacService;
 
+    @Mock
+    private UserAccountRepository userAccountRepository;
+
     private SkillSearchAppService service;
 
     @BeforeEach
@@ -69,7 +74,9 @@ class SkillSearchAppServiceTest {
                 namespaceRepository,
                 namespaceService,
                 new SkillLifecycleProjectionService(skillVersionRepository),
-                rbacService
+                new ComplianceSnapshotProjectionService(new com.fasterxml.jackson.databind.ObjectMapper()),
+                rbacService,
+                userAccountRepository
         );
     }
 
@@ -100,11 +107,14 @@ class SkillSearchAppServiceTest {
         when(skillRepository.findByIdIn(List.of(11L))).thenReturn(List.of(visibleSkill));
         when(namespaceRepository.findByIdIn(List.of(2L))).thenReturn(List.of(activeNamespace));
         when(skillVersionRepository.findByIdIn(List.of(111L))).thenReturn(List.of());
+        when(userAccountRepository.findByIdIn(List.of("owner-1")))
+                .thenReturn(List.of(new UserAccount("owner-1", "Alice", "alice@example.com", null)));
 
         SkillSearchAppService.SearchResponse response = service.search("skill", null, "newest", 0, 1, null, null);
 
         assertEquals(1, response.items().size());
         assertEquals("visible-skill", response.items().getFirst().slug());
+        assertEquals("Alice", response.items().getFirst().ownerDisplayName());
         assertEquals(1, response.total());
         verify(searchQueryService, times(1)).search(any());
     }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/cli/CliSkillAppServiceTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/service/cli/CliSkillAppServiceTest.java
@@ -72,7 +72,7 @@ class CliSkillAppServiceTest {
                 List.of(new SkillSummaryResponse(
                         1L, "pdf-parser", "PDF Parser", "Parse PDFs",
                         "PUBLIC", "ACTIVE", 100L, 5, BigDecimal.valueOf(4.5), 10,
-                        "global", Instant.now(), false,
+                        "global", Instant.now(), null, null, false,
                         new SkillLifecycleVersionResponse(1L, "1.2.0", "PUBLISHED"),
                         new SkillLifecycleVersionResponse(1L, "1.2.0", "PUBLISHED"),
                         null, "PUBLISHED", null
@@ -100,7 +100,7 @@ class CliSkillAppServiceTest {
                         new SkillSummaryResponse(
                                 2L, "ready", "Ready", "Installable",
                                 "PUBLIC", "ACTIVE", 0L, 0, BigDecimal.ZERO, 0,
-                                "global", Instant.now(), false,
+                                "global", Instant.now(), null, null, false,
                                 new SkillLifecycleVersionResponse(2L, "1.0.0", "PUBLISHED"),
                                 new SkillLifecycleVersionResponse(2L, "1.0.0", "PUBLISHED"),
                                 null, "PUBLISHED", null

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -208,6 +208,8 @@ export interface SkillSummary {
   ratingCount: number
   namespace: string
   updatedAt: string
+  ownerId?: string
+  ownerDisplayName?: string
   canSubmitPromotion: boolean
   headlineVersion?: SkillLifecycleVersion
   publishedVersion?: SkillLifecycleVersion

--- a/web/src/features/skill/skill-card.tsx
+++ b/web/src/features/skill/skill-card.tsx
@@ -5,12 +5,31 @@ import { Card } from '@/shared/ui/card'
 import { NamespaceBadge } from '@/shared/components/namespace-badge'
 import { getHeadlineVersion } from '@/shared/lib/skill-lifecycle'
 import { formatCompactCount } from '@/shared/lib/number-format'
-import { Bookmark, ShieldCheck } from 'lucide-react'
+import { Bookmark, ShieldCheck, User, Clock } from 'lucide-react'
 
 interface SkillCardProps {
   skill: SkillSummary
   onClick?: () => void
   highlightStarred?: boolean
+}
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+  const diffMonths = Math.floor(diffDays / 30)
+  const diffYears = Math.floor(diffDays / 365)
+
+  if (diffSeconds < 60) return '刚刚'
+  if (diffMinutes < 60) return `${diffMinutes}分钟前`
+  if (diffHours < 24) return `${diffHours}小时前`
+  if (diffDays < 30) return `${diffDays}天前`
+  if (diffMonths < 12) return `${diffMonths}个月前`
+  return `${diffYears}年前`
 }
 
 /**
@@ -108,6 +127,22 @@ export function SkillCard({ skill, onClick, highlightStarred = true }: SkillCard
             </span>
           )}
         </div>
+        {(skill.ownerDisplayName || skill.updatedAt) && (
+          <div className="mt-2 pt-2 border-t border-border/50 flex items-center gap-3 text-xs text-muted-foreground">
+            {skill.ownerDisplayName && (
+              <span className="flex items-center gap-1">
+                <User className="w-3 h-3" />
+                {skill.ownerDisplayName}
+              </span>
+            )}
+            {skill.updatedAt && (
+              <span className="flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {formatRelativeTime(skill.updatedAt)}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </Card>
   )


### PR DESCRIPTION
Maintainer follow-up for #751.

The original PR added ownerDisplayName to the response but populated it as null, so the card could not show the author. This follow-up batch-loads UserAccount records for matched skills (avoids N+1), enriches both public search and my-skills summaries, and adds a regression assertion.

Closes the missing behavior in #751; no API shape change beyond the existing field.