### PR TITLE
fix(web): preserve HTTPS in sub-path redirects

### DIFF
--- a/scripts/tests/web-base-path-nginx-smoke-test.sh
+++ b/scripts/tests/web-base-path-nginx-smoke-test.sh
@@ -86,6 +86,11 @@ if [ "$code" != '301' ]; then
   echo "bare prefix must 301-redirect, got: $code" >&2
   exit 1
 fi
+location=$(curl -s -o /dev/null -D - "$base/skillhub" | awk 'tolower($1) == "location:" { print $2 }' | tr -d '\r')
+if [ "$location" != '/skillhub/' ]; then
+  echo "bare prefix redirect must stay relative to preserve an upstream HTTPS scheme, got: $location" >&2
+  exit 1
+fi
 
 docker rm -f "$name" >/dev/null 2>&1 || true
 

--- a/web/docker-entrypoint.d/20-base-path.sh
+++ b/web/docker-entrypoint.d/20-base-path.sh
@@ -96,7 +96,7 @@ if [ "$SKILLHUB_WEB_BASE_PATH" = / ]; then
     >"$routing_config"
 else
   base_path_without_trailing_slash=${SKILLHUB_WEB_BASE_PATH%/}
-  printf 'set $skillhub_forwarded_prefix %s;\n\nlocation = %s {\n    return 301 %s/;\n}\n\nlocation ^~ %s {\n    rewrite ^%s(.*)$ /$1 last;\n}\n' \
+  printf 'set $skillhub_forwarded_prefix %s;\n\nlocation = %s {\n    absolute_redirect off;\n    return 301 %s/;\n}\n\nlocation ^~ %s {\n    rewrite ^%s(.*)$ /$1 last;\n}\n' \
     "$base_path_without_trailing_slash" \
     "$base_path_without_trailing_slash" \
     "$base_path_without_trailing_slash" \


### PR DESCRIPTION
## What

- emit a relative `Location: /skillhub/` for the bare sub-path redirect
- add a regression assertion for the redirect target, not only its status code

## Why

The latest main edge deployment behind the Hong Kong TLS proxy returned:

```text
GET https://skill.xf-yun.com.cn/skillhub
301 Location: http://skill.xf-yun.com.cn/skillhub/
```

Nginx generated an absolute redirect using the Web container's internal HTTP scheme. A relative redirect preserves the browser's external HTTPS scheme and host.

## Testing

- `sh -n web/docker-entrypoint.d/20-base-path.sh`
- `bash -n scripts/tests/web-base-path-nginx-smoke-test.sh`
- `bash scripts/tests/web-base-path-nginx-smoke-test.sh`
- `bash scripts/tests/nginx-forwarded-proto-test.sh`
- `bash scripts/tests/web-base-path-routing-test.sh`
- `bash scripts/tests/runtime-secret-test.sh`
- `bash scripts/tests/validate-release-config-test.sh`
- `git diff --check`

After CI, the fix will be deployed as a new main edge image and rechecked through the real HTTPS domain before release approval.
