### PR TITLE
fix(deploy): preserve storage volume ownership

### DIFF
--- a/.github/workflows/pr-scripts.yml
+++ b/.github/workflows/pr-scripts.yml
@@ -7,6 +7,7 @@ on:
       - '.env.release.example'
       - '.env.release.draft'
       - 'compose.release.yml'
+      - 'server/Dockerfile'
       - 'Makefile'
       - 'web/Dockerfile'
       - 'web/nginx.conf.template'
@@ -43,4 +44,5 @@ jobs:
       - run: bash scripts/tests/web-base-path-routing-test.sh
       - run: bash scripts/tests/web-base-path-nginx-smoke-test.sh
       - run: bash scripts/tests/dev-web-host-test.sh
+      - run: bash scripts/tests/server-image-compat-test.sh
       - run: bash scripts/tests/workflow-security-test.sh

--- a/scripts/tests/server-image-compat-test.sh
+++ b/scripts/tests/server-image-compat-test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOCKERFILE="$REPO_ROOT/server/Dockerfile"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+grep -Fq 'groupadd --system --gid 101 app' "$DOCKERFILE" \
+  || fail 'server runtime group must retain the v0.2.17 gid 101 for storage-volume upgrades'
+grep -Fq 'useradd --system --uid 100 --gid app --create-home app' "$DOCKERFILE" \
+  || fail 'server runtime user must retain the v0.2.17 uid 100 for storage-volume upgrades'
+grep -Eq '^USER app[[:space:]]*$' "$DOCKERFILE" \
+  || fail 'server runtime must continue to run as the non-root app user'
+
+echo 'server-image-compat-test passed'

--- a/scripts/tests/workflow-security-test.sh
+++ b/scripts/tests/workflow-security-test.sh
@@ -69,6 +69,8 @@ grep -Fq '.env.release.draft' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run when release env draft changes"
 grep -Fq 'compose.release.yml' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run when release compose changes"
+grep -Fq 'server/Dockerfile' "$PR_SCRIPTS_WORKFLOW" \
+  || fail "pr-scripts must run when the production server image changes"
 grep -Fq 'web/Dockerfile' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run when the web image changes"
 grep -Fq 'web/nginx.conf.template' "$PR_SCRIPTS_WORKFLOW" \
@@ -87,6 +89,8 @@ grep -Fq 'bash scripts/tests/runtime-secret-test.sh' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run runtime-secret-test"
 grep -Fq 'bash scripts/tests/dev-web-host-test.sh' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run dev-web-host-test"
+grep -Fq 'bash scripts/tests/server-image-compat-test.sh' "$PR_SCRIPTS_WORKFLOW" \
+  || fail "pr-scripts must run server-image-compat-test"
 grep -Fq 'bash scripts/tests/workflow-security-test.sh' "$PR_SCRIPTS_WORKFLOW" \
   || fail "pr-scripts must run workflow-security-test"
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,11 +23,12 @@ RUN ./mvnw package -DskipTests -B
 # The Noble variant publishes a linux/riscv64 image; the Alpine JRE currently
 # used by this project is limited to amd64 and arm64.
 FROM eclipse-temurin:21-jre-noble
+# Keep the Alpine image's numeric IDs so existing storage volumes remain writable.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget && \
     rm -rf /var/lib/apt/lists/* && \
-    groupadd --system app && \
-    useradd --system --gid app --create-home app
+    groupadd --system --gid 101 app && \
+    useradd --system --uid 100 --gid app --create-home app
 WORKDIR /app
 
 COPY --from=build /app/skillhub-app/target/*.jar app.jar


### PR DESCRIPTION
## What

Preserve the server runtime user's numeric UID/GID across the Alpine-to-Noble image change:

- app user remains UID 100
- app group remains GID 101
- add a deterministic production-image compatibility check
- make PR Scripts run when server/Dockerfile changes

## Why

v0.2.17 used UID 100/GID 101. After #725 changed the runtime base image to Noble, implicit system-user allocation produced UID 999/GID 999.

A retained local-storage volume from v0.2.17 therefore becomes read-only to the new server process. The service health check still passes, but built-in Skill synchronization and package publishing fail with AccessDeniedException.

## How

Create the Noble app user and group with the established numeric IDs. The container continues to run as the non-root app user; no startup-time chown, privileged entrypoint, or data migration is added.

## Testing

Repository checks:

- bash scripts/tests/server-image-compat-test.sh
- bash scripts/tests/runtime-secret-test.sh
- bash scripts/tests/validate-release-config-test.sh
- bash scripts/tests/web-base-path-routing-test.sh
- bash scripts/tests/web-base-path-nginx-smoke-test.sh
- bash scripts/tests/dev-web-host-test.sh
- bash scripts/tests/workflow-security-test.sh
- git diff --check

Hong Kong validation host, exact commit aa4ea17c4af84fab9f1e0afaba037415924b095f:

- official server/Dockerfile build: PASS
- clean candidate volume write: PASS
- v0.2.17-created volume write with current main edge: expected FAIL (Permission denied)
- same v0.2.17-created volume write with candidate: PASS
- stable retained volume write: PASS
- built-in Skill sync: 17 published, 0 failed
- HTTPS domain smoke: 15 passed, 0 failed
- namespace/token/publish/scan/review/search/download feature regression: 41 passed, 0 failed
- PostgreSQL, Redis, scanner, server, and Web: healthy with zero restarts

## Impact

Fixes local-file storage upgrades from v0.2.17 and other images using UID 100/GID 101. Fresh volumes remain writable. S3-backed installations are behaviorally unchanged.
