### PR TITLE
fix(publish): match allowed filenames case-insensitively

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidator.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidator.java
@@ -8,6 +8,7 @@ import com.iflytek.skillhub.domain.skill.metadata.SkillMetadataParser;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,7 +65,7 @@ public class SkillPackageValidator {
         this.maxSingleFileSize = maxSingleFileSize;
         this.maxTotalPackageSize = maxTotalPackageSize;
         this.allowedExtensions = allowedExtensions.stream()
-                .map(String::toLowerCase)
+                .map(extension -> extension.toLowerCase(Locale.ROOT))
                 .collect(java.util.stream.Collectors.toUnmodifiableSet());
     }
 
@@ -138,7 +139,8 @@ public class SkillPackageValidator {
     }
 
     private boolean hasAllowedExtension(String normalizedPath) {
-        return allowedExtensions.stream().anyMatch(normalizedPath::endsWith);
+        String lowercasePath = normalizedPath.toLowerCase(Locale.ROOT);
+        return allowedExtensions.stream().anyMatch(lowercasePath::endsWith);
     }
 
     private String formatMetadataError(LocalizedDomainException exception) {

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
@@ -108,17 +108,19 @@ class SkillPackageValidatorTest {
     void acceptsAllowedExtensionRegardlessOfFilenameCase() {
         SkillPackageValidator customValidator = new SkillPackageValidator(
                 new SkillMetadataParser(), 100, SkillPackagePolicy.MAX_SINGLE_FILE_SIZE,
-                SkillPackagePolicy.MAX_TOTAL_PACKAGE_SIZE, Set.of(".md", "Makefile"));
+                SkillPackagePolicy.MAX_TOTAL_PACKAGE_SIZE, Set.of(".md", "Makefile", "Dockerfile"));
         List<PackageEntry> entries = List.of(
                 skillMdEntry(),
-                new PackageEntry("Makefile", "build:\n".getBytes(), 7, "text/plain")
+                new PackageEntry("README.MD", "# Readme\n".getBytes(), 9, "text/markdown"),
+                new PackageEntry("MAKEFILE", "build:\n".getBytes(), 7, "text/plain"),
+                new PackageEntry("tools/DOCKERFILE", "FROM scratch\n".getBytes(), 13, "text/plain")
         );
 
         ValidationResult result = customValidator.validate(entries);
 
         assertTrue(result.passed());
         assertTrue(result.warnings().stream()
-                .noneMatch(warning -> warning.contains("Disallowed file extension: Makefile")));
+                .noneMatch(warning -> warning.contains("Disallowed file extension")));
     }
 
     @Test

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/SkillPackageValidatorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -101,6 +102,23 @@ class SkillPackageValidatorTest {
 
         assertTrue(result.passed());
         assertTrue(result.warnings().stream().anyMatch(e -> e.contains("Disallowed file extension") && e.contains("malware.exe")));
+    }
+
+    @Test
+    void acceptsAllowedExtensionRegardlessOfFilenameCase() {
+        SkillPackageValidator customValidator = new SkillPackageValidator(
+                new SkillMetadataParser(), 100, SkillPackagePolicy.MAX_SINGLE_FILE_SIZE,
+                SkillPackagePolicy.MAX_TOTAL_PACKAGE_SIZE, Set.of(".md", "Makefile"));
+        List<PackageEntry> entries = List.of(
+                skillMdEntry(),
+                new PackageEntry("Makefile", "build:\n".getBytes(), 7, "text/plain")
+        );
+
+        ValidationResult result = customValidator.validate(entries);
+
+        assertTrue(result.passed());
+        assertTrue(result.warnings().stream()
+                .noneMatch(warning -> warning.contains("Disallowed file extension: Makefile")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Normalize both configured allowlist entries and package paths with `Locale.ROOT` before matching.
- Add a regression test covering a conventionally capitalized `Makefile`.
- Restore CLI/API publishing for packages whose explicitly allowed filenames contain uppercase letters.

## Validation

- [x] Backend tests passed
- [x] Frontend typecheck and lint passed
- [x] OpenAPI contract unchanged; regeneration not applicable
- [ ] Staging smoke test not run (Docker is unavailable on this machine; no API or operator workflow changed)

Commands run:

```text
.\mvnw.cmd -pl skillhub-domain -am "-Dtest=SkillPackageValidatorTest" "-Dsurefire.failIfNoSpecifiedTests=false" test
# 21 tests, 0 failures

.\mvnw.cmd -pl skillhub-domain -am test
# 443 domain + 21 storage tests, 0 failures

pnpm run typecheck
pnpm run lint
```

The repository's full `skillhub-app` dependency-suite command was also attempted. The local executor timed out after six minutes while it was still progressing (97 Surefire reports generated, no failures observed); GitHub CI remains the authoritative full-suite run.

## Risk

- User-facing impact: explicitly allowed filenames now match case-insensitively as intended.
- Deployment or migration impact: none.
- Rollback approach: revert the single commit.

## Notes

- Closes #766
- No API shape, authentication, namespace routing, or documentation contract changed.
