### PR TITLE
fix(auth): allow public routes after session expiry

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/AuthContextFilter.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/filter/AuthContextFilter.java
@@ -59,8 +59,8 @@ public class AuthContextFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
-        if (!routeSecurityPolicyRegistry.shouldProjectRequestContext(
-                RouteSecurityPolicyRegistry.requestPath(request))) {
+        String requestPath = RouteSecurityPolicyRegistry.requestPath(request);
+        if (!routeSecurityPolicyRegistry.shouldProjectRequestContext(requestPath)) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -68,6 +68,10 @@ public class AuthContextFilter extends OncePerRequestFilter {
         if (principal != null) {
             if (isInactiveUser(principal.userId())) {
                 clearAuthentication(request);
+                if (isAnonymousFallbackAllowed(request, requestPath)) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 objectMapper.writeValue(
@@ -106,7 +110,12 @@ public class AuthContextFilter extends OncePerRequestFilter {
         }
         session.removeAttribute("platformPrincipal");
         session.removeAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
-        session.invalidate();
+    }
+
+    private boolean isAnonymousFallbackAllowed(HttpServletRequest request, String requestPath) {
+        return !"/api/v1/auth/me".equals(requestPath)
+                && routeSecurityPolicyRegistry.accessLevel(request.getMethod(), requestPath)
+                == RouteSecurityPolicyRegistry.AccessLevel.PERMIT_ALL;
     }
 
     private PlatformPrincipal resolvePrincipal(HttpServletRequest request) {

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/filter/AuthContextFilterTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/filter/AuthContextFilterTest.java
@@ -30,11 +30,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.context.support.StaticMessageSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,7 +68,7 @@ class AuthContextFilterTest {
     }
 
     @Test
-    void disabledSessionUser_shouldInvalidateSessionAndBlockRequest() throws Exception {
+    void disabledSessionUser_shouldClearAuthenticationWithoutInvalidatingSession() throws Exception {
         PlatformPrincipal principal = new PlatformPrincipal("user-1", "Alice", "alice@example.com", null, "local", Set.of("USER"));
         UserAccount user = new UserAccount("user-1", "Alice", "alice@example.com", null);
         user.setStatus(UserStatus.DISABLED);
@@ -88,9 +90,70 @@ class AuthContextFilterTest {
 
         assertEquals(401, response.getStatus());
         assertTrue(response.getContentAsString().contains("\"code\":401"));
-        assertTrue(session.isInvalid());
+        assertFalse(session.isInvalid());
+        assertNull(session.getAttribute("platformPrincipal"));
+        assertNull(session.getAttribute("SPRING_SECURITY_CONTEXT"));
         assertNull(SecurityContextHolder.getContext().getAuthentication());
         verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void disabledSessionUser_shouldContinuePublicGetAsAnonymous() throws Exception {
+        PlatformPrincipal principal = principal("user-public");
+        UserAccount user = disabledUser("user-public");
+        MockHttpServletRequest request = authenticatedRequest("GET", "/api/v1/skills", principal);
+        MockHttpSession session = (MockHttpSession) request.getSession(false);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+        when(userAccountRepository.findById("user-public")).thenReturn(java.util.Optional.of(user));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertEquals(200, response.getStatus());
+        assertFalse(session.isInvalid());
+        assertNull(session.getAttribute("platformPrincipal"));
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void disabledSessionUser_shouldBlockProtectedMethodOnOtherwisePublicPath() throws Exception {
+        PlatformPrincipal principal = principal("user-protected");
+        MockHttpServletRequest request = authenticatedRequest("POST", "/api/v1/skills", principal);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+        when(userAccountRepository.findById("user-protected"))
+                .thenReturn(java.util.Optional.of(disabledUser("user-protected")));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertEquals(401, response.getStatus());
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void missingSessionUser_shouldBeClearedOnceAndNotResurrectedOnNextPublicRequest() throws Exception {
+        PlatformPrincipal principal = principal("deleted-user");
+        MockHttpServletRequest firstRequest = authenticatedRequest("GET", "/api/v1/search", principal);
+        MockHttpSession session = (MockHttpSession) firstRequest.getSession(false);
+        FilterChain firstChain = mock(FilterChain.class);
+        when(userAccountRepository.findById("deleted-user")).thenReturn(java.util.Optional.empty());
+
+        filter.doFilter(firstRequest, new MockHttpServletResponse(), firstChain);
+        SecurityContextHolder.clearContext();
+
+        MockHttpServletRequest secondRequest = new MockHttpServletRequest();
+        secondRequest.setMethod("GET");
+        secondRequest.setRequestURI("/api/v1/search");
+        secondRequest.setSession(session);
+        FilterChain secondChain = mock(FilterChain.class);
+        filter.doFilter(secondRequest, new MockHttpServletResponse(), secondChain);
+
+        assertFalse(session.isInvalid());
+        assertNull(session.getAttribute("platformPrincipal"));
+        verify(firstChain).doFilter(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        verify(secondChain).doFilter(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        verify(userAccountRepository, times(1)).findById("deleted-user");
     }
 
     @Test
@@ -162,5 +225,27 @@ class AuthContextFilterTest {
         verify(filterChain).doFilter(same(request), same(response));
         verify(userAccountRepository, never()).findById(org.mockito.ArgumentMatchers.anyString());
         verify(namespaceMemberRepository, never()).findByUserId(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    private static PlatformPrincipal principal(String userId) {
+        return new PlatformPrincipal(userId, "Test User", userId + "@example.com", null, "local", Set.of("USER"));
+    }
+
+    private static UserAccount disabledUser(String userId) {
+        UserAccount user = new UserAccount(userId, "Test User", userId + "@example.com", null);
+        user.setStatus(UserStatus.DISABLED);
+        return user;
+    }
+
+    private static MockHttpServletRequest authenticatedRequest(
+            String method, String path, PlatformPrincipal principal) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod(method);
+        request.setRequestURI(path);
+        request.getSession(true).setAttribute("platformPrincipal", principal);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(principal, null, List.of())
+        );
+        return request;
     }
 }

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/config/SecurityConfig.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/config/SecurityConfig.java
@@ -7,14 +7,17 @@ import com.iflytek.skillhub.auth.oauth.OAuth2LoginSuccessHandler;
 import com.iflytek.skillhub.auth.oauth.SkillHubOAuth2AuthorizationRequestResolver;
 import com.iflytek.skillhub.auth.mock.MockAuthFilter;
 import com.iflytek.skillhub.auth.policy.RouteSecurityPolicyRegistry;
+import com.iflytek.skillhub.auth.session.ExpiredPublicSessionFilter;
 import com.iflytek.skillhub.auth.token.ApiTokenAuthenticationFilter;
 import com.iflytek.skillhub.auth.token.ApiTokenScopeFilter;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -28,6 +31,7 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -135,6 +139,11 @@ public class SecurityConfig {
             )
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                .invalidSessionStrategy((request, response) -> {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    response.getWriter().write("{\"code\":401,\"msg\":\"Session expired\"}");
+                })
             )
             .exceptionHandling(exceptions -> exceptions
                 .accessDeniedHandler(apiAccessDeniedHandler)
@@ -154,6 +163,7 @@ public class SecurityConfig {
                 .invalidateHttpSession(true)
                 .deleteCookies("SESSION")
             )
+            .addFilterBefore(new ExpiredPublicSessionFilter(routeSecurityPolicyRegistry), CsrfFilter.class)
             .addFilterBefore(apiTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterAfter(apiTokenScopeFilter, ApiTokenAuthenticationFilter.class);
 

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/config/SecurityConfig.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/config/SecurityConfig.java
@@ -11,12 +11,10 @@ import com.iflytek.skillhub.auth.token.ApiTokenAuthenticationFilter;
 import com.iflytek.skillhub.auth.token.ApiTokenScopeFilter;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -137,11 +135,6 @@ public class SecurityConfig {
             )
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-                .invalidSessionStrategy((request, response) -> {
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                    response.getWriter().write("{\"code\":401,\"msg\":\"Session expired\"}");
-                })
             )
             .exceptionHandling(exceptions -> exceptions
                 .accessDeniedHandler(apiAccessDeniedHandler)

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistry.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistry.java
@@ -171,6 +171,21 @@ public class RouteSecurityPolicyRegistry {
     }
 
     /**
+     * Resolves the first matching authorization policy for a request. Routes not
+     * listed in the catalog follow Spring Security's authenticated fallback.
+     */
+    public AccessLevel accessLevel(String method, String path) {
+        if (path == null) {
+            return AccessLevel.AUTHENTICATED;
+        }
+        return AUTHORIZATION_POLICIES.stream()
+                .filter(policy -> policy.matches(method, path, pathMatcher))
+                .map(RouteAuthorizationPolicy::accessLevel)
+                .findFirst()
+                .orElse(AccessLevel.AUTHENTICATED);
+    }
+
+    /**
      * Authorization routes that are deliberately unreachable with an API token.
      */
     public Set<String> sessionOnlyRoutes() {
@@ -282,6 +297,13 @@ public class RouteSecurityPolicyRegistry {
             return method == null
                     ? new AntPathRequestMatcher(pattern)
                     : new AntPathRequestMatcher(pattern, method.name());
+        }
+
+        boolean matches(String requestMethod, String requestPath, AntPathMatcher matcher) {
+            if (method != null && (requestMethod == null || !method.name().equalsIgnoreCase(requestMethod))) {
+                return false;
+            }
+            return matcher.match(pattern, requestPath);
         }
     }
 

--- a/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/session/ExpiredPublicSessionFilter.java
+++ b/server/skillhub-auth/src/main/java/com/iflytek/skillhub/auth/session/ExpiredPublicSessionFilter.java
@@ -1,0 +1,76 @@
+package com.iflytek.skillhub.auth.session;
+
+import com.iflytek.skillhub.auth.policy.RouteSecurityPolicyRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Treats an expired session cookie as absent only for routes that already allow anonymous access.
+ */
+public final class ExpiredPublicSessionFilter extends OncePerRequestFilter {
+
+    private static final Set<String> SESSION_COOKIES = Set.of("SESSION", "JSESSIONID");
+
+    private final RouteSecurityPolicyRegistry routeSecurityPolicyRegistry;
+
+    public ExpiredPublicSessionFilter(RouteSecurityPolicyRegistry routeSecurityPolicyRegistry) {
+        this.routeSecurityPolicyRegistry = routeSecurityPolicyRegistry;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String requestPath = RouteSecurityPolicyRegistry.requestPath(request);
+        boolean publicRoute = routeSecurityPolicyRegistry.accessLevel(request.getMethod(), requestPath)
+                == RouteSecurityPolicyRegistry.AccessLevel.PERMIT_ALL;
+        if (publicRoute && request.getRequestedSessionId() != null && !request.isRequestedSessionIdValid()) {
+            filterChain.doFilter(new SessionlessRequest(request), response);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private static final class SessionlessRequest extends HttpServletRequestWrapper {
+
+        private SessionlessRequest(HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public Cookie[] getCookies() {
+            Cookie[] cookies = super.getCookies();
+            if (cookies == null) {
+                return null;
+            }
+            Cookie[] retained = Arrays.stream(cookies)
+                    .filter(cookie -> !SESSION_COOKIES.contains(cookie.getName()))
+                    .toArray(Cookie[]::new);
+            return retained.length == 0 ? null : retained;
+        }
+    }
+}

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistryTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/policy/RouteSecurityPolicyRegistryTest.java
@@ -19,6 +19,22 @@ class RouteSecurityPolicyRegistryTest {
     private final RouteSecurityPolicyRegistry registry = new RouteSecurityPolicyRegistry();
 
     @Test
+    void accessLevel_respectsMethodSpecificPublicRoutesAndProtectedFallback() {
+        assertEquals(RouteSecurityPolicyRegistry.AccessLevel.PERMIT_ALL,
+                registry.accessLevel("GET", "/api/v1/skills"));
+        assertEquals(RouteSecurityPolicyRegistry.AccessLevel.AUTHENTICATED,
+                registry.accessLevel("POST", "/api/v1/skills"));
+        assertEquals(RouteSecurityPolicyRegistry.AccessLevel.AUTHENTICATED,
+                registry.accessLevel("GET", "/api/v1/unlisted"));
+    }
+
+    @Test
+    void accessLevel_matchesPublicSubpaths() {
+        assertEquals(RouteSecurityPolicyRegistry.AccessLevel.PERMIT_ALL,
+                registry.accessLevel("GET", "/api/v1/resolve/team/demo"));
+    }
+
+    @Test
     void authorizeApiToken_requiresPublishScopeForPublishEndpoints() {
         var denied = registry.authorizeApiToken("POST", "/api/web/skills/global/publish", Set.of("skill:read"));
         var allowed = registry.authorizeApiToken("POST", "/api/web/skills/global/publish", Set.of("skill:publish"));

--- a/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/session/ExpiredPublicSessionFilterTest.java
+++ b/server/skillhub-auth/src/test/java/com/iflytek/skillhub/auth/session/ExpiredPublicSessionFilterTest.java
@@ -1,0 +1,92 @@
+package com.iflytek.skillhub.auth.session;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.iflytek.skillhub.auth.policy.RouteSecurityPolicyRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class ExpiredPublicSessionFilterTest {
+
+    private final ExpiredPublicSessionFilter filter =
+            new ExpiredPublicSessionFilter(new RouteSecurityPolicyRegistry());
+
+    @Test
+    void expiredSessionOnPublicRoute_shouldBeHiddenFromDownstreamSecurityFilters() throws Exception {
+        MockHttpServletRequest request = expiredSessionRequest("GET", "/api/v1/skills");
+        request.setCookies(
+                new Cookie("SESSION", "expired"),
+                new Cookie("JSESSIONID", "expired-servlet"),
+                new Cookie("locale", "zh"));
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        HttpServletRequest downstream = capturedRequest(chain);
+        assertNull(downstream.getRequestedSessionId());
+        assertArrayEquals(new String[]{"locale"},
+                java.util.Arrays.stream(downstream.getCookies()).map(Cookie::getName).toArray(String[]::new));
+    }
+
+    @Test
+    void expiredSessionOnProtectedMethod_shouldRemainVisibleForUnauthorizedResponse() throws Exception {
+        MockHttpServletRequest request = expiredSessionRequest("POST", "/api/v1/skills");
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        assertSame(request, capturedRequest(chain));
+        assertEquals("expired", request.getRequestedSessionId());
+    }
+
+    @Test
+    void validSessionOnPublicRoute_shouldRemainUnchanged() throws Exception {
+        MockHttpServletRequest request = expiredSessionRequest("GET", "/api/v1/search");
+        request.setRequestedSessionIdValid(true);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        assertSame(request, capturedRequest(chain));
+    }
+
+    @Test
+    void forwardedPrefix_shouldUseServletPathForPublicRouteDecision() throws Exception {
+        MockHttpServletRequest request = expiredSessionRequest("GET", "/skillhub/api/v1/search");
+        request.setContextPath("/skillhub");
+        request.setServletPath("/api/v1/search");
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        assertNull(capturedRequest(chain).getRequestedSessionId());
+    }
+
+    private static MockHttpServletRequest expiredSessionRequest(String method, String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod(method);
+        request.setRequestURI(path);
+        request.setRequestedSessionId("expired");
+        request.setRequestedSessionIdValid(false);
+        return request;
+    }
+
+    private static HttpServletRequest capturedRequest(FilterChain chain) throws Exception {
+        ArgumentCaptor<ServletRequest> requestCaptor = ArgumentCaptor.forClass(ServletRequest.class);
+        ArgumentCaptor<ServletResponse> responseCaptor = ArgumentCaptor.forClass(ServletResponse.class);
+        verify(chain).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        return (HttpServletRequest) requestCaptor.getValue();
+    }
+}


### PR DESCRIPTION
## Summary

- treat a stale or disabled session principal as anonymous on routes already declared `permitAll`
- keep protected routes fail-closed and preserve the existing `accountDisabled` response for `/api/v1/auth/me`
- stop invalidating the whole session when clearing stale authentication
- let normal route authorization handle an expired server-side session instead of globally returning `Session expired`

## Design

The filter resolves access through the existing ordered `RouteSecurityPolicyRegistry`; it does not maintain a second public-route list. Unmatched routes remain authenticated by default.

No frontend production change is required. The current auth query already maps 401 to an anonymous user, while protected route guards continue to redirect to login.

## Validation

- `RouteSecurityPolicyRegistryTest`: 20 passed
- `AuthContextFilterTest`: 7 passed
- covered public GET vs protected POST, disabled/missing users, `/auth/me` compatibility, retained session, and two consecutive requests without principal resurrection

Closes #614
