### PR TITLE
feat(cli): filter sync push skill batches

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable CLI behavior changes are documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Add repeatable `sync push --all --include <skill>` filters so operators can
+  validate and publish a reviewed subset from a large local Skill collection.
+  Invalid or missing directory names fail before any package validation request.
+
 ### Fixed
 
 - Resolve `namespace/slug`, `@namespace/slug`, and `namespace--slug`

--- a/cli/README.md
+++ b/cli/README.md
@@ -263,11 +263,19 @@ skillhub sync pull --namespace team-a --prune
 # Validate and upload every local skill for review
 skillhub sync push --all --namespace team-a --dry-run
 skillhub sync push --all --namespace team-a --submit-review
+
+# Validate only a reviewed subset from a larger collection
+skillhub sync push --all --include scanpy --include rdkit --namespace team-a --dry-run
 ```
 
 The default workspace is `<cwd>/.agents/skills`. Pull never overwrites local changes unless `--force` is supplied. Remote removals are reported as `orphaned` and are retained unless `--prune` is supplied. Both destructive cases still require explicit flags.
 
 Workspace push is non-overwriting: an existing namespace/slug/version is reported as a conflict, including versions that are still uploaded or pending review. Other skills in the same `--all` run continue processing.
+
+`--include <skill>` is repeatable and limits `sync push --all` to exact immediate directory names.
+Every requested directory is checked before validation starts; a missing or invalid name fails the
+command without sending a partial batch. This is useful for publishing a reviewed topical subset
+from a large Agent Skills collection while keeping the original workspace intact.
 
 Namespace sync writes `.skillhub/namespace-sync.json` in the workspace and per-skill `.skillhub/metadata.json` files. These files contain the registry coordinate, published version, aggregate fingerprint, and file hashes used by `status` and `diff`.
 
@@ -402,6 +410,7 @@ Update mechanism:
 | `skillhub whoami [--registry <url>] [--token <token>] [--json]` | Validate current token and display user information |
 | `skillhub search <query> [--registry <url>] [--token <token>] [--limit <n>] [--json]` | Search published skills |
 | `skillhub install <coordinate> [--scope <user\|project>] [--namespace <slug>] [--version <v>] [--agent <profile>] [--dir <path>] [--force] [--registry <url>] [--token <token>] [--json]` | Install a skill |
+| `skillhub sync <pull\|status\|diff\|push> [path] [--all] [--include <skill>] [--namespace <slug>] [--dir <path>] [--dry-run] [--submit-review] [--json]` | Synchronize a namespace workspace or publish a selected local subset |
 | `skillhub list [--agent <profile>] [--dir <path>] [--registry <url>] [--json]` | List installed skills |
 | `skillhub remove <coordinate> [--agent <profile>] [--all] [--remote] [--hard] [--namespace <slug>] [--registry <url>] [--token <token>] [--json]` | Remove a skill |
 | `skillhub doctor [--json]` | Scan project directory and rebuild local inventory |

--- a/cli/src/commands/help.ts
+++ b/cli/src/commands/help.ts
@@ -45,11 +45,12 @@ export const commands = {
   },
   sync: {
     summary: 'Synchronize and maintain namespace workspaces',
-    usage: 'skillhub sync <pull|status|diff|push> [options]',
+    usage: 'skillhub sync <pull|status|diff|push> [path] [--all] [--include <skill>] [options]',
     examples: [
       'skillhub sync pull --namespace team-a',
       'skillhub sync status --namespace team-a --json',
-      'skillhub sync push --all --namespace team-a --submit-review'
+      'skillhub sync push --all --namespace team-a --submit-review',
+      'skillhub sync push --all --include scanpy --include rdkit --namespace research --dry-run'
     ]
   },
   list: {

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import { ConfigStore } from '../stores/config-store'
 import { CredentialsStore } from '../stores/credentials-store'
 import { SkillHubClient } from '../clients/skillhub-client'
@@ -31,6 +31,7 @@ export interface SyncPullOptions extends SyncCommonOptions {
 
 export interface SyncPushOptions extends SyncCommonOptions {
   all?: boolean
+  include?: string[]
   visibility?: string
   dryRun?: boolean
   submitReview?: boolean
@@ -78,20 +79,25 @@ export async function syncDiffCommand(options: SyncCommonOptions): Promise<strin
 }
 
 export async function syncPushCommand(path: string | undefined, options: SyncPushOptions): Promise<string> {
-  const context = await resolveSyncContext(options)
   if (path && options.all) {
     throw new CliError('path cannot be combined with --all', EXIT.usage)
   }
   if (!path && !options.all) {
     throw new CliError('provide a skill path or pass --all', EXIT.usage)
   }
+  const includedSkills = normalizeIncludedSkills(options.include)
+  if (includedSkills.length > 0 && !options.all) {
+    throw new CliError('--include requires --all', EXIT.usage)
+  }
 
+  const context = await resolveSyncContext(options)
   const visibility = normalizeVisibility(options.visibility ?? 'namespace-only')
   if (options.submitReview && visibility === 'PRIVATE') {
     throw new CliError('--submit-review requires public or namespace-only visibility', EXIT.usage)
   }
   const paths = options.all
-    ? await discoverSkillDirectories(context.rootDir)
+    ? selectIncludedSkillDirectories(
+        await discoverSkillDirectories(context.rootDir), includedSkills, context.rootDir)
     : [resolve(path!)]
   if (paths.length === 0) {
     throw new CliError(`no skill directories found in ${context.rootDir}`, EXIT.filesystem, { path: context.rootDir })
@@ -114,6 +120,36 @@ export async function syncPushCommand(path: string | undefined, options: SyncPus
     })
   }
   return output
+}
+
+function normalizeIncludedSkills(values: string[] | undefined): string[] {
+  if (!values) return []
+  const included: string[] = []
+  const seen = new Set<string>()
+  for (const rawValue of values) {
+    const value = rawValue.trim()
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+      throw new CliError('--include must be a skill directory name', EXIT.usage, { include: rawValue })
+    }
+    if (!seen.has(value)) {
+      included.push(value)
+      seen.add(value)
+    }
+  }
+  return included
+}
+
+function selectIncludedSkillDirectories(paths: string[], included: string[], rootDir: string): string[] {
+  if (included.length === 0) return paths
+  const byName = new Map(paths.map(path => [basename(path), path]))
+  const missing = included.filter(name => !byName.has(name))
+  if (missing.length > 0) {
+    throw new CliError(`included skill directories not found: ${missing.join(', ')}`, EXIT.filesystem, {
+      path: rootDir,
+      missing
+    })
+  }
+  return included.map(name => byName.get(name)!)
 }
 
 async function resolveSyncContext(options: SyncCommonOptions): Promise<{

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,7 +9,7 @@ import { logoutCommand } from './commands/logout'
 import { publishCommand, type PublishCommandOptions } from './commands/publish'
 import { removeCommand, type RemoveCommandOptions } from './commands/remove'
 import { searchCommand } from './commands/search'
-import { syncDiffCommand, syncPullCommand, syncPushCommand, syncStatusCommand, type SyncCommonOptions, type SyncPullOptions, type SyncPushOptions } from './commands/sync'
+import { syncDiffCommand, syncPullCommand, syncPushCommand, syncStatusCommand, type SyncPullOptions, type SyncPushOptions } from './commands/sync'
 import { updateCommand } from './commands/update'
 import { versionCommand } from './commands/version'
 import { whoamiCommand } from './commands/whoami'
@@ -255,27 +255,36 @@ cli
   .option('--prune', 'Remove managed local skills missing remotely')
   .option('--force', 'Overwrite local changes')
   .option('--all', 'Push every skill directory in the workspace')
+  .option('--include <skill>', 'Push only a named skill directory (repeatable; requires --all)')
   .option('--visibility <v>', 'Visibility (public|namespace-only|private)', { default: 'namespace-only' })
   .option('--dry-run', 'Validate without uploading')
   .option('--submit-review', 'Submit an uploaded version for review when required')
   .option('--registry <url>', 'Registry URL')
   .option('--token <token>', 'API token')
   .option('--json', 'Output JSON')
-  .action((action: string, path: string | undefined, options: SyncPullOptions & SyncPushOptions) => {
-    const command = action === 'pull'
-      ? () => syncPullCommand(options)
+  .action((action: string, path: string | undefined, options: SyncPullOptions
+    & Omit<SyncPushOptions, 'include'> & { include?: string | string[] }) => {
+    const { include, ...baseOptions } = options
+    const normalizedInclude = toArray(include)
+    const normalizedOptions: SyncPullOptions & SyncPushOptions = normalizedInclude
+      ? { ...baseOptions, include: normalizedInclude }
+      : baseOptions
+    const command = normalizedInclude && action !== 'push'
+      ? () => Promise.reject(new CliError('--include is only supported by sync push', EXIT.usage))
+      : action === 'pull'
+      ? () => syncPullCommand(normalizedOptions)
       : action === 'status'
-        ? () => syncStatusCommand(options as SyncCommonOptions)
+        ? () => syncStatusCommand(normalizedOptions)
         : action === 'diff'
-          ? () => syncDiffCommand(options as SyncCommonOptions)
+          ? () => syncDiffCommand(normalizedOptions)
           : action === 'push'
-            ? () => syncPushCommand(path, options)
+            ? () => syncPushCommand(path, normalizedOptions)
             : () => Promise.reject(new CliError(
                 `unknown sync action: ${action}`,
                 EXIT.usage,
                 { next: 'use pull, status, diff, or push' }
               ))
-    return runCommand(command, Boolean(options.json))
+    return runCommand(command, Boolean(normalizedOptions.json))
   })
 
 cli

--- a/cli/test/integration/help-command.test.ts
+++ b/cli/test/integration/help-command.test.ts
@@ -27,6 +27,18 @@ describe('help command', () => {
     expect(result.stdout).toContain('Namespace for local or remote delete')
   })
 
+  test('prints repeatable sync include filters in both help surfaces', async () => {
+    const detailed = await runCli(['help', 'sync'])
+    expect(detailed.exitCode).toBe(0)
+    expect(detailed.stdout).toContain('[--include <skill>]')
+    expect(detailed.stdout).toContain('--include scanpy --include rdkit')
+
+    const commandHelp = await runCli(['sync', '--help'])
+    expect(commandHelp.exitCode).toBe(0)
+    expect(commandHelp.stdout).toContain('--include <skill>')
+    expect(commandHelp.stdout).toContain('repeatable; requires --all')
+  })
+
   test('prints search help with optional query', async () => {
     const result = await runCli(['help', 'search'])
     expect(result.exitCode).toBe(0)

--- a/cli/test/integration/sync-command.test.ts
+++ b/cli/test/integration/sync-command.test.ts
@@ -141,6 +141,82 @@ describe('sync command', () => {
     }
   })
 
+  test('push all validates only repeated include selections', async () => {
+    const env = await createTempHome()
+    const skillsDir = join(env.cwd, 'scientific-skills')
+    for (const name of ['scanpy', 'rdkit', 'literature-review']) {
+      const skillDir = join(skillsDir, name)
+      await mkdir(skillDir, { recursive: true })
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: ${name}\nversion: 1.0.0\n---\n`
+      )
+    }
+    const registry = await startFakeRegistry({ token: 'token' })
+
+    try {
+      const result = await runCli([
+        'sync', 'push', '--all', '--include', 'rdkit', '--include', 'scanpy',
+        '--namespace', 'research', '--dir', skillsDir, '--dry-run',
+        '--registry', registry.url, '--token', 'token', '--json'
+      ], { HOME: env.home }, { cwd: env.cwd })
+
+      expect(result.exitCode).toBe(0)
+      const items = JSON.parse(result.stdout).items as Array<{ slug: string; action: string }>
+      expect(items.map(item => item.slug)).toEqual(['rdkit', 'scanpy'])
+      expect(items.every(item => item.action === 'validated')).toBe(true)
+      expect(registry.received.validate?.fileName).toBe('scanpy.zip')
+      expect(registry.received.publish).toBeNull()
+    } finally {
+      registry.stop()
+      await rm(skillsDir, { recursive: true, force: true })
+    }
+  })
+
+  test('push all rejects missing includes before registry validation', async () => {
+    const env = await createTempHome()
+    const skillsDir = join(env.cwd, 'scientific-skills')
+    await mkdir(join(skillsDir, 'scanpy'), { recursive: true })
+    await writeFile(
+      join(skillsDir, 'scanpy', 'SKILL.md'),
+      '---\nname: scanpy\ndescription: Scanpy\nversion: 1.0.0\n---\n'
+    )
+    const registry = await startFakeRegistry({ token: 'token' })
+
+    try {
+      const result = await runCli([
+        'sync', 'push', '--all', '--include', 'scanpy', '--include', 'missing-skill',
+        '--namespace', 'research', '--dir', skillsDir, '--dry-run',
+        '--registry', registry.url, '--token', 'token'
+      ], { HOME: env.home }, { cwd: env.cwd })
+
+      expect(result.exitCode).toBe(4)
+      expect(result.stderr).toContain('included skill directories not found: missing-skill')
+      expect(registry.received.validate).toBeNull()
+    } finally {
+      registry.stop()
+      await rm(skillsDir, { recursive: true, force: true })
+    }
+  })
+
+  test('include requires all', async () => {
+    const result = await runCli(['sync', 'push', 'scanpy', '--include', 'scanpy'])
+    expect(result.exitCode).toBe(5)
+    expect(result.stderr).toContain('--include requires --all')
+  })
+
+  test('include is rejected for non-push sync actions', async () => {
+    const result = await runCli(['sync', 'status', '--include', 'scanpy'])
+    expect(result.exitCode).toBe(5)
+    expect(result.stderr).toContain('--include is only supported by sync push')
+  })
+
+  test('include rejects path-like names before registry validation', async () => {
+    const result = await runCli(['sync', 'push', '--all', '--include', '../scanpy'])
+    expect(result.exitCode).toBe(5)
+    expect(result.stderr).toContain('--include must be a skill directory name')
+  })
+
   test('push dry-run uses strict validation without uploading', async () => {
     const env = await createTempHome()
     const skillDir = join(env.cwd, 'demo')


### PR DESCRIPTION
﻿## Summary

- Add repeatable `sync push --all --include <skill>` filters for publishing a reviewed subset from a large local Agent Skills collection.
- Preserve the requested include order and deduplicate repeated names.
- Validate every requested directory name and existence before any package validation request, preventing partial batches caused by a typo.
- Reject `--include` without `--all` and on non-`push` sync actions instead of silently ignoring it.
- Document the command in CLI help, README, command reference, and changelog.

## Why

Large standards-based collections such as `K-Dense-AI/scientific-agent-skills` contain 160+ immediate skill directories. Operators often want a governed topical subset (for example `scanpy`, `rdkit`, and `literature-review`) without copying directories into a temporary workspace or validating the entire collection against registry request limits.

## Validation

```text
bun test test/integration/sync-command.test.ts --timeout 10000
# 11 passed

bun test test/integration/help-command.test.ts
# 9 passed

bun run typecheck
bun run lint
bun run build
# all passed
```

`bun test` for the whole CLI tree was attempted. On this Windows runner it hung in the existing `update --check` network test and was terminated; the relevant sync/help suites pass, and all new tests pass under Bun's default 5-second threshold. Remote Linux CI remains authoritative for the complete suite.

## Behavior examples

```bash
skillhub sync push --all \
  --include scanpy \
  --include rdkit \
  --namespace research \
  --dry-run
```

A missing requested directory exits before the first registry validation call. Existing `sync push --all` behavior is unchanged when no `--include` is supplied.

## Risk

- CLI-only additive option; no server/API/database/UI changes.
- No overwrite semantics changed.
- Rollback is the single commit.

## Related

- Refs #516
- K-Dense governed publishing guide: https://github.com/K-Dense-AI/scientific-agent-skills/pull/241
- Astron repository import proposal: https://github.com/iflytek/astron-agent/issues/1658
