### PR TITLE
fix(cli): stabilize namespace sync fingerprints

### DIFF
--- a/cli/src/services/skill-fingerprint.ts
+++ b/cli/src/services/skill-fingerprint.ts
@@ -50,5 +50,5 @@ async function listSkillFiles(root: string): Promise<string[]> {
   }
 
   await walk(root)
-  return files.sort((left, right) => left.localeCompare(right))
+  return files.sort()
 }

--- a/cli/test/unit/services/skill-fingerprint.test.ts
+++ b/cli/test/unit/services/skill-fingerprint.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
@@ -5,6 +6,25 @@ import { createTempHome } from '../../helpers/temp-env'
 import { diffSkillFiles, snapshotSkillDirectory } from '../../../src/services/skill-fingerprint'
 
 describe('skill fingerprint', () => {
+  test('matches the server fingerprint for mixed-case package paths', async () => {
+    const env = await createTempHome()
+    const skillDir = join(env.cwd, 'mixed-case-paths')
+    const skillContent = '# Mixed-case paths\n'
+    const referenceContent = 'Reference\n'
+    await mkdir(join(skillDir, 'references'), { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), skillContent)
+    await writeFile(join(skillDir, 'references', 'guide.md'), referenceContent)
+
+    const skillHash = createHash('sha256').update(skillContent).digest('hex')
+    const referenceHash = createHash('sha256').update(referenceContent).digest('hex')
+    const serverFingerprint = createHash('sha256')
+      .update(`SKILL.md:${skillHash}\n`)
+      .update(`references/guide.md:${referenceHash}\n`)
+      .digest('hex')
+
+    expect((await snapshotSkillDirectory(skillDir)).fingerprint).toBe(`sha256:${serverFingerprint}`)
+  })
+
   test('ignores SkillHub metadata and reports changed files', async () => {
     const env = await createTempHome()
     const skillDir = join(env.cwd, 'demo')


### PR DESCRIPTION
## Summary

- use deterministic UTF-16/code-unit path ordering when computing CLI package fingerprints
- match the server's Java `String` ordering for mixed-case package paths
- add a regression test covering `SKILL.md` plus a lowercase `references/` path

## Root cause

Namespace sync used locale-sensitive `localeCompare` ordering while the server uses Java string ordering. A package containing mixed-case paths could be downloaded correctly and then immediately reported as `local-changed` even though every file hash matched.

## Validation

- targeted regression demonstrated RED before the change and GREEN after it
- `bun test`: 390 passed, 0 failed
- `bun run typecheck`: passed
- `bun run lint`: passed
- `bun run build`: passed
- live candidate CLI against a deployed SkillHub server:
  - `sync pull`: installed successfully
  - immediate `sync status`: `up-to-date`
  - clean `sync diff`: empty
  - edited `SKILL.md`: `status` and `diff` both reported the changed file
  - `sync push --all --dry-run`: validated successfully
  - temporary API token revoked

## Scope

CLI-only change. No Server, Web, Scanner, API, schema, or deployment-image behavior changes.
