### PR TITLE
feat(cli): add source-safe skill upgrades

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable CLI behavior changes are documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Add `skillhub upgrade <coordinate...>` for bounded, explicit upgrades of already-installed Skills,
+  including side-effect-free `--check`, structured `--json`, local-change protection, and target
+  filters.
+
 ### Fixed
+
+- Prevent `--force` from overwriting an unmanaged or different-source Skill at the same target path.
+  Source ownership is the full `registry + namespace + slug` identity.
+- Exclude installer-owned `.skillhub/` state when publishing a local Skill directory.
 
 - Resolve `namespace/slug`, `@namespace/slug`, and `namespace--slug`
   coordinates against their declared namespace instead of silently falling

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable CLI behavior changes are documented in this file.
 
 - Prevent `--force` from overwriting an unmanaged or different-source Skill at the same target path.
   Source ownership is the full `registry + namespace + slug` identity.
+- Reject registry downgrades and partial-target updates that the shared inventory version cannot
+  represent safely.
 - Exclude installer-owned `.skillhub/` state when publishing a local Skill directory.
 
 - Resolve `namespace/slug`, `@namespace/slug`, and `namespace--slug`

--- a/cli/README.md
+++ b/cli/README.md
@@ -171,7 +171,7 @@ skillhub install pdf-parser --agent codex --agent claude-code
 # Install to custom directory
 skillhub install pdf-parser --dir ~/.claude/skills
 
-# Force overwrite existing installation
+# Reinstall a SkillHub-managed installation from the same source
 skillhub install pdf-parser --force
 ```
 
@@ -228,16 +228,43 @@ For a custom path or an unsupported Agent directory, use `--dir` to specify the 
 
 ```json
 {
+  "schemaVersion": 1,
   "registry": "https://skill.xfyun.cn",
   "namespace": "global",
   "slug": "pdf-parser",
   "version": "1.0.0",
+  "versionId": 123,
   "fingerprint": "sha256:...",
+  "files": { "SKILL.md": "sha256..." },
   "source": "skillhub",
   "agent": "codex",
   "installedAt": "2026-04-28T06:00:00.000Z"
 }
 ```
+
+The CLI creates `.skillhub/metadata.json` after extracting a downloaded package. It is not part of
+the published ZIP and is excluded when a managed directory is published again.
+
+## ⬆️ Upgrade Installed Skills
+
+`upgrade` only operates on explicitly selected, SkillHub-managed local installations. It never
+installs a missing Skill and has no implicit upgrade-all mode.
+
+```bash
+# Preview without changing files
+skillhub upgrade @global/skillhub-registry --check
+
+# Upgrade one or a bounded list of installed Skills
+skillhub upgrade @global/skillhub-registry
+skillhub upgrade @team/code-review @team/java-guide
+
+# Machine-readable plan
+skillhub upgrade @team/code-review --check --json
+```
+
+The source identity is `registry + namespace + slug`. `--force` may replace local changes only when
+that full identity matches the installation metadata; it never overwrites an unmanaged directory or
+a Skill installed from another source.
 
 ## 🔄 Namespace Workspaces
 
@@ -402,6 +429,7 @@ Update mechanism:
 | `skillhub whoami [--registry <url>] [--token <token>] [--json]` | Validate current token and display user information |
 | `skillhub search <query> [--registry <url>] [--token <token>] [--limit <n>] [--json]` | Search published skills |
 | `skillhub install <coordinate> [--scope <user\|project>] [--namespace <slug>] [--version <v>] [--agent <profile>] [--dir <path>] [--force] [--registry <url>] [--token <token>] [--json]` | Install a skill |
+| `skillhub upgrade <coordinate...> [--namespace <slug>] [--agent <profile>] [--dir <path>] [--registry <url>] [--check] [--force] [--json]` | Upgrade explicitly selected installed skills |
 | `skillhub list [--agent <profile>] [--dir <path>] [--registry <url>] [--json]` | List installed skills |
 | `skillhub remove <coordinate> [--agent <profile>] [--all] [--remote] [--hard] [--namespace <slug>] [--registry <url>] [--token <token>] [--json]` | Remove a skill |
 | `skillhub doctor [--json]` | Scan project directory and rebuild local inventory |
@@ -447,12 +475,15 @@ skillhub search test --registry https://skillhub.example.com
 
 ```bash
 # Use --force to overwrite
-skillhub install pdf-parser --force
+skillhub install pdf-parser --force # same SkillHub source only
 
 # Or remove first then install
 skillhub remove pdf-parser
 skillhub install pdf-parser
 ```
+
+`--force` does not bypass source ownership. Move or explicitly remove an unmanaged or different-source
+directory before installing another Skill with the same visible slug.
 
 ### Corrupted Inventory
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -269,6 +269,8 @@ a Skill installed from another source.
 All targets in one inventory entry are upgraded together. A filter that selects only part of that
 entry is rejected because the current inventory format stores one shared version for all targets.
 The command also keeps the local files when the registry resolves to an older version.
+If a multi-Skill run fails after an earlier upgrade commits, execution stops and reports each item
+as `upgraded`, `failed`, or `not-attempted`; a committed upgrade is never rolled back implicitly.
 New installations store absolute target paths. An older inventory entry with relative target paths
 must be reinstalled before upgrade because its original working directory cannot be recovered safely.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -266,6 +266,10 @@ The source identity is `registry + namespace + slug`. `--force` may replace loca
 that full identity matches the installation metadata; it never overwrites an unmanaged directory or
 a Skill installed from another source.
 
+All targets in one inventory entry are upgraded together. A filter that selects only part of that
+entry is rejected because the current inventory format stores one shared version for all targets.
+The command also keeps the local files when the registry resolves to an older version.
+
 ## 🔄 Namespace Workspaces
 
 Use namespace synchronization when an Agent workspace should maintain all installable skills from one team space.

--- a/cli/README.md
+++ b/cli/README.md
@@ -269,6 +269,8 @@ a Skill installed from another source.
 All targets in one inventory entry are upgraded together. A filter that selects only part of that
 entry is rejected because the current inventory format stores one shared version for all targets.
 The command also keeps the local files when the registry resolves to an older version.
+New installations store absolute target paths. An older inventory entry with relative target paths
+must be reinstalled before upgrade because its original working directory cannot be recovered safely.
 
 ## 🔄 Namespace Workspaces
 

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -8,12 +8,14 @@
         "cac": "^6.7.14",
         "fflate": "^0.8.2",
         "prompts": "^2.4.2",
+        "proper-lockfile": "4.1.2",
         "semver": "^7.6.3",
         "zod": "^3.24.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.13",
         "@types/prompts": "^2.4.9",
+        "@types/proper-lockfile": "4.1.4",
         "@types/semver": "^7.5.8",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
@@ -48,6 +50,10 @@
     "@types/node": ["@types/node@25.6.0", "https://registry.npmmirror.com/@types/node/-/node-25.6.0.tgz", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/prompts": ["@types/prompts@2.4.9", "https://registry.npmmirror.com/@types/prompts/-/prompts-2.4.9.tgz", { "dependencies": { "@types/node": "*", "kleur": "^3.0.3" } }, "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA=="],
+
+    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "https://registry.npmmirror.com/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
+
+    "@types/retry": ["@types/retry@0.12.5", "https://registry.npmmirror.com/@types/retry/-/retry-0.12.5.tgz", {}, "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="],
 
     "@types/semver": ["@types/semver@7.7.1", "https://registry.npmmirror.com/@types/semver/-/semver-7.7.1.tgz", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
@@ -163,6 +169,8 @@
 
     "globby": ["globby@11.1.0", "https://registry.npmmirror.com/globby/-/globby-11.1.0.tgz", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
+    "graceful-fs": ["graceful-fs@4.2.11", "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
     "graphemer": ["graphemer@1.4.0", "https://registry.npmmirror.com/graphemer/-/graphemer-1.4.0.tgz", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "has-flag": ["has-flag@4.0.0", "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -239,11 +247,15 @@
 
     "prompts": ["prompts@2.4.2", "https://registry.npmmirror.com/prompts/-/prompts-2.4.2.tgz", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
+    "proper-lockfile": ["proper-lockfile@4.1.2", "https://registry.npmmirror.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
     "punycode": ["punycode@2.3.1", "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "resolve-from": ["resolve-from@4.0.0", "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "retry": ["retry@0.12.0", "https://registry.npmmirror.com/retry/-/retry-0.12.0.tgz", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "reusify": ["reusify@1.1.0", "https://registry.npmmirror.com/reusify/-/reusify-1.1.0.tgz", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -256,6 +268,8 @@
     "shebang-command": ["shebang-command@2.0.0", "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "https://registry.npmmirror.com/signal-exit/-/signal-exit-3.0.7.tgz", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "https://registry.npmmirror.com/sisteransi/-/sisteransi-1.0.5.tgz", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -48,12 +48,14 @@
     "cac": "^6.7.14",
     "fflate": "^0.8.2",
     "prompts": "^2.4.2",
+    "proper-lockfile": "4.1.2",
     "semver": "^7.6.3",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.13",
     "@types/prompts": "^2.4.9",
+    "@types/proper-lockfile": "4.1.4",
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",

--- a/cli/src/commands/help.ts
+++ b/cli/src/commands/help.ts
@@ -43,6 +43,15 @@ export const commands = {
       'skillhub install pdf-parser --scope project --agent codex'
     ]
   },
+  upgrade: {
+    summary: 'Upgrade explicitly selected installed skills',
+    usage: 'skillhub upgrade <coordinate...> [--namespace <slug>] [--agent <profile>] [--dir <path>] [--registry <url>] [--check] [--force] [--json]',
+    examples: [
+      'skillhub upgrade @global/skillhub-registry',
+      'skillhub upgrade @team/code-review @team/java-guide --check --json',
+      'skillhub upgrade code-review --namespace team --agent codex'
+    ]
+  },
   sync: {
     summary: 'Synchronize and maintain namespace workspaces',
     usage: 'skillhub sync <pull|status|diff|push> [options]',

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -115,7 +115,16 @@ export async function installCommand(
   })
 
   if (options.json) {
-    return JSON.stringify({ ok: true, namespace, slug, installed: result.installed })
+    return JSON.stringify({
+      ok: true,
+      namespace,
+      slug,
+      installed: result.installed,
+      ...(result.warnings?.length ? { warnings: result.warnings } : {})
+    })
   }
-  return result.installed.map(i => `Installed ${namespace}/${slug} -> ${i.dir} (${i.agent})`).join('\n')
+  return [
+    ...result.installed.map(i => `Installed ${namespace}/${slug} -> ${i.dir} (${i.agent})`),
+    ...(result.warnings ?? []).map(warning => `Warning: ${warning}`)
+  ].join('\n')
 }

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -49,7 +49,9 @@ export async function publishCommand(path: string, options: PublishCommandOption
       throw new CliError(`file must be a zip archive: ${path}`, EXIT.filesystem, { path })
     }
   } else if (pathStat.isDirectory()) {
-    archiveBlob = await createZip(path)
+    archiveBlob = await createZip(path, {
+      exclude: relativePath => relativePath === '.skillhub' || relativePath.startsWith('.skillhub/')
+    })
     archiveName = `${basename(path)}.zip`
   } else {
     throw new CliError(`path must be a file or directory: ${path}`, EXIT.filesystem, { path })

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -145,6 +145,7 @@ function renderPullResult(result: PullResult, json: boolean, check: boolean): st
     ...result.entries
       .filter(entry => !result.actions.some(action => action.slug === entry.slug))
       .map(entry => `${entry.status.padEnd(16)} ${entry.slug}`),
+    ...result.warnings.map(item => `warning    ${item.slug}: ${item.message}`),
     ...result.failures.map(item => `failed     ${item.slug}: ${item.message}`)
   ]
   return lines.join('\n')

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -135,7 +135,7 @@ async function resolveSyncContext(options: SyncCommonOptions): Promise<{
   return { client: new SkillHubClient(registry, token), registry, token, namespace, rootDir }
 }
 
-function renderPullResult(result: PullResult, json: boolean, check: boolean): string {
+export function renderPullResult(result: PullResult, json: boolean, check: boolean): string {
   if (json) {
     return JSON.stringify({ ok: result.failures.length === 0, check, ...result })
   }

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -53,7 +53,8 @@ export async function upgradeCommand(coordinates: string[], options: UpgradeComm
   const output = renderUpgradeResult(plan, result, Boolean(options.json))
   if (result.failed > 0) {
     process.stdout.write(`${output}\n`)
-    throw new CliError('one or more skills failed to upgrade', EXIT.generic, {
+    const firstFailure = result.items.find(item => item.action === 'failed')
+    throw new CliError('one or more skills failed to upgrade', firstFailure?.exitCode ?? EXIT.generic, {
       failed: result.items.filter(item => item.action === 'failed')
     })
   }
@@ -104,6 +105,7 @@ function renderUpgradeResult(plan: UpgradePlan, result: UpgradeExecutionResult, 
     remoteVersion: item.remoteVersion,
     action: executionByCoordinate.get(item.coordinate)?.action ?? item.action,
     reason: executionByCoordinate.get(item.coordinate)?.reason ?? item.reason,
+    warnings: executionByCoordinate.get(item.coordinate)?.warnings,
     changedFiles: item.changedFiles,
     targets: item.targets
   }))
@@ -127,7 +129,8 @@ function renderUpgradeResult(plan: UpgradePlan, result: UpgradeExecutionResult, 
     ...items.map(item => {
       const versions = item.remoteVersion ? ` ${item.currentVersion} -> ${item.remoteVersion}` : ''
       const reason = item.reason ? ` (${item.reason})` : ''
-      return `${item.action.padEnd(13)} ${item.coordinate}${versions}${reason}`
+      const warnings = item.warnings?.length ? ` [warning: ${item.warnings.join('; ')}]` : ''
+      return `${item.action.padEnd(13)} ${item.coordinate}${versions}${reason}${warnings}`
     })
   ].join('\n')
 }

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1,0 +1,78 @@
+import { CredentialsStore } from '../stores/credentials-store'
+import { resolveToken } from '../services/registry-service'
+import { CliError } from '../shared/errors'
+import { EXIT } from '../shared/constants'
+import { executeSkillUpgradePlan, planSkillUpgrades, type UpgradePlan } from '../services/upgrade-service'
+
+export interface UpgradeCommandOptions {
+  namespace?: string
+  agent?: string[]
+  dir?: string
+  registry?: string
+  token?: string
+  check?: boolean
+  force?: boolean
+  json?: boolean
+}
+
+export async function upgradeCommand(coordinates: string[], options: UpgradeCommandOptions): Promise<string> {
+  const credentials = new CredentialsStore()
+  const tokenForRegistry = async (registry: string): Promise<string | undefined> =>
+    resolveToken(options, process.env, await credentials.getToken(registry))
+
+  const plan = await planSkillUpgrades({
+    coordinates,
+    namespace: options.namespace,
+    registry: options.registry,
+    agents: options.agent,
+    dir: options.dir,
+    force: Boolean(options.force),
+    tokenForRegistry
+  })
+  const output = renderUpgradePlan(plan, Boolean(options.check), Boolean(options.json))
+
+  if (plan.blocked > 0) {
+    process.stdout.write(`${output}\n`)
+    throw new CliError('upgrade plan contains blocked skills', EXIT.validation, {
+      blocked: plan.items.filter(item => item.action === 'blocked').map(item => ({
+        coordinate: item.coordinate,
+        reason: item.reason
+      }))
+    })
+  }
+  if (!options.check) {
+    await executeSkillUpgradePlan(plan, { force: Boolean(options.force), tokenForRegistry })
+  }
+  return output
+}
+
+function renderUpgradePlan(plan: UpgradePlan, check: boolean, json: boolean): string {
+  if (json) {
+    return JSON.stringify({
+      ok: plan.blocked === 0,
+      check,
+      summary: { upgrades: plan.upgrades, unchanged: plan.unchanged, blocked: plan.blocked },
+      items: plan.items.map(item => ({
+        coordinate: item.coordinate,
+        registry: item.registry,
+        currentVersion: item.currentVersion,
+        remoteVersion: item.remoteVersion,
+        action: item.action === 'upgrade' && !check ? 'upgraded' : item.action,
+        reason: item.reason,
+        changedFiles: item.changedFiles,
+        targets: item.targets
+      }))
+    })
+  }
+
+  const heading = check ? 'Upgrade plan' : 'Upgrade result'
+  return [
+    `${heading}: ${plan.upgrades} upgrade, ${plan.unchanged} unchanged, ${plan.blocked} blocked`,
+    ...plan.items.map(item => {
+      const action = item.action === 'upgrade' && !check ? 'upgraded' : item.action
+      const versions = item.remoteVersion ? ` ${item.currentVersion} -> ${item.remoteVersion}` : ''
+      const reason = item.reason ? ` (${item.reason})` : ''
+      return `${action.padEnd(10)} ${item.coordinate}${versions}${reason}`
+    })
+  ].join('\n')
+}

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -96,7 +96,7 @@ function renderUpgradePlan(
   ].join('\n')
 }
 
-function renderUpgradeResult(plan: UpgradePlan, result: UpgradeExecutionResult, json: boolean): string {
+export function renderUpgradeResult(plan: UpgradePlan, result: UpgradeExecutionResult, json: boolean): string {
   const executionByCoordinate = new Map(result.items.map(item => [item.coordinate, item]))
   const items = plan.items.map(item => ({
     coordinate: item.coordinate,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -2,7 +2,12 @@ import { CredentialsStore } from '../stores/credentials-store'
 import { resolveToken } from '../services/registry-service'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
-import { executeSkillUpgradePlan, planSkillUpgrades, type UpgradePlan } from '../services/upgrade-service'
+import {
+  executeSkillUpgradePlan,
+  planSkillUpgrades,
+  type UpgradeExecutionResult,
+  type UpgradePlan
+} from '../services/upgrade-service'
 
 export interface UpgradeCommandOptions {
   namespace?: string | undefined
@@ -44,8 +49,15 @@ export async function upgradeCommand(coordinates: string[], options: UpgradeComm
   }
   if (options.check) return renderUpgradePlan(plan, { check: true, executed: false }, Boolean(options.json))
 
-  await executeSkillUpgradePlan(plan, { tokenForRegistry })
-  return renderUpgradePlan(plan, { check: false, executed: true }, Boolean(options.json))
+  const result = await executeSkillUpgradePlan(plan, { tokenForRegistry })
+  const output = renderUpgradeResult(plan, result, Boolean(options.json))
+  if (result.failed > 0) {
+    process.stdout.write(`${output}\n`)
+    throw new CliError('one or more skills failed to upgrade', EXIT.generic, {
+      failed: result.items.filter(item => item.action === 'failed')
+    })
+  }
+  return output
 }
 
 function renderUpgradePlan(
@@ -79,6 +91,43 @@ function renderUpgradePlan(
       const versions = item.remoteVersion ? ` ${item.currentVersion} -> ${item.remoteVersion}` : ''
       const reason = item.reason ? ` (${item.reason})` : ''
       return `${action.padEnd(10)} ${item.coordinate}${versions}${reason}`
+    })
+  ].join('\n')
+}
+
+function renderUpgradeResult(plan: UpgradePlan, result: UpgradeExecutionResult, json: boolean): string {
+  const executionByCoordinate = new Map(result.items.map(item => [item.coordinate, item]))
+  const items = plan.items.map(item => ({
+    coordinate: item.coordinate,
+    registry: item.registry,
+    currentVersion: item.currentVersion,
+    remoteVersion: item.remoteVersion,
+    action: executionByCoordinate.get(item.coordinate)?.action ?? item.action,
+    reason: executionByCoordinate.get(item.coordinate)?.reason ?? item.reason,
+    changedFiles: item.changedFiles,
+    targets: item.targets
+  }))
+
+  if (json) {
+    return JSON.stringify({
+      ok: result.failed === 0,
+      check: false,
+      summary: {
+        upgraded: result.upgraded,
+        unchanged: result.unchanged,
+        failed: result.failed,
+        notAttempted: result.notAttempted
+      },
+      items
+    })
+  }
+
+  return [
+    `Upgrade result: ${result.upgraded} upgraded, ${result.unchanged} unchanged, ${result.failed} failed, ${result.notAttempted} not attempted`,
+    ...items.map(item => {
+      const versions = item.remoteVersion ? ` ${item.currentVersion} -> ${item.remoteVersion}` : ''
+      const reason = item.reason ? ` (${item.reason})` : ''
+      return `${item.action.padEnd(13)} ${item.coordinate}${versions}${reason}`
     })
   ].join('\n')
 }

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -30,7 +30,10 @@ export async function upgradeCommand(coordinates: string[], options: UpgradeComm
     tokenForRegistry
   })
   if (plan.blocked > 0) {
-    const output = renderUpgradePlan(plan, 'plan', Boolean(options.json))
+    const output = renderUpgradePlan(plan, {
+      check: Boolean(options.check),
+      executed: false
+    }, Boolean(options.json))
     process.stdout.write(`${output}\n`)
     throw new CliError('upgrade plan contains blocked skills', EXIT.validation, {
       blocked: plan.items.filter(item => item.action === 'blocked').map(item => ({
@@ -39,25 +42,28 @@ export async function upgradeCommand(coordinates: string[], options: UpgradeComm
       }))
     })
   }
-  if (options.check) return renderUpgradePlan(plan, 'plan', Boolean(options.json))
+  if (options.check) return renderUpgradePlan(plan, { check: true, executed: false }, Boolean(options.json))
 
   await executeSkillUpgradePlan(plan, { tokenForRegistry })
-  return renderUpgradePlan(plan, 'result', Boolean(options.json))
+  return renderUpgradePlan(plan, { check: false, executed: true }, Boolean(options.json))
 }
 
-function renderUpgradePlan(plan: UpgradePlan, mode: 'plan' | 'result', json: boolean): string {
-  const check = mode === 'plan'
+function renderUpgradePlan(
+  plan: UpgradePlan,
+  state: { check: boolean; executed: boolean },
+  json: boolean
+): string {
   if (json) {
     return JSON.stringify({
       ok: plan.blocked === 0,
-      check,
+      check: state.check,
       summary: { upgrades: plan.upgrades, unchanged: plan.unchanged, blocked: plan.blocked },
       items: plan.items.map(item => ({
         coordinate: item.coordinate,
         registry: item.registry,
         currentVersion: item.currentVersion,
         remoteVersion: item.remoteVersion,
-        action: item.action === 'upgrade' && mode === 'result' ? 'upgraded' : item.action,
+        action: item.action === 'upgrade' && state.executed ? 'upgraded' : item.action,
         reason: item.reason,
         changedFiles: item.changedFiles,
         targets: item.targets
@@ -65,11 +71,11 @@ function renderUpgradePlan(plan: UpgradePlan, mode: 'plan' | 'result', json: boo
     })
   }
 
-  const heading = mode === 'plan' ? 'Upgrade plan' : 'Upgrade result'
+  const heading = state.executed ? 'Upgrade result' : 'Upgrade plan'
   return [
     `${heading}: ${plan.upgrades} upgrade, ${plan.unchanged} unchanged, ${plan.blocked} blocked`,
     ...plan.items.map(item => {
-      const action = item.action === 'upgrade' && mode === 'result' ? 'upgraded' : item.action
+      const action = item.action === 'upgrade' && state.executed ? 'upgraded' : item.action
       const versions = item.remoteVersion ? ` ${item.currentVersion} -> ${item.remoteVersion}` : ''
       const reason = item.reason ? ` (${item.reason})` : ''
       return `${action.padEnd(10)} ${item.coordinate}${versions}${reason}`

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -5,14 +5,14 @@ import { EXIT } from '../shared/constants'
 import { executeSkillUpgradePlan, planSkillUpgrades, type UpgradePlan } from '../services/upgrade-service'
 
 export interface UpgradeCommandOptions {
-  namespace?: string
-  agent?: string[]
-  dir?: string
-  registry?: string
-  token?: string
-  check?: boolean
-  force?: boolean
-  json?: boolean
+  namespace?: string | undefined
+  agent?: string[] | undefined
+  dir?: string | undefined
+  registry?: string | undefined
+  token?: string | undefined
+  check?: boolean | undefined
+  force?: boolean | undefined
+  json?: boolean | undefined
 }
 
 export async function upgradeCommand(coordinates: string[], options: UpgradeCommandOptions): Promise<string> {
@@ -29,9 +29,8 @@ export async function upgradeCommand(coordinates: string[], options: UpgradeComm
     force: Boolean(options.force),
     tokenForRegistry
   })
-  const output = renderUpgradePlan(plan, Boolean(options.check), Boolean(options.json))
-
   if (plan.blocked > 0) {
+    const output = renderUpgradePlan(plan, 'plan', Boolean(options.json))
     process.stdout.write(`${output}\n`)
     throw new CliError('upgrade plan contains blocked skills', EXIT.validation, {
       blocked: plan.items.filter(item => item.action === 'blocked').map(item => ({
@@ -40,13 +39,14 @@ export async function upgradeCommand(coordinates: string[], options: UpgradeComm
       }))
     })
   }
-  if (!options.check) {
-    await executeSkillUpgradePlan(plan, { force: Boolean(options.force), tokenForRegistry })
-  }
-  return output
+  if (options.check) return renderUpgradePlan(plan, 'plan', Boolean(options.json))
+
+  await executeSkillUpgradePlan(plan, { tokenForRegistry })
+  return renderUpgradePlan(plan, 'result', Boolean(options.json))
 }
 
-function renderUpgradePlan(plan: UpgradePlan, check: boolean, json: boolean): string {
+function renderUpgradePlan(plan: UpgradePlan, mode: 'plan' | 'result', json: boolean): string {
+  const check = mode === 'plan'
   if (json) {
     return JSON.stringify({
       ok: plan.blocked === 0,
@@ -57,7 +57,7 @@ function renderUpgradePlan(plan: UpgradePlan, check: boolean, json: boolean): st
         registry: item.registry,
         currentVersion: item.currentVersion,
         remoteVersion: item.remoteVersion,
-        action: item.action === 'upgrade' && !check ? 'upgraded' : item.action,
+        action: item.action === 'upgrade' && mode === 'result' ? 'upgraded' : item.action,
         reason: item.reason,
         changedFiles: item.changedFiles,
         targets: item.targets
@@ -65,11 +65,11 @@ function renderUpgradePlan(plan: UpgradePlan, check: boolean, json: boolean): st
     })
   }
 
-  const heading = check ? 'Upgrade plan' : 'Upgrade result'
+  const heading = mode === 'plan' ? 'Upgrade plan' : 'Upgrade result'
   return [
     `${heading}: ${plan.upgrades} upgrade, ${plan.unchanged} unchanged, ${plan.blocked} blocked`,
     ...plan.items.map(item => {
-      const action = item.action === 'upgrade' && !check ? 'upgraded' : item.action
+      const action = item.action === 'upgrade' && mode === 'result' ? 'upgraded' : item.action
       const versions = item.remoteVersion ? ` ${item.currentVersion} -> ${item.remoteVersion}` : ''
       const reason = item.reason ? ` (${item.reason})` : ''
       return `${action.padEnd(10)} ${item.coordinate}${versions}${reason}`

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { removeCommand, type RemoveCommandOptions } from './commands/remove'
 import { searchCommand } from './commands/search'
 import { syncDiffCommand, syncPullCommand, syncPushCommand, syncStatusCommand, type SyncCommonOptions, type SyncPullOptions, type SyncPushOptions } from './commands/sync'
 import { updateCommand } from './commands/update'
+import { upgradeCommand, type UpgradeCommandOptions } from './commands/upgrade'
 import { versionCommand } from './commands/version'
 import { whoamiCommand } from './commands/whoami'
 import { EXIT } from './shared/constants'
@@ -245,6 +246,23 @@ cli
   .option('--json', 'Output JSON')
   .action((slug: string, options: InstallCommandOptions & { agent?: string | string[] }) => {
     return runCommand(() => installCommand(slug, { ...options, agent: toArray(options.agent) }), Boolean(options.json))
+  })
+
+cli
+  .command('upgrade [...coordinates]', 'Upgrade explicitly selected installed skills')
+  .option('--namespace <slug>', 'Filter a bare slug by namespace')
+  .option('--agent <profile>', 'Filter installed targets by Agent (repeatable)')
+  .option('--dir <path>', 'Filter installed targets by directory')
+  .option('--registry <url>', 'Filter by installation source registry')
+  .option('--token <token>', 'API token override')
+  .option('--check', 'Show the exact plan without writing')
+  .option('--force', 'Replace local changes from the same source')
+  .option('--json', 'Output JSON')
+  .action((coordinates: string[], options: UpgradeCommandOptions & { agent?: string | string[] }) => {
+    return runCommand(
+      () => upgradeCommand(coordinates, { ...options, agent: toArray(options.agent) }),
+      Boolean(options.json)
+    )
   })
 
 cli

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -8,8 +8,14 @@ import { extractZip } from '../platform/archive'
 import { readBoundedResponseBody } from '../platform/download'
 import { canonicalizeExistingPath, pathExists } from '../platform/paths'
 import { snapshotSkillDirectory } from './skill-fingerprint'
+import {
+  readInstalledSkillMetadata,
+  sameInstalledSkillSource,
+  type InstalledSkillIdentity
+} from './installed-skill-metadata'
 import type { AgentCandidate } from '../agents/types'
 import type { ResolveResponse } from '../clients/skillhub-client'
+import type { Inventory } from '../stores/inventory-store'
 
 export interface InstallOptions {
   registry: string
@@ -25,15 +31,16 @@ export interface InstallOptions {
 
 async function preflightInstallTargets(
   targets: AgentCandidate[],
-  slug: string,
-  force: boolean
+  identity: InstalledSkillIdentity,
+  force: boolean,
+  inventory: Inventory
 ): Promise<Array<{ target: AgentCandidate; skillDir: string }>> {
   const seenSkillDirs = new Set<string>()
   const preparedTargets: Array<{ target: AgentCandidate; skillDir: string }> = []
 
   for (const target of targets) {
     const canonicalRootDir = await canonicalizeExistingPath(target.rootDir)
-    const canonicalSkillDir = join(canonicalRootDir, slug)
+    const canonicalSkillDir = join(canonicalRootDir, identity.slug)
     if (seenSkillDirs.has(canonicalSkillDir)) {
       throw new CliError(`multiple install targets resolve to ${canonicalSkillDir}`, EXIT.usage, {
         path: canonicalSkillDir,
@@ -42,12 +49,39 @@ async function preflightInstallTargets(
     }
     seenSkillDirs.add(canonicalSkillDir)
 
-    const skillDir = join(target.rootDir, slug)
-    if (await pathExists(skillDir) && !force) {
+    const skillDir = join(target.rootDir, identity.slug)
+    const exists = await pathExists(skillDir)
+    if (exists && !force) {
       throw new CliError(`skill already installed at ${skillDir}`, EXIT.filesystem, {
         path: skillDir,
-        next: 'pass --force to overwrite'
+        next: 'pass --force to replace a same-source installation'
       })
+    }
+    if (exists) {
+      const metadataResult = await readInstalledSkillMetadata(skillDir)
+      const inventoryOwners = inventory.items.filter(item =>
+        item.targets.some(existing => existing.installDir === skillDir))
+
+      if (metadataResult.status !== 'valid') {
+        throw new CliError(`cannot verify SkillHub ownership of ${skillDir}`, EXIT.filesystem, {
+          path: skillDir,
+          reason: metadataResult.status === 'missing' ? 'installation metadata is missing' : metadataResult.reason,
+          next: 'move or remove the existing directory before installing'
+        })
+      }
+      if (!sameInstalledSkillSource(metadataResult.metadata, identity) ||
+          inventoryOwners.some(owner => !sameInstalledSkillSource(owner, identity))) {
+        throw new CliError(`source conflict at ${skillDir}`, EXIT.filesystem, {
+          path: skillDir,
+          expected: identity,
+          actual: {
+            registry: metadataResult.metadata.registry,
+            namespace: metadataResult.metadata.namespace,
+            slug: metadataResult.metadata.slug
+          },
+          next: 'choose another target directory or remove the conflicting skill explicitly'
+        })
+      }
     }
     preparedTargets.push({ target, skillDir })
   }
@@ -56,15 +90,19 @@ async function preflightInstallTargets(
 }
 
 export async function installSkill(options: InstallOptions): Promise<{ installed: Array<{ agent: string; dir: string }> }> {
-  const preparedTargets = await preflightInstallTargets(options.targets, options.slug, options.force)
+  const store = new InventoryStore(options.home)
+  const inventory = await store.read()
+  const preparedTargets = await preflightInstallTargets(options.targets, {
+    registry: options.registry,
+    namespace: options.namespace,
+    slug: options.slug
+  }, options.force, inventory)
   const client = new SkillHubClient(options.registry, options.token)
   const resolved = options.resolved ?? await client.resolve(options.namespace, options.slug, options.version)
   const response = await client.download(options.namespace, options.slug, resolved.version)
   const buffer = await readBoundedResponseBody(response)
 
   const installed: Array<{ agent: string; dir: string }> = []
-  const store = new InventoryStore(options.home)
-
   for (const { target, skillDir } of preparedTargets) {
     await mkdir(target.rootDir, { recursive: true })
     const tempDir = await mkdtemp(join(target.rootDir, `.${options.slug}.install-`))
@@ -78,10 +116,12 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
       const metaDir = join(tempDir, '.skillhub')
       await mkdir(metaDir, { recursive: true })
       await writeFile(join(metaDir, 'metadata.json'), JSON.stringify({
+        schemaVersion: 1,
         registry: options.registry,
         namespace: options.namespace,
         slug: options.slug,
         version: resolved.version,
+        versionId: resolved.versionId,
         fingerprint: resolved.fingerprint,
         files: snapshot.files,
         source: 'skillhub',

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { SkillHubClient } from '../clients/skillhub-client'
 import { InventoryStore, InventoryVersionConflictError } from '../stores/inventory-store'
 import { CliError } from '../shared/errors'
@@ -43,6 +43,7 @@ export interface InstallResult {
 interface StagedInstall {
   target: AgentCandidate
   skillDir: string
+  canonicalSkillDir: string
   tempDir: string
   installedAt: string
   backupDir: string | null
@@ -54,9 +55,9 @@ async function preflightInstallTargets(
   identity: InstalledSkillIdentity,
   force: boolean,
   inventory: Inventory
-): Promise<Array<{ target: AgentCandidate; skillDir: string }>> {
+): Promise<Array<{ target: AgentCandidate; skillDir: string; canonicalSkillDir: string }>> {
   const seenSkillDirs = new Set<string>()
-  const preparedTargets: Array<{ target: AgentCandidate; skillDir: string }> = []
+  const preparedTargets: Array<{ target: AgentCandidate; skillDir: string; canonicalSkillDir: string }> = []
 
   for (const target of targets) {
     const rootDir = resolve(target.rootDir)
@@ -82,9 +83,9 @@ async function preflightInstallTargets(
       })
     }
     if (exists) {
-      await assertReplaceableInstallation(skillDir, skillDir, identity, inventory)
+      await assertReplaceableInstallation(skillDir, skillDir, canonicalSkillDir, identity, inventory)
     }
-    preparedTargets.push({ target: resolvedTarget, skillDir })
+    preparedTargets.push({ target: resolvedTarget, skillDir, canonicalSkillDir })
   }
 
   return preparedTargets
@@ -105,7 +106,7 @@ export async function installSkill(options: InstallOptions): Promise<InstallResu
 
   const staged: StagedInstall[] = []
   try {
-    for (const { target, skillDir } of preparedTargets) {
+    for (const { target, skillDir, canonicalSkillDir } of preparedTargets) {
       await mkdir(target.rootDir, { recursive: true })
       const tempDir = await mkdtemp(join(target.rootDir, `.${options.slug}.install-`))
       try {
@@ -128,7 +129,7 @@ export async function installSkill(options: InstallOptions): Promise<InstallResu
           agent: target.agent,
           installedAt
         }, null, 2))
-        staged.push({ target, skillDir, tempDir, installedAt, backupDir: null, movedIntoPlace: false })
+        staged.push({ target, skillDir, canonicalSkillDir, tempDir, installedAt, backupDir: null, movedIntoPlace: false })
       } catch (error) {
         await rm(tempDir, { recursive: true, force: true }).catch(() => {})
         throw error
@@ -144,7 +145,7 @@ export async function installSkill(options: InstallOptions): Promise<InstallResu
       }
 
       const lockedInventory = await store.read()
-      assertNoPartialVersionChange(lockedInventory, staged, {
+      await assertNoPartialVersionChange(lockedInventory, staged, {
         registry: options.registry,
         namespace: options.namespace,
         slug: options.slug
@@ -168,7 +169,7 @@ export async function installSkill(options: InstallOptions): Promise<InstallResu
           const backupDir = `${item.skillDir}.skillhub-backup-${process.pid}-${Date.now()}`
           await rename(item.skillDir, backupDir)
           item.backupDir = backupDir
-          await assertReplaceableInstallation(item.backupDir, item.skillDir, {
+          await assertReplaceableInstallation(item.backupDir, item.skillDir, item.canonicalSkillDir, {
             registry: options.registry,
             namespace: options.namespace,
             slug: options.slug
@@ -191,6 +192,10 @@ export async function installSkill(options: InstallOptions): Promise<InstallResu
       }
 
       try {
+        const replacedInstallDirs = await findEquivalentInventoryInstallDirs(
+          lockedInventory,
+          new Set(staged.map(item => item.canonicalSkillDir))
+        )
         await store.replaceTargetsAtInstallDirs(
           options.registry,
           options.namespace,
@@ -202,7 +207,8 @@ export async function installSkill(options: InstallOptions): Promise<InstallResu
             installDir: item.skillDir,
             installedAt: item.installedAt
           })),
-          resolved.fingerprint
+          resolved.fingerprint,
+          replacedInstallDirs
         )
       } catch (error) {
         if (error instanceof InventoryVersionConflictError) {
@@ -281,17 +287,20 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function assertNoPartialVersionChange(
+async function assertNoPartialVersionChange(
   inventory: Inventory,
   staged: StagedInstall[],
   identity: InstalledSkillIdentity,
   resolved: ResolveResponse
-): void {
+): Promise<void> {
   const item = inventory.items.find(candidate => sameInstalledSkillSource(candidate, identity))
   if (!item) return
 
-  const selectedInstallDirs = new Set(staged.map(candidate => candidate.skillDir))
-  const retainedTargets = item.targets.filter(target => !selectedInstallDirs.has(target.installDir))
+  const selectedInstallDirs = new Set(staged.map(candidate => candidate.canonicalSkillDir))
+  const retainedTargets: typeof item.targets = []
+  for (const target of item.targets) {
+    if (!selectedInstallDirs.has(await canonicalInventoryInstallDir(target))) retainedTargets.push(target)
+  }
   if (retainedTargets.length === 0) return
   if (item.version === resolved.version && item.fingerprint === resolved.fingerprint) return
 
@@ -305,6 +314,7 @@ function assertNoPartialVersionChange(
 async function assertReplaceableInstallation(
   metadataDir: string,
   inventoryInstallDir: string,
+  canonicalInstallDir: string,
   identity: InstalledSkillIdentity,
   inventory: Inventory
 ): Promise<void> {
@@ -317,8 +327,15 @@ async function assertReplaceableInstallation(
     })
   }
 
-  const inventoryOwners = inventory.items.filter(item =>
-    item.targets.some(existing => existing.installDir === inventoryInstallDir))
+  const inventoryOwners: Inventory['items'] = []
+  for (const item of inventory.items) {
+    for (const target of item.targets) {
+      if (await canonicalInventoryInstallDir(target) === canonicalInstallDir) {
+        inventoryOwners.push(item)
+        break
+      }
+    }
+  }
   if (!sameInstalledSkillSource(metadataResult.metadata, identity) ||
       inventoryOwners.some(owner => !sameInstalledSkillSource(owner, identity))) {
     throw new CliError(`source conflict at ${inventoryInstallDir}`, EXIT.filesystem, {
@@ -332,4 +349,25 @@ async function assertReplaceableInstallation(
       next: 'choose another target directory or remove the conflicting skill explicitly'
     })
   }
+}
+
+async function findEquivalentInventoryInstallDirs(
+  inventory: Inventory,
+  canonicalInstallDirs: Set<string>
+): Promise<string[]> {
+  const matches: string[] = []
+  for (const item of inventory.items) {
+    for (const target of item.targets) {
+      if (canonicalInstallDirs.has(await canonicalInventoryInstallDir(target))) {
+        matches.push(target.installDir)
+      }
+    }
+  }
+  return matches
+}
+
+async function canonicalInventoryInstallDir(target: { rootDir: string; installDir: string }): Promise<string> {
+  const resolvedRoot = resolve(target.rootDir)
+  const canonicalRoot = await canonicalizeExistingPath(resolvedRoot)
+  return resolve(canonicalRoot, relative(resolvedRoot, resolve(target.installDir)))
 }

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -59,7 +59,8 @@ async function preflightInstallTargets(
   const preparedTargets: Array<{ target: AgentCandidate; skillDir: string }> = []
 
   for (const target of targets) {
-    const canonicalRootDir = await canonicalizeExistingPath(resolve(target.rootDir))
+    const rootDir = resolve(target.rootDir)
+    const canonicalRootDir = await canonicalizeExistingPath(rootDir)
     const canonicalSkillDir = join(canonicalRootDir, identity.slug)
     if (seenSkillDirs.has(canonicalSkillDir)) {
       throw new CliError(`multiple install targets resolve to ${canonicalSkillDir}`, EXIT.usage, {
@@ -69,8 +70,10 @@ async function preflightInstallTargets(
     }
     seenSkillDirs.add(canonicalSkillDir)
 
-    const canonicalTarget = { ...target, rootDir: canonicalRootDir }
-    const skillDir = canonicalSkillDir
+    // Use the canonical path only as an internal identity. Persist the resolved
+    // user path so macOS aliases and Windows short names remain stable in CLI output.
+    const resolvedTarget = { ...target, rootDir }
+    const skillDir = join(rootDir, identity.slug)
     const exists = await pathExists(skillDir)
     if (exists && !force) {
       throw new CliError(`skill already installed at ${skillDir}`, EXIT.filesystem, {
@@ -81,7 +84,7 @@ async function preflightInstallTargets(
     if (exists) {
       await assertReplaceableInstallation(skillDir, skillDir, identity, inventory)
     }
-    preparedTargets.push({ target: canonicalTarget, skillDir })
+    preparedTargets.push({ target: resolvedTarget, skillDir })
   }
 
   return preparedTargets

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -29,6 +29,15 @@ export interface InstallOptions {
   resolved?: ResolveResponse | undefined
 }
 
+interface StagedInstall {
+  target: AgentCandidate
+  skillDir: string
+  tempDir: string
+  installedAt: string
+  backupDir: string | null
+  movedIntoPlace: boolean
+}
+
 async function preflightInstallTargets(
   targets: AgentCandidate[],
   identity: InstalledSkillIdentity,
@@ -79,97 +88,130 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
   const response = await client.download(options.namespace, options.slug, resolved.version)
   const buffer = await readBoundedResponseBody(response)
 
-  const installed: Array<{ agent: string; dir: string }> = []
-  for (const { target, skillDir } of preparedTargets) {
-    await mkdir(target.rootDir, { recursive: true })
-    const tempDir = await mkdtemp(join(target.rootDir, `.${options.slug}.install-`))
-    let movedIntoPlace = false
-
-    try {
-      await extractZip(buffer, tempDir)
-
-      const installedAt = new Date().toISOString()
-      const snapshot = await snapshotSkillDirectory(tempDir)
-      const metaDir = join(tempDir, '.skillhub')
-      await mkdir(metaDir, { recursive: true })
-      await writeFile(join(metaDir, 'metadata.json'), JSON.stringify({
-        schemaVersion: 1,
-        registry: options.registry,
-        namespace: options.namespace,
-        slug: options.slug,
-        version: resolved.version,
-        versionId: resolved.versionId,
-        fingerprint: resolved.fingerprint,
-        files: snapshot.files,
-        source: 'skillhub',
-        agent: target.agent,
-        installedAt
-      }, null, 2))
-
-      if (await pathExists(skillDir) && !options.force) {
-        throw new CliError(`skill already installed at ${skillDir}`, EXIT.filesystem, {
-          path: skillDir,
-          next: 'pass --force to overwrite'
-        })
-      }
-
-      const backupDir = `${skillDir}.skillhub-backup-${process.pid}-${Date.now()}`
-      let backupCreated = false
-      const releaseInstallLock = await acquireInstallTargetLock(target.rootDir, options.slug)
+  const staged: StagedInstall[] = []
+  try {
+    for (const { target, skillDir } of preparedTargets) {
+      await mkdir(target.rootDir, { recursive: true })
+      const tempDir = await mkdtemp(join(target.rootDir, `.${options.slug}.install-`))
       try {
-        if (await pathExists(skillDir)) {
-          if (!options.force) {
-            throw new CliError(`skill already installed at ${skillDir}`, EXIT.filesystem, {
-              path: skillDir,
-              next: 'pass --force to overwrite'
-            })
-          }
-          await rename(skillDir, backupDir)
-          backupCreated = true
-          await assertReplaceableInstallation(
-            backupDir,
-            skillDir,
-            { registry: options.registry, namespace: options.namespace, slug: options.slug },
-            await store.read()
-          )
-        }
-        await rename(tempDir, skillDir)
-        movedIntoPlace = true
+        await extractZip(buffer, tempDir)
 
-        await store.replaceTargetAtInstallDir(options.registry, options.namespace, options.slug, resolved.version, {
+        const installedAt = new Date().toISOString()
+        const snapshot = await snapshotSkillDirectory(tempDir)
+        const metaDir = join(tempDir, '.skillhub')
+        await mkdir(metaDir, { recursive: true })
+        await writeFile(join(metaDir, 'metadata.json'), JSON.stringify({
+          schemaVersion: 1,
+          registry: options.registry,
+          namespace: options.namespace,
+          slug: options.slug,
+          version: resolved.version,
+          versionId: resolved.versionId,
+          fingerprint: resolved.fingerprint,
+          files: snapshot.files,
+          source: 'skillhub',
           agent: target.agent,
-          rootDir: target.rootDir,
-          installDir: skillDir,
           installedAt
-        }, resolved.fingerprint)
-
-        if (backupCreated) await rm(backupDir, { recursive: true, force: true }).catch(() => {})
+        }, null, 2))
+        staged.push({ target, skillDir, tempDir, installedAt, backupDir: null, movedIntoPlace: false })
       } catch (error) {
-        if (movedIntoPlace) {
-          await rm(skillDir, { recursive: true, force: true }).catch(() => {})
-          movedIntoPlace = false
-        }
-        if (backupCreated) await rename(backupDir, skillDir).catch(() => {})
-        if (!options.force && await pathExists(skillDir)) {
-          throw new CliError(`skill already installed at ${skillDir}`, EXIT.filesystem, {
-            path: skillDir,
-            next: 'pass --force to overwrite'
-          })
-        }
-        throw error
-      } finally {
-        await releaseInstallLock()
-      }
-    } finally {
-      if (!movedIntoPlace) {
         await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+        throw error
       }
     }
 
-    installed.push({ agent: target.agent, dir: skillDir })
-  }
+    const releases: Array<() => Promise<void>> = []
+    try {
+      for (const item of [...staged].sort((left, right) => left.skillDir.localeCompare(right.skillDir))) {
+        releases.push(await acquireInstallTargetLock(item.target.rootDir, options.slug))
+      }
 
-  return { installed }
+      const lockedInventory = await store.read()
+      assertNoPartialVersionChange(lockedInventory, staged, {
+        registry: options.registry,
+        namespace: options.namespace,
+        slug: options.slug
+      }, resolved)
+
+      for (const item of staged) {
+        if (await pathExists(item.skillDir)) {
+          if (!options.force) {
+            throw new CliError(`skill already installed at ${item.skillDir}`, EXIT.filesystem, {
+              path: item.skillDir,
+              next: 'pass --force to overwrite'
+            })
+          }
+          item.backupDir = `${item.skillDir}.skillhub-backup-${process.pid}-${Date.now()}`
+          await rename(item.skillDir, item.backupDir)
+          await assertReplaceableInstallation(item.backupDir, item.skillDir, {
+            registry: options.registry,
+            namespace: options.namespace,
+            slug: options.slug
+          }, lockedInventory)
+        }
+        await rename(item.tempDir, item.skillDir)
+        item.movedIntoPlace = true
+      }
+
+      await store.replaceTargetsAtInstallDirs(
+        options.registry,
+        options.namespace,
+        options.slug,
+        resolved.version,
+        staged.map(item => ({
+          agent: item.target.agent,
+          rootDir: item.target.rootDir,
+          installDir: item.skillDir,
+          installedAt: item.installedAt
+        })),
+        resolved.fingerprint
+      )
+
+      for (const item of staged) {
+        if (item.backupDir) await rm(item.backupDir, { recursive: true, force: true }).catch(() => {})
+      }
+    } catch (error) {
+      for (const item of [...staged].reverse()) {
+        if (item.movedIntoPlace) {
+          await rm(item.skillDir, { recursive: true, force: true }).catch(() => {})
+          item.movedIntoPlace = false
+        }
+        if (item.backupDir) await rename(item.backupDir, item.skillDir).catch(() => {})
+      }
+      throw error
+    } finally {
+      for (const release of releases.reverse()) await release()
+    }
+
+    return {
+      installed: staged.map(item => ({ agent: item.target.agent, dir: item.skillDir }))
+    }
+  } finally {
+    for (const item of staged) {
+      if (!item.movedIntoPlace) await rm(item.tempDir, { recursive: true, force: true }).catch(() => {})
+    }
+  }
+}
+
+function assertNoPartialVersionChange(
+  inventory: Inventory,
+  staged: StagedInstall[],
+  identity: InstalledSkillIdentity,
+  resolved: ResolveResponse
+): void {
+  const item = inventory.items.find(candidate => sameInstalledSkillSource(candidate, identity))
+  if (!item) return
+
+  const selectedInstallDirs = new Set(staged.map(candidate => candidate.skillDir))
+  const retainedTargets = item.targets.filter(target => !selectedInstallDirs.has(target.installDir))
+  if (retainedTargets.length === 0) return
+  if (item.version === resolved.version && item.fingerprint === resolved.fingerprint) return
+
+  throw new CliError('partial-target install would create inconsistent versions', EXIT.validation, {
+    coordinate: `@${identity.namespace}/${identity.slug}`,
+    retainedTargets: retainedTargets.map(target => ({ agent: target.agent, dir: target.installDir })),
+    next: 'select all installed targets for the upgrade'
+  })
 }
 
 async function assertReplaceableInstallation(
@@ -209,8 +251,14 @@ async function acquireInstallTargetLock(rootDir: string, slug: string): Promise<
 
   const createLock = async () => {
     const handle = await open(lockPath, 'wx')
-    await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }))
-    return handle
+    try {
+      await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }))
+      return handle
+    } catch (error) {
+      await handle.close().catch(() => {})
+      await rm(lockPath, { force: true }).catch(() => {})
+      throw error
+    }
   }
 
   let handle: Awaited<ReturnType<typeof open>>

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { SkillHubClient } from '../clients/skillhub-client'
 import { InventoryStore, InventoryVersionConflictError } from '../stores/inventory-store'
@@ -16,6 +16,7 @@ import {
 import type { AgentCandidate } from '../agents/types'
 import type { ResolveResponse } from '../clients/skillhub-client'
 import type { Inventory } from '../stores/inventory-store'
+import { acquireSkillTargetLock } from './skill-target-lock'
 
 export interface InstallOptions {
   registry: string
@@ -127,7 +128,7 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
     const releases: Array<() => Promise<void>> = []
     try {
       for (const item of [...staged].sort((left, right) => left.skillDir.localeCompare(right.skillDir))) {
-        releases.push(await acquireInstallTargetLock(item.target.rootDir, options.slug))
+        releases.push(await acquireSkillTargetLock(item.target.rootDir, options.slug))
       }
 
       const lockedInventory = await store.read()
@@ -311,53 +312,5 @@ async function assertReplaceableInstallation(
       },
       next: 'choose another target directory or remove the conflicting skill explicitly'
     })
-  }
-}
-
-async function acquireInstallTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
-  const lockPath = join(rootDir, `.${slug}.skillhub-install.lock`)
-
-  const createLock = async () => {
-    const handle = await open(lockPath, 'wx')
-    try {
-      await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }))
-      return handle
-    } catch (error) {
-      await handle.close().catch(() => {})
-      await rm(lockPath, { force: true }).catch(() => {})
-      throw error
-    }
-  }
-
-  let handle: Awaited<ReturnType<typeof open>>
-  try {
-    handle = await createLock()
-  } catch (error) {
-    if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error
-
-    let ownerIsRunning = true
-    try {
-      const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { pid?: unknown }
-      if (typeof lock.pid !== 'number') throw new Error('invalid install lock')
-      process.kill(lock.pid, 0)
-    } catch (lockError) {
-      if (lockError instanceof Error && 'code' in lockError && lockError.code === 'ESRCH') {
-        ownerIsRunning = false
-      }
-    }
-
-    if (ownerIsRunning) {
-      throw new CliError(`install target is busy: ${join(rootDir, slug)}`, EXIT.filesystem, {
-        path: join(rootDir, slug),
-        next: 'wait for the other SkillHub CLI process to finish and retry'
-      })
-    }
-    await rm(lockPath, { force: true })
-    handle = await createLock()
-  }
-
-  return async () => {
-    await handle.close().catch(() => {})
-    await rm(lockPath, { force: true }).catch(() => {})
   }
 }

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -31,6 +31,13 @@ export interface InstallOptions {
   expectedTargetFiles?: Record<string, Record<string, string>> | undefined
   allowTargetDrift?: boolean | undefined
   requireExistingTargets?: boolean | undefined
+  /** Internal test seam for lock lifecycle failures; production uses acquireSkillTargetLock. */
+  acquireTargetLock?: typeof acquireSkillTargetLock
+}
+
+export interface InstallResult {
+  installed: Array<{ agent: string; dir: string }>
+  warnings?: string[]
 }
 
 interface StagedInstall {
@@ -80,7 +87,7 @@ async function preflightInstallTargets(
   return preparedTargets
 }
 
-export async function installSkill(options: InstallOptions): Promise<{ installed: Array<{ agent: string; dir: string }> }> {
+export async function installSkill(options: InstallOptions): Promise<InstallResult> {
   const store = new InventoryStore(options.home)
   const inventory = await store.read()
   const preparedTargets = await preflightInstallTargets(options.targets, {
@@ -126,9 +133,11 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
     }
 
     const releases: Array<() => Promise<void>> = []
+    const warnings: string[] = []
+    const acquireTargetLock = options.acquireTargetLock ?? acquireSkillTargetLock
     try {
       for (const item of [...staged].sort((left, right) => left.skillDir.localeCompare(right.skillDir))) {
-        releases.push(await acquireSkillTargetLock(item.target.rootDir, options.slug))
+        releases.push(await acquireTargetLock(item.target.rootDir, options.slug))
       }
 
       const lockedInventory = await store.read()
@@ -245,11 +254,18 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
       }
       throw error
     } finally {
-      for (const release of releases.reverse()) await release()
+      for (const release of releases.reverse()) {
+        try {
+          await release()
+        } catch (error) {
+          warnings.push(`target lock cleanup failed: ${describeError(error)}`)
+        }
+      }
     }
 
     return {
-      installed: staged.map(item => ({ agent: item.target.agent, dir: item.skillDir }))
+      installed: staged.map(item => ({ agent: item.target.agent, dir: item.skillDir })),
+      warnings
     }
   } finally {
     for (const item of staged) {

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -29,6 +29,7 @@ export interface InstallOptions {
   resolved?: ResolveResponse | undefined
   expectedTargetFiles?: Record<string, Record<string, string>> | undefined
   allowTargetDrift?: boolean | undefined
+  requireExistingTargets?: boolean | undefined
 }
 
 interface StagedInstall {
@@ -137,15 +138,23 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
       }, resolved)
 
       for (const item of staged) {
-        if (await pathExists(item.skillDir)) {
+        const targetExists = await pathExists(item.skillDir)
+        if (!targetExists && options.requireExistingTargets) {
+          throw new CliError(`installed target disappeared before upgrade commit: ${item.skillDir}`, EXIT.validation, {
+            path: item.skillDir,
+            next: 'reinstall the Skill explicitly before upgrading it'
+          })
+        }
+        if (targetExists) {
           if (!options.force) {
             throw new CliError(`skill already installed at ${item.skillDir}`, EXIT.filesystem, {
               path: item.skillDir,
               next: 'pass --force to overwrite'
             })
           }
-          item.backupDir = `${item.skillDir}.skillhub-backup-${process.pid}-${Date.now()}`
-          await rename(item.skillDir, item.backupDir)
+          const backupDir = `${item.skillDir}.skillhub-backup-${process.pid}-${Date.now()}`
+          await rename(item.skillDir, backupDir)
+          item.backupDir = backupDir
           await assertReplaceableInstallation(item.backupDir, item.skillDir, {
             registry: options.registry,
             namespace: options.namespace,

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { SkillHubClient } from '../clients/skillhub-client'
 import { InventoryStore } from '../stores/inventory-store'
@@ -58,30 +58,7 @@ async function preflightInstallTargets(
       })
     }
     if (exists) {
-      const metadataResult = await readInstalledSkillMetadata(skillDir)
-      const inventoryOwners = inventory.items.filter(item =>
-        item.targets.some(existing => existing.installDir === skillDir))
-
-      if (metadataResult.status !== 'valid') {
-        throw new CliError(`cannot verify SkillHub ownership of ${skillDir}`, EXIT.filesystem, {
-          path: skillDir,
-          reason: metadataResult.status === 'missing' ? 'installation metadata is missing' : metadataResult.reason,
-          next: 'move or remove the existing directory before installing'
-        })
-      }
-      if (!sameInstalledSkillSource(metadataResult.metadata, identity) ||
-          inventoryOwners.some(owner => !sameInstalledSkillSource(owner, identity))) {
-        throw new CliError(`source conflict at ${skillDir}`, EXIT.filesystem, {
-          path: skillDir,
-          expected: identity,
-          actual: {
-            registry: metadataResult.metadata.registry,
-            namespace: metadataResult.metadata.namespace,
-            slug: metadataResult.metadata.slug
-          },
-          next: 'choose another target directory or remove the conflicting skill explicitly'
-        })
-      }
+      await assertReplaceableInstallation(skillDir, skillDir, identity, inventory)
     }
     preparedTargets.push({ target, skillDir })
   }
@@ -138,10 +115,23 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
 
       const backupDir = `${skillDir}.skillhub-backup-${process.pid}-${Date.now()}`
       let backupCreated = false
+      const releaseInstallLock = await acquireInstallTargetLock(target.rootDir, options.slug)
       try {
         if (await pathExists(skillDir)) {
+          if (!options.force) {
+            throw new CliError(`skill already installed at ${skillDir}`, EXIT.filesystem, {
+              path: skillDir,
+              next: 'pass --force to overwrite'
+            })
+          }
           await rename(skillDir, backupDir)
           backupCreated = true
+          await assertReplaceableInstallation(
+            backupDir,
+            skillDir,
+            { registry: options.registry, namespace: options.namespace, slug: options.slug },
+            await store.read()
+          )
         }
         await rename(tempDir, skillDir)
         movedIntoPlace = true
@@ -167,6 +157,8 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
           })
         }
         throw error
+      } finally {
+        await releaseInstallLock()
       }
     } finally {
       if (!movedIntoPlace) {
@@ -178,4 +170,78 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
   }
 
   return { installed }
+}
+
+async function assertReplaceableInstallation(
+  metadataDir: string,
+  inventoryInstallDir: string,
+  identity: InstalledSkillIdentity,
+  inventory: Inventory
+): Promise<void> {
+  const metadataResult = await readInstalledSkillMetadata(metadataDir)
+  if (metadataResult.status !== 'valid') {
+    throw new CliError(`cannot verify SkillHub ownership of ${inventoryInstallDir}`, EXIT.filesystem, {
+      path: inventoryInstallDir,
+      reason: metadataResult.status === 'missing' ? 'installation metadata is missing' : metadataResult.reason,
+      next: 'move or remove the existing directory before installing'
+    })
+  }
+
+  const inventoryOwners = inventory.items.filter(item =>
+    item.targets.some(existing => existing.installDir === inventoryInstallDir))
+  if (!sameInstalledSkillSource(metadataResult.metadata, identity) ||
+      inventoryOwners.some(owner => !sameInstalledSkillSource(owner, identity))) {
+    throw new CliError(`source conflict at ${inventoryInstallDir}`, EXIT.filesystem, {
+      path: inventoryInstallDir,
+      expected: identity,
+      actual: {
+        registry: metadataResult.metadata.registry,
+        namespace: metadataResult.metadata.namespace,
+        slug: metadataResult.metadata.slug
+      },
+      next: 'choose another target directory or remove the conflicting skill explicitly'
+    })
+  }
+}
+
+async function acquireInstallTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
+  const lockPath = join(rootDir, `.${slug}.skillhub-install.lock`)
+
+  const createLock = async () => {
+    const handle = await open(lockPath, 'wx')
+    await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }))
+    return handle
+  }
+
+  let handle: Awaited<ReturnType<typeof open>>
+  try {
+    handle = await createLock()
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error
+
+    let ownerIsRunning = true
+    try {
+      const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { pid?: unknown }
+      if (typeof lock.pid !== 'number') throw new Error('invalid install lock')
+      process.kill(lock.pid, 0)
+    } catch (lockError) {
+      if (lockError instanceof Error && 'code' in lockError && lockError.code === 'ESRCH') {
+        ownerIsRunning = false
+      }
+    }
+
+    if (ownerIsRunning) {
+      throw new CliError(`install target is busy: ${join(rootDir, slug)}`, EXIT.filesystem, {
+        path: join(rootDir, slug),
+        next: 'wait for the other SkillHub CLI process to finish and retry'
+      })
+    }
+    await rm(lockPath, { force: true })
+    handle = await createLock()
+  }
+
+  return async () => {
+    await handle.close().catch(() => {})
+    await rm(lockPath, { force: true }).catch(() => {})
+  }
 }

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -1,13 +1,13 @@
 import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { SkillHubClient } from '../clients/skillhub-client'
-import { InventoryStore } from '../stores/inventory-store'
+import { InventoryStore, InventoryVersionConflictError } from '../stores/inventory-store'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 import { extractZip } from '../platform/archive'
 import { readBoundedResponseBody } from '../platform/download'
 import { canonicalizeExistingPath, pathExists } from '../platform/paths'
-import { snapshotSkillDirectory } from './skill-fingerprint'
+import { diffSkillFiles, snapshotSkillDirectory } from './skill-fingerprint'
 import {
   readInstalledSkillMetadata,
   sameInstalledSkillSource,
@@ -27,6 +27,8 @@ export interface InstallOptions {
   force: boolean
   home?: string | undefined
   resolved?: ResolveResponse | undefined
+  expectedTargetFiles?: Record<string, Record<string, string>> | undefined
+  allowTargetDrift?: boolean | undefined
 }
 
 interface StagedInstall {
@@ -48,7 +50,7 @@ async function preflightInstallTargets(
   const preparedTargets: Array<{ target: AgentCandidate; skillDir: string }> = []
 
   for (const target of targets) {
-    const canonicalRootDir = await canonicalizeExistingPath(target.rootDir)
+    const canonicalRootDir = await canonicalizeExistingPath(resolve(target.rootDir))
     const canonicalSkillDir = join(canonicalRootDir, identity.slug)
     if (seenSkillDirs.has(canonicalSkillDir)) {
       throw new CliError(`multiple install targets resolve to ${canonicalSkillDir}`, EXIT.usage, {
@@ -58,7 +60,8 @@ async function preflightInstallTargets(
     }
     seenSkillDirs.add(canonicalSkillDir)
 
-    const skillDir = join(target.rootDir, identity.slug)
+    const canonicalTarget = { ...target, rootDir: canonicalRootDir }
+    const skillDir = canonicalSkillDir
     const exists = await pathExists(skillDir)
     if (exists && !force) {
       throw new CliError(`skill already installed at ${skillDir}`, EXIT.filesystem, {
@@ -69,7 +72,7 @@ async function preflightInstallTargets(
     if (exists) {
       await assertReplaceableInstallation(skillDir, skillDir, identity, inventory)
     }
-    preparedTargets.push({ target, skillDir })
+    preparedTargets.push({ target: canonicalTarget, skillDir })
   }
 
   return preparedTargets
@@ -148,35 +151,86 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
             namespace: options.namespace,
             slug: options.slug
           }, lockedInventory)
+          const expectedFiles = options.expectedTargetFiles?.[item.skillDir]
+          if (expectedFiles && !options.allowTargetDrift) {
+            const currentSnapshot = await snapshotSkillDirectory(item.backupDir)
+            const changedFiles = diffSkillFiles(expectedFiles, currentSnapshot.files)
+            if (changedFiles.length > 0) {
+              throw new CliError(`local changes detected after upgrade planning at ${item.skillDir}`, EXIT.validation, {
+                path: item.skillDir,
+                changedFiles,
+                next: 'review the local changes and retry with --force only if replacement is intended'
+              })
+            }
+          }
         }
         await rename(item.tempDir, item.skillDir)
         item.movedIntoPlace = true
       }
 
-      await store.replaceTargetsAtInstallDirs(
-        options.registry,
-        options.namespace,
-        options.slug,
-        resolved.version,
-        staged.map(item => ({
-          agent: item.target.agent,
-          rootDir: item.target.rootDir,
-          installDir: item.skillDir,
-          installedAt: item.installedAt
-        })),
-        resolved.fingerprint
-      )
+      try {
+        await store.replaceTargetsAtInstallDirs(
+          options.registry,
+          options.namespace,
+          options.slug,
+          resolved.version,
+          staged.map(item => ({
+            agent: item.target.agent,
+            rootDir: item.target.rootDir,
+            installDir: item.skillDir,
+            installedAt: item.installedAt
+          })),
+          resolved.fingerprint
+        )
+      } catch (error) {
+        if (error instanceof InventoryVersionConflictError) {
+          throw new CliError(error.message, EXIT.validation, {
+            coordinate: `@${options.namespace}/${options.slug}`,
+            retainedTargets: error.retainedTargets.map(target => ({ agent: target.agent, dir: target.installDir })),
+            next: 'select all installed targets for the upgrade'
+          })
+        }
+        throw error
+      }
 
       for (const item of staged) {
         if (item.backupDir) await rm(item.backupDir, { recursive: true, force: true }).catch(() => {})
       }
     } catch (error) {
+      const rollbackFailures: Array<{ operation: string; path: string; error: string }> = []
       for (const item of [...staged].reverse()) {
         if (item.movedIntoPlace) {
-          await rm(item.skillDir, { recursive: true, force: true }).catch(() => {})
-          item.movedIntoPlace = false
+          try {
+            await rm(item.skillDir, { recursive: true, force: true })
+            item.movedIntoPlace = false
+          } catch (rollbackError) {
+            rollbackFailures.push({
+              operation: 'remove replacement',
+              path: item.skillDir,
+              error: describeError(rollbackError)
+            })
+          }
         }
-        if (item.backupDir) await rename(item.backupDir, item.skillDir).catch(() => {})
+        if (item.backupDir) {
+          try {
+            await rename(item.backupDir, item.skillDir)
+            item.backupDir = null
+          } catch (rollbackError) {
+            rollbackFailures.push({
+              operation: 'restore backup',
+              path: item.backupDir,
+              error: describeError(rollbackError)
+            })
+          }
+        }
+      }
+      if (rollbackFailures.length > 0) {
+        throw new CliError('installation failed and rollback was incomplete', EXIT.filesystem, {
+          originalError: describeError(error),
+          rollbackFailures,
+          retainedBackups: staged.flatMap(item => item.backupDir ? [item.backupDir] : []),
+          next: 'restore the retained backup directories before retrying'
+        })
       }
       throw error
     } finally {
@@ -191,6 +245,10 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
       if (!item.movedIntoPlace) await rm(item.tempDir, { recursive: true, force: true }).catch(() => {})
     }
   }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function assertNoPartialVersionChange(

--- a/cli/src/services/install-service.ts
+++ b/cli/src/services/install-service.ts
@@ -212,13 +212,14 @@ export async function installSkill(options: InstallOptions): Promise<{ installed
           }
         }
         if (item.backupDir) {
+          const backupDir = item.backupDir
           try {
-            await rename(item.backupDir, item.skillDir)
+            await rename(backupDir, item.skillDir)
             item.backupDir = null
           } catch (rollbackError) {
             rollbackFailures.push({
               operation: 'restore backup',
-              path: item.backupDir,
+              path: backupDir,
               error: describeError(rollbackError)
             })
           }

--- a/cli/src/services/installed-skill-metadata.ts
+++ b/cli/src/services/installed-skill-metadata.ts
@@ -37,6 +37,19 @@ export async function readInstalledSkillMetadata(skillDir: string): Promise<Inst
         return { status: 'invalid', reason: `metadata field "${field}" must be a non-empty string` }
       }
     }
+    if (value.source !== undefined && value.source !== 'skillhub') {
+      return { status: 'invalid', reason: 'metadata field "source" must be "skillhub"' }
+    }
+    if (value.schemaVersion !== undefined && value.schemaVersion !== 1) {
+      return { status: 'invalid', reason: 'metadata schema version is not supported' }
+    }
+    if (value.versionId !== undefined &&
+        (!Number.isInteger(value.versionId) || (value.versionId as number) <= 0)) {
+      return { status: 'invalid', reason: 'metadata field "versionId" must be a positive integer' }
+    }
+    if (value.fingerprint !== undefined && typeof value.fingerprint !== 'string') {
+      return { status: 'invalid', reason: 'metadata field "fingerprint" must be a string' }
+    }
     if (value.files !== undefined && !isStringRecord(value.files)) {
       return { status: 'invalid', reason: 'metadata field "files" must map paths to hashes' }
     }

--- a/cli/src/services/installed-skill-metadata.ts
+++ b/cli/src/services/installed-skill-metadata.ts
@@ -1,0 +1,69 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { pathExists } from '../platform/paths'
+
+export interface InstalledSkillIdentity {
+  registry: string
+  namespace: string
+  slug: string
+}
+
+export interface InstalledSkillMetadata extends InstalledSkillIdentity {
+  schemaVersion?: number
+  version: string
+  versionId?: number
+  fingerprint?: string
+  files?: Record<string, string>
+  source?: string
+  agent?: string
+  installedAt?: string
+}
+
+export type InstalledMetadataReadResult =
+  | { status: 'missing' }
+  | { status: 'invalid'; reason: string }
+  | { status: 'valid'; metadata: InstalledSkillMetadata }
+
+export async function readInstalledSkillMetadata(skillDir: string): Promise<InstalledMetadataReadResult> {
+  const metadataPath = join(skillDir, '.skillhub', 'metadata.json')
+  if (!(await pathExists(metadataPath))) return { status: 'missing' }
+
+  try {
+    const value = JSON.parse(await readFile(metadataPath, 'utf-8')) as unknown
+    if (!isRecord(value)) return { status: 'invalid', reason: 'metadata root must be an object' }
+
+    for (const field of ['registry', 'namespace', 'slug', 'version'] as const) {
+      if (typeof value[field] !== 'string' || value[field].length === 0) {
+        return { status: 'invalid', reason: `metadata field "${field}" must be a non-empty string` }
+      }
+    }
+    if (value.files !== undefined && !isStringRecord(value.files)) {
+      return { status: 'invalid', reason: 'metadata field "files" must map paths to hashes' }
+    }
+
+    return { status: 'valid', metadata: value as unknown as InstalledSkillMetadata }
+  } catch {
+    return { status: 'invalid', reason: 'metadata is not valid JSON' }
+  }
+}
+
+export function sameInstalledSkillSource(
+  left: InstalledSkillIdentity,
+  right: InstalledSkillIdentity
+): boolean {
+  return normalizeRegistry(left.registry) === normalizeRegistry(right.registry) &&
+    left.namespace === right.namespace &&
+    left.slug === right.slug
+}
+
+function normalizeRegistry(registry: string): string {
+  return registry.replace(/\/+$/, '')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every(entry => typeof entry === 'string')
+}

--- a/cli/src/services/remove-service.ts
+++ b/cli/src/services/remove-service.ts
@@ -3,6 +3,7 @@ import { relative, isAbsolute } from 'node:path'
 import { InventoryStore } from '../stores/inventory-store'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
+import { acquireSkillTargetLock } from './skill-target-lock'
 
 /**
  * Validate that child path is strictly under parent directory.
@@ -52,8 +53,9 @@ export async function removeLocalSkill(options: RemoveLocalOptions): Promise<Rem
   }
 
   const removed: RemoveResult['removed'] = []
+  const releases: Array<() => Promise<void>> = []
 
-  for (const { item, target } of targetsToRemove) {
+  for (const { target } of targetsToRemove) {
     // Validate installDir is strictly under the recorded rootDir
     if (!target.rootDir || !isPathUnder(target.installDir, target.rootDir)) {
       throw new CliError(`unsafe remove path: ${target.installDir} is not under ${target.rootDir ?? 'unknown root'}`, EXIT.filesystem, {
@@ -61,20 +63,31 @@ export async function removeLocalSkill(options: RemoveLocalOptions): Promise<Rem
         next: 'verify inventory integrity with `skillhub doctor`'
       })
     }
+  }
 
-    let existed = true
-    try {
-      await stat(target.installDir)
-    } catch {
-      existed = false
+  try {
+    for (const { target } of [...targetsToRemove]
+      .sort((left, right) => left.target.installDir.localeCompare(right.target.installDir))) {
+      releases.push(await acquireSkillTargetLock(target.rootDir, options.slug))
     }
 
-    if (existed) {
-      await rm(target.installDir, { recursive: true })
-    }
+    for (const { item, target } of targetsToRemove) {
+      let existed = true
+      try {
+        await stat(target.installDir)
+      } catch {
+        existed = false
+      }
 
-    await store.removeTarget(options.registry, item.namespace, options.slug, target.installDir)
-    removed.push({ namespace: item.namespace, agent: target.agent, dir: target.installDir, existed })
+      if (existed) {
+        await rm(target.installDir, { recursive: true })
+      }
+
+      await store.removeTarget(options.registry, item.namespace, options.slug, target.installDir)
+      removed.push({ namespace: item.namespace, agent: target.agent, dir: target.installDir, existed })
+    }
+  } finally {
+    for (const release of releases.reverse()) await release()
   }
 
   return { removed }

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -1,53 +1,94 @@
-import { open, readFile, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
+import { open, readFile, rename, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { ensureDir } from '../platform/paths'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 
 /** Serializes every local lifecycle mutation for one Skill target directory. */
 export async function acquireSkillTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
-  const lockPath = join(rootDir, `.${slug}.skillhub-install.lock`)
+  const lockPath = await skillTargetLockPath(rootDir, slug)
+  const ownershipToken = randomUUID()
 
   const createLock = async () => {
     const handle = await open(lockPath, 'wx')
     try {
-      await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }))
+      await handle.writeFile(JSON.stringify({
+        pid: process.pid,
+        ownershipToken,
+        createdAt: new Date().toISOString()
+      }))
       return handle
     } catch (error) {
       await handle.close().catch(() => {})
-      await rm(lockPath, { force: true }).catch(() => {})
+      await removeOwnedLock(lockPath, ownershipToken)
       throw error
     }
   }
 
-  let handle: Awaited<ReturnType<typeof open>>
-  try {
-    handle = await createLock()
-  } catch (error) {
-    if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error
-
-    let ownerIsRunning = true
+  let handle: Awaited<ReturnType<typeof open>> | null = null
+  for (let attempt = 0; attempt < 3 && !handle; attempt++) {
     try {
-      const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { pid?: unknown }
-      if (typeof lock.pid !== 'number') throw new Error('invalid Skill target lock')
-      process.kill(lock.pid, 0)
-    } catch (lockError) {
-      if (lockError instanceof Error && 'code' in lockError && lockError.code === 'ESRCH') {
-        ownerIsRunning = false
-      }
-    }
+      handle = await createLock()
+      break
+    } catch (error) {
+      if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error
 
-    if (ownerIsRunning) {
-      throw new CliError(`install target is busy: ${join(rootDir, slug)}`, EXIT.filesystem, {
-        path: join(rootDir, slug),
-        next: 'wait for the other SkillHub CLI process to finish and retry'
-      })
+      let ownerIsRunning = true
+      try {
+        const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { pid?: unknown }
+        if (typeof lock.pid !== 'number') throw new Error('invalid Skill target lock')
+        process.kill(lock.pid, 0)
+      } catch (lockError) {
+        if (lockError instanceof Error && 'code' in lockError && lockError.code === 'ESRCH') {
+          ownerIsRunning = false
+        }
+      }
+
+      if (ownerIsRunning) throw targetBusyError(rootDir, slug)
+
+      const quarantinedPath = `${lockPath}.stale-${ownershipToken}`
+      try {
+        await rename(lockPath, quarantinedPath)
+      } catch (reclaimError) {
+        if (reclaimError instanceof Error && 'code' in reclaimError && reclaimError.code === 'ENOENT') continue
+        throw reclaimError
+      }
+      await rm(quarantinedPath, { force: true }).catch(() => {})
     }
-    await rm(lockPath, { force: true })
-    handle = await createLock()
   }
+  if (!handle) throw targetBusyError(rootDir, slug)
+  const ownedHandle = handle
 
   return async () => {
-    await handle.close().catch(() => {})
-    await rm(lockPath, { force: true }).catch(() => {})
+    await ownedHandle.close().catch(() => {})
+    await removeOwnedLock(lockPath, ownershipToken)
+  }
+}
+
+export async function skillTargetLockPath(rootDir: string, slug: string): Promise<string> {
+  const target = resolve(rootDir, slug)
+  const digest = createHash('sha256').update(target).digest('hex')
+  const uid = typeof process.getuid === 'function' ? process.getuid() : 'user'
+  const lockDir = join(tmpdir(), `skillhub-cli-target-locks-${uid}`)
+  await ensureDir(lockDir)
+  return join(lockDir, `${digest}.lock`)
+}
+
+function targetBusyError(rootDir: string, slug: string): CliError {
+  return new CliError(`install target is busy: ${join(rootDir, slug)}`, EXIT.filesystem, {
+    path: join(rootDir, slug),
+    next: 'wait for the other SkillHub CLI process to finish and retry'
+  })
+}
+
+async function removeOwnedLock(lockPath: string, ownershipToken: string): Promise<void> {
+  try {
+    const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { ownershipToken?: unknown }
+    if (lock.ownershipToken !== ownershipToken) return
+    await rm(lockPath, { force: true })
+  } catch {
+    // Missing or replaced locks are no longer owned by this caller.
   }
 }

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -36,7 +36,27 @@ export async function skillTargetLockPath(rootDir: string, slug: string): Promis
   return join(lockDir, `${digest}.lock`)
 }
 
-async function ensurePrivateLockDir(lockDir: string): Promise<void> {
+interface LockDirectoryDetails {
+  isDirectory(): boolean
+  isSymbolicLink(): boolean
+  uid: number
+  mode: number
+}
+
+export function assertPrivateLockDir(
+  lockDir: string,
+  details: LockDirectoryDetails,
+  currentUid: number | null
+): void {
+  if (!details.isDirectory() || details.isSymbolicLink()) {
+    throw new Error(`unsafe SkillHub CLI lock directory: ${lockDir}`)
+  }
+  if (currentUid !== null && details.uid !== currentUid) {
+    throw new Error(`SkillHub CLI lock directory is owned by another user: ${lockDir}`)
+  }
+}
+
+export async function ensurePrivateLockDir(lockDir: string): Promise<void> {
   try {
     await mkdir(lockDir, { mode: 0o700 })
   } catch (error) {
@@ -44,12 +64,8 @@ async function ensurePrivateLockDir(lockDir: string): Promise<void> {
   }
 
   const details = await lstat(lockDir)
-  if (!details.isDirectory() || details.isSymbolicLink()) {
-    throw new Error(`unsafe SkillHub CLI lock directory: ${lockDir}`)
-  }
-  if (typeof process.getuid === 'function' && details.uid !== process.getuid()) {
-    throw new Error(`SkillHub CLI lock directory is owned by another user: ${lockDir}`)
-  }
+  const currentUid = typeof process.getuid === 'function' ? process.getuid() : null
+  assertPrivateLockDir(lockDir, details, currentUid)
   if (process.platform !== 'win32' && (details.mode & 0o077) !== 0) {
     await chmod(lockDir, 0o700)
   }

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -1,7 +1,7 @@
-import { createHash, randomUUID } from 'node:crypto'
-import { open, readFile, rename, rm } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { lock } from 'proper-lockfile'
 import { ensureDir } from '../platform/paths'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
@@ -9,61 +9,19 @@ import { EXIT } from '../shared/constants'
 /** Serializes every local lifecycle mutation for one Skill target directory. */
 export async function acquireSkillTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
   const lockPath = await skillTargetLockPath(rootDir, slug)
-  const ownershipToken = randomUUID()
-
-  const createLock = async () => {
-    const handle = await open(lockPath, 'wx')
-    try {
-      await handle.writeFile(JSON.stringify({
-        pid: process.pid,
-        ownershipToken,
-        createdAt: new Date().toISOString()
-      }))
-      return handle
-    } catch (error) {
-      await handle.close().catch(() => {})
-      await removeOwnedLock(lockPath, ownershipToken)
-      throw error
+  try {
+    return await lock(lockPath, {
+      lockfilePath: lockPath,
+      realpath: false,
+      stale: 10_000,
+      update: 3_000,
+      retries: 0
+    })
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ELOCKED') {
+      throw targetBusyError(rootDir, slug)
     }
-  }
-
-  let handle: Awaited<ReturnType<typeof open>> | null = null
-  for (let attempt = 0; attempt < 3 && !handle; attempt++) {
-    try {
-      handle = await createLock()
-      break
-    } catch (error) {
-      if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error
-
-      let ownerIsRunning = true
-      try {
-        const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { pid?: unknown }
-        if (typeof lock.pid !== 'number') throw new Error('invalid Skill target lock')
-        process.kill(lock.pid, 0)
-      } catch (lockError) {
-        if (lockError instanceof Error && 'code' in lockError && lockError.code === 'ESRCH') {
-          ownerIsRunning = false
-        }
-      }
-
-      if (ownerIsRunning) throw targetBusyError(rootDir, slug)
-
-      const quarantinedPath = `${lockPath}.stale-${ownershipToken}`
-      try {
-        await rename(lockPath, quarantinedPath)
-      } catch (reclaimError) {
-        if (reclaimError instanceof Error && 'code' in reclaimError && reclaimError.code === 'ENOENT') continue
-        throw reclaimError
-      }
-      await rm(quarantinedPath, { force: true }).catch(() => {})
-    }
-  }
-  if (!handle) throw targetBusyError(rootDir, slug)
-  const ownedHandle = handle
-
-  return async () => {
-    await ownedHandle.close().catch(() => {})
-    await removeOwnedLock(lockPath, ownershipToken)
+    throw error
   }
 }
 
@@ -81,14 +39,4 @@ function targetBusyError(rootDir: string, slug: string): CliError {
     path: join(rootDir, slug),
     next: 'wait for the other SkillHub CLI process to finish and retry'
   })
-}
-
-async function removeOwnedLock(lockPath: string, ownershipToken: string): Promise<void> {
-  try {
-    const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { ownershipToken?: unknown }
-    if (lock.ownershipToken !== ownershipToken) return
-    await rm(lockPath, { force: true })
-  } catch {
-    // Missing or replaced locks are no longer owned by this caller.
-  }
 }

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -28,7 +28,7 @@ export async function acquireSkillTargetLock(rootDir: string, slug: string): Pro
 
 export async function skillTargetLockPath(rootDir: string, slug: string): Promise<string> {
   const canonicalRoot = await canonicalizeExistingPath(resolve(rootDir))
-  const target = await canonicalizeExistingPath(resolve(canonicalRoot, slug))
+  const target = resolve(canonicalRoot, slug)
   const digest = createHash('sha256').update(target).digest('hex')
   const uid = typeof process.getuid === 'function' ? process.getuid() : 'user'
   const lockDir = join(tmpdir(), `skillhub-cli-target-locks-${uid}`)

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -1,0 +1,53 @@
+import { open, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { CliError } from '../shared/errors'
+import { EXIT } from '../shared/constants'
+
+/** Serializes every local lifecycle mutation for one Skill target directory. */
+export async function acquireSkillTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
+  const lockPath = join(rootDir, `.${slug}.skillhub-install.lock`)
+
+  const createLock = async () => {
+    const handle = await open(lockPath, 'wx')
+    try {
+      await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }))
+      return handle
+    } catch (error) {
+      await handle.close().catch(() => {})
+      await rm(lockPath, { force: true }).catch(() => {})
+      throw error
+    }
+  }
+
+  let handle: Awaited<ReturnType<typeof open>>
+  try {
+    handle = await createLock()
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error
+
+    let ownerIsRunning = true
+    try {
+      const lock = JSON.parse(await readFile(lockPath, 'utf-8')) as { pid?: unknown }
+      if (typeof lock.pid !== 'number') throw new Error('invalid Skill target lock')
+      process.kill(lock.pid, 0)
+    } catch (lockError) {
+      if (lockError instanceof Error && 'code' in lockError && lockError.code === 'ESRCH') {
+        ownerIsRunning = false
+      }
+    }
+
+    if (ownerIsRunning) {
+      throw new CliError(`install target is busy: ${join(rootDir, slug)}`, EXIT.filesystem, {
+        path: join(rootDir, slug),
+        next: 'wait for the other SkillHub CLI process to finish and retry'
+      })
+    }
+    await rm(lockPath, { force: true })
+    handle = await createLock()
+  }
+
+  return async () => {
+    await handle.close().catch(() => {})
+    await rm(lockPath, { force: true }).catch(() => {})
+  }
+}

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'node:crypto'
+import { chmod, lstat, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { lock } from 'proper-lockfile'
-import { ensureDir } from '../platform/paths'
+import { canonicalizeExistingPath } from '../platform/paths'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 
@@ -26,12 +27,32 @@ export async function acquireSkillTargetLock(rootDir: string, slug: string): Pro
 }
 
 export async function skillTargetLockPath(rootDir: string, slug: string): Promise<string> {
-  const target = resolve(rootDir, slug)
+  const canonicalRoot = await canonicalizeExistingPath(resolve(rootDir))
+  const target = await canonicalizeExistingPath(resolve(canonicalRoot, slug))
   const digest = createHash('sha256').update(target).digest('hex')
   const uid = typeof process.getuid === 'function' ? process.getuid() : 'user'
   const lockDir = join(tmpdir(), `skillhub-cli-target-locks-${uid}`)
-  await ensureDir(lockDir)
+  await ensurePrivateLockDir(lockDir)
   return join(lockDir, `${digest}.lock`)
+}
+
+async function ensurePrivateLockDir(lockDir: string): Promise<void> {
+  try {
+    await mkdir(lockDir, { mode: 0o700 })
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error
+  }
+
+  const details = await lstat(lockDir)
+  if (!details.isDirectory() || details.isSymbolicLink()) {
+    throw new Error(`unsafe SkillHub CLI lock directory: ${lockDir}`)
+  }
+  if (typeof process.getuid === 'function' && details.uid !== process.getuid()) {
+    throw new Error(`SkillHub CLI lock directory is owned by another user: ${lockDir}`)
+  }
+  if (process.platform !== 'win32' && (details.mode & 0o077) !== 0) {
+    await chmod(lockDir, 0o700)
+  }
 }
 
 function targetBusyError(rootDir: string, slug: string): CliError {

--- a/cli/src/services/sync-service.ts
+++ b/cli/src/services/sync-service.ts
@@ -36,6 +36,7 @@ export interface PullResult {
   entries: SyncStatusEntry[]
   actions: Array<{ slug: string; action: 'installed' | 'updated' | 'pruned' }>
   failures: Array<{ slug: string; message: string }>
+  warnings: Array<{ slug: string; message: string }>
 }
 
 export interface PushResultItem {
@@ -133,6 +134,7 @@ export async function pullNamespace(options: {
   check: boolean
   prune: boolean
   force: boolean
+  installSkillFn?: typeof installSkill
 }): Promise<PullResult> {
   const inspected = await inspectNamespaceWorkspace(options)
   const result: PullResult = {
@@ -140,7 +142,8 @@ export async function pullNamespace(options: {
     rootDir: options.rootDir,
     entries: inspected.entries,
     actions: [],
-    failures: []
+    failures: [],
+    warnings: []
   }
   if (options.check) return result
 
@@ -154,7 +157,7 @@ export async function pullNamespace(options: {
     const remote = remoteBySlug.get(entry.slug)
     if (!remote) continue
     try {
-      await installSkill({
+      const installed = await (options.installSkillFn ?? installSkill)({
         registry: options.registry,
         token: options.token,
         namespace: options.namespace,
@@ -172,6 +175,7 @@ export async function pullNamespace(options: {
         force: entry.status !== 'not-installed' || options.force
       })
       result.actions.push({ slug: entry.slug, action: entry.status === 'not-installed' ? 'installed' : 'updated' })
+      result.warnings.push(...(installed.warnings ?? []).map(message => ({ slug: entry.slug, message })))
     } catch (error) {
       result.failures.push({ slug: entry.slug, message: error instanceof Error ? error.message : 'install failed' })
     }

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -1,4 +1,5 @@
 import { relative, resolve } from 'node:path'
+import { compare as compareSemver, valid as validSemver } from 'semver'
 import { pathExists } from '../platform/paths'
 import { SkillHubClient, type ResolveResponse } from '../clients/skillhub-client'
 import { InventoryStore, type InventoryItem, type InventoryTarget } from '../stores/inventory-store'
@@ -13,10 +14,10 @@ const MAX_UPGRADE_SELECTION = 50
 
 export interface UpgradeSelectionOptions {
   coordinates: string[]
-  namespace?: string
-  registry?: string
-  agents?: string[]
-  dir?: string
+  namespace?: string | undefined
+  registry?: string | undefined
+  agents?: string[] | undefined
+  dir?: string | undefined
   force: boolean
   home?: string
   tokenForRegistry: (registry: string) => Promise<string | undefined>
@@ -68,6 +69,15 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
       targets: selection.targets.map(target => ({ agent: target.agent, dir: target.installDir })),
       inventoryItem: selection.item,
       selectedTargets: selection.targets
+    }
+
+    if (selection.targets.length !== selection.item.targets.length) {
+      items.push({
+        ...base,
+        action: 'blocked',
+        reason: 'partial-target upgrades are not supported because one inventory item has one shared version'
+      })
+      continue
     }
 
     let resolved: ResolveResponse
@@ -129,9 +139,44 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
       continue
     }
 
-    const unchanged = selection.item.version === resolved.version &&
+    const versionOrder = compareVersions(selection.item.version, resolved.version)
+    if (versionOrder === 'remote-older') {
+      items.push({
+        ...base,
+        remoteVersion: resolved.version,
+        action: 'blocked',
+        reason: 'remote version is older than the installed version; local files were kept',
+        changedFiles: inspection.changedFiles,
+        resolved
+      })
+      continue
+    }
+    if (versionOrder === 'unknown') {
+      items.push({
+        ...base,
+        remoteVersion: resolved.version,
+        action: 'blocked',
+        reason: 'cannot determine version order; use explicit install after verifying the release',
+        changedFiles: inspection.changedFiles,
+        resolved
+      })
+      continue
+    }
+
+    const unchanged = versionOrder === 'same' &&
       selection.item.fingerprint === resolved.fingerprint &&
       inspection.metadataCurrent
+    if (versionOrder === 'same' && !unchanged) {
+      items.push({
+        ...base,
+        remoteVersion: resolved.version,
+        action: 'blocked',
+        reason: 'remote content changed without a newer version; use explicit install after verifying the release',
+        changedFiles: inspection.changedFiles,
+        resolved
+      })
+      continue
+    }
     items.push({
       ...base,
       remoteVersion: resolved.version,
@@ -151,7 +196,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
 
 export async function executeSkillUpgradePlan(
   plan: UpgradePlan,
-  options: Pick<UpgradeSelectionOptions, 'force' | 'home' | 'tokenForRegistry'>
+  options: Pick<UpgradeSelectionOptions, 'home' | 'tokenForRegistry'>
 ): Promise<void> {
   if (plan.blocked > 0) {
     throw new CliError('upgrade plan contains blocked skills', EXIT.validation)
@@ -284,4 +329,13 @@ function isSameOrWithin(parent: string, candidate: string): boolean {
 
 function normalizeRegistry(registry: string): string {
   return registry.replace(/\/+$/, '')
+}
+
+function compareVersions(
+  installedVersion: string,
+  remoteVersion: string
+): 'same' | 'remote-newer' | 'remote-older' | 'unknown' {
+  if (installedVersion === remoteVersion) return 'same'
+  if (!validSemver(installedVersion) || !validSemver(remoteVersion)) return 'unknown'
+  return compareSemver(remoteVersion, installedVersion) > 0 ? 'remote-newer' : 'remote-older'
 }

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -48,6 +48,20 @@ export interface UpgradePlan {
   unchanged: number
 }
 
+export type UpgradeExecutionAction = 'upgraded' | 'unchanged' | 'failed' | 'not-attempted'
+
+export interface UpgradeExecutionResult {
+  items: Array<{
+    coordinate: string
+    action: UpgradeExecutionAction
+    reason?: string
+  }>
+  upgraded: number
+  unchanged: number
+  failed: number
+  notAttempted: number
+}
+
 export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promise<UpgradePlan> {
   if (options.coordinates.length === 0) {
     throw new CliError('provide at least one installed skill coordinate', EXIT.usage)
@@ -208,32 +222,61 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
 export async function executeSkillUpgradePlan(
   plan: UpgradePlan,
   options: Pick<UpgradeSelectionOptions, 'home' | 'tokenForRegistry'>
-): Promise<void> {
+): Promise<UpgradeExecutionResult> {
   if (plan.blocked > 0) {
     throw new CliError('upgrade plan contains blocked skills', EXIT.validation)
   }
 
+  const items: UpgradeExecutionResult['items'] = []
+  let stopped = false
   for (const item of plan.items) {
+    if (item.action === 'unchanged') {
+      items.push({ coordinate: item.coordinate, action: 'unchanged' })
+      continue
+    }
     if (item.action !== 'upgrade' || !item.resolved) continue
-    const token = await options.tokenForRegistry(item.registry)
-    await installSkill({
-      registry: item.registry,
-      token,
-      namespace: item.inventoryItem.namespace,
-      slug: item.inventoryItem.slug,
-      resolved: item.resolved,
-      targets: item.selectedTargets.map(target => ({
-        agent: target.agent,
-        rootDir: target.rootDir,
-        scope: 'project',
-        source: 'explicit'
-      })),
-      force: true,
-      home: options.home,
-      expectedTargetFiles: item.expectedTargetFiles,
-      allowTargetDrift: item.allowTargetDrift,
-      requireExistingTargets: true
-    })
+    if (stopped) {
+      items.push({ coordinate: item.coordinate, action: 'not-attempted' })
+      continue
+    }
+
+    try {
+      const token = await options.tokenForRegistry(item.registry)
+      await installSkill({
+        registry: item.registry,
+        token,
+        namespace: item.inventoryItem.namespace,
+        slug: item.inventoryItem.slug,
+        resolved: item.resolved,
+        targets: item.selectedTargets.map(target => ({
+          agent: target.agent,
+          rootDir: target.rootDir,
+          scope: 'project',
+          source: 'explicit'
+        })),
+        force: true,
+        home: options.home,
+        expectedTargetFiles: item.expectedTargetFiles,
+        allowTargetDrift: item.allowTargetDrift,
+        requireExistingTargets: true
+      })
+      items.push({ coordinate: item.coordinate, action: 'upgraded' })
+    } catch (error) {
+      items.push({
+        coordinate: item.coordinate,
+        action: 'failed',
+        reason: error instanceof Error ? error.message : 'unexpected upgrade failure'
+      })
+      stopped = true
+    }
+  }
+
+  return {
+    items,
+    upgraded: items.filter(item => item.action === 'upgraded').length,
+    unchanged: items.filter(item => item.action === 'unchanged').length,
+    failed: items.filter(item => item.action === 'failed').length,
+    notAttempted: items.filter(item => item.action === 'not-attempted').length
   }
 }
 

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -337,5 +337,7 @@ function compareVersions(
 ): 'same' | 'remote-newer' | 'remote-older' | 'unknown' {
   if (installedVersion === remoteVersion) return 'same'
   if (!validSemver(installedVersion) || !validSemver(remoteVersion)) return 'unknown'
-  return compareSemver(remoteVersion, installedVersion) > 0 ? 'remote-newer' : 'remote-older'
+  const order = compareSemver(remoteVersion, installedVersion)
+  if (order === 0) return 'same'
+  return order > 0 ? 'remote-newer' : 'remote-older'
 }

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -371,9 +371,9 @@ async function inspectTargets(item: InventoryItem, targets: InventoryTarget[]): 
       baselineMissing = true
     } else {
       const snapshot = await snapshotSkillDirectory(installDir)
-      currentFiles[installDir] = snapshot.files
+      currentFiles[target.installDir] = snapshot.files
       for (const path of diffSkillFiles(result.metadata.files, snapshot.files)) {
-        changedFiles.add(`${installDir}:${path}`)
+        changedFiles.add(`${target.installDir}:${path}`)
       }
     }
     if (result.metadata.version !== item.version || result.metadata.fingerprint !== item.fingerprint) {

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -231,7 +231,8 @@ export async function executeSkillUpgradePlan(
       force: true,
       home: options.home,
       expectedTargetFiles: item.expectedTargetFiles,
-      allowTargetDrift: item.allowTargetDrift
+      allowTargetDrift: item.allowTargetDrift,
+      requireExistingTargets: true
     })
   }
 }

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -1,0 +1,287 @@
+import { relative, resolve } from 'node:path'
+import { pathExists } from '../platform/paths'
+import { SkillHubClient, type ResolveResponse } from '../clients/skillhub-client'
+import { InventoryStore, type InventoryItem, type InventoryTarget } from '../stores/inventory-store'
+import { CliError } from '../shared/errors'
+import { EXIT } from '../shared/constants'
+import { hasExplicitNamespace, parseSkillName, resolveSkillName } from '../shared/skill-name-parser'
+import { diffSkillFiles, snapshotSkillDirectory } from './skill-fingerprint'
+import { installSkill } from './install-service'
+import { readInstalledSkillMetadata, sameInstalledSkillSource } from './installed-skill-metadata'
+
+const MAX_UPGRADE_SELECTION = 50
+
+export interface UpgradeSelectionOptions {
+  coordinates: string[]
+  namespace?: string
+  registry?: string
+  agents?: string[]
+  dir?: string
+  force: boolean
+  home?: string
+  tokenForRegistry: (registry: string) => Promise<string | undefined>
+}
+
+export type UpgradePlanAction = 'upgrade' | 'unchanged' | 'blocked'
+
+export interface UpgradePlanItem {
+  coordinate: string
+  registry: string
+  currentVersion: string
+  remoteVersion?: string
+  action: UpgradePlanAction
+  reason?: string
+  changedFiles: string[]
+  targets: Array<{ agent: string; dir: string }>
+  resolved?: ResolveResponse
+  inventoryItem: InventoryItem
+  selectedTargets: InventoryTarget[]
+}
+
+export interface UpgradePlan {
+  items: UpgradePlanItem[]
+  blocked: number
+  upgrades: number
+  unchanged: number
+}
+
+export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promise<UpgradePlan> {
+  if (options.coordinates.length === 0) {
+    throw new CliError('provide at least one installed skill coordinate', EXIT.usage)
+  }
+  if (options.coordinates.length > MAX_UPGRADE_SELECTION) {
+    throw new CliError(`upgrade accepts at most ${MAX_UPGRADE_SELECTION} coordinates`, EXIT.usage)
+  }
+
+  const store = new InventoryStore(options.home)
+  const inventory = await store.read()
+  const selected = selectInventoryItems(inventory.items, options)
+  const items: UpgradePlanItem[] = []
+
+  for (const selection of selected) {
+    const coordinate = `@${selection.item.namespace}/${selection.item.slug}`
+    const base = {
+      coordinate,
+      registry: selection.item.registry,
+      currentVersion: selection.item.version,
+      changedFiles: [] as string[],
+      targets: selection.targets.map(target => ({ agent: target.agent, dir: target.installDir })),
+      inventoryItem: selection.item,
+      selectedTargets: selection.targets
+    }
+
+    let resolved: ResolveResponse
+    try {
+      const token = await options.tokenForRegistry(selection.item.registry)
+      resolved = await new SkillHubClient(selection.item.registry, token)
+        .resolve(selection.item.namespace, selection.item.slug)
+    } catch (error) {
+      items.push({
+        ...base,
+        action: 'blocked',
+        reason: error instanceof Error ? error.message : 'remote version unavailable'
+      })
+      continue
+    }
+
+    if (resolved.namespace !== selection.item.namespace || resolved.slug !== selection.item.slug) {
+      items.push({
+        ...base,
+        remoteVersion: resolved.version,
+        action: 'blocked',
+        reason: 'registry resolved a different skill identity'
+      })
+      continue
+    }
+
+    const inspection = await inspectTargets(selection.item, selection.targets)
+    const hardConflict = inspection.hardConflicts[0]
+    if (hardConflict) {
+      items.push({
+        ...base,
+        remoteVersion: resolved.version,
+        action: 'blocked',
+        reason: hardConflict,
+        changedFiles: inspection.changedFiles,
+        resolved
+      })
+      continue
+    }
+    if (inspection.changedFiles.length > 0 && !options.force) {
+      items.push({
+        ...base,
+        remoteVersion: resolved.version,
+        action: 'blocked',
+        reason: 'local changes detected; pass --force to replace same-source files',
+        changedFiles: inspection.changedFiles,
+        resolved
+      })
+      continue
+    }
+    if (inspection.baselineMissing && !options.force) {
+      items.push({
+        ...base,
+        remoteVersion: resolved.version,
+        action: 'blocked',
+        reason: 'installed metadata has no file baseline; pass --force to migrate this same-source installation',
+        resolved
+      })
+      continue
+    }
+
+    const unchanged = selection.item.version === resolved.version &&
+      selection.item.fingerprint === resolved.fingerprint &&
+      inspection.metadataCurrent
+    items.push({
+      ...base,
+      remoteVersion: resolved.version,
+      action: unchanged ? 'unchanged' : 'upgrade',
+      changedFiles: inspection.changedFiles,
+      resolved
+    })
+  }
+
+  return {
+    items,
+    blocked: items.filter(item => item.action === 'blocked').length,
+    upgrades: items.filter(item => item.action === 'upgrade').length,
+    unchanged: items.filter(item => item.action === 'unchanged').length
+  }
+}
+
+export async function executeSkillUpgradePlan(
+  plan: UpgradePlan,
+  options: Pick<UpgradeSelectionOptions, 'force' | 'home' | 'tokenForRegistry'>
+): Promise<void> {
+  if (plan.blocked > 0) {
+    throw new CliError('upgrade plan contains blocked skills', EXIT.validation)
+  }
+
+  for (const item of plan.items) {
+    if (item.action !== 'upgrade' || !item.resolved) continue
+    const token = await options.tokenForRegistry(item.registry)
+    await installSkill({
+      registry: item.registry,
+      token,
+      namespace: item.inventoryItem.namespace,
+      slug: item.inventoryItem.slug,
+      resolved: item.resolved,
+      targets: item.selectedTargets.map(target => ({
+        agent: target.agent,
+        rootDir: target.rootDir,
+        scope: 'project',
+        source: 'explicit'
+      })),
+      force: true,
+      home: options.home
+    })
+  }
+}
+
+function selectInventoryItems(
+  items: InventoryItem[],
+  options: Pick<UpgradeSelectionOptions, 'coordinates' | 'namespace' | 'registry' | 'agents' | 'dir'>
+): Array<{ item: InventoryItem; targets: InventoryTarget[] }> {
+  const selected = new Map<string, { item: InventoryItem; targets: InventoryTarget[] }>()
+
+  for (const coordinate of options.coordinates) {
+    const explicitNamespace = hasExplicitNamespace(coordinate)
+    const parsed = explicitNamespace
+      ? resolveSkillName(coordinate, options.namespace)
+      : parseSkillName(coordinate)
+    const namespace = explicitNamespace ? parsed.namespace : options.namespace
+
+    const matches = items.flatMap(item => {
+      if (item.slug !== parsed.slug) return []
+      if (namespace && item.namespace !== namespace) return []
+      if (options.registry && normalizeRegistry(item.registry) !== normalizeRegistry(options.registry)) return []
+      const targets = item.targets.filter(target => matchesTargetFilters(target, options.agents, options.dir))
+      return targets.length > 0 ? [{ item, targets }] : []
+    })
+
+    if (matches.length === 0) {
+      throw new CliError(`skill "${coordinate}" is not installed`, EXIT.usage, {
+        next: `use skillhub install ${coordinate}`
+      })
+    }
+    if (matches.length > 1) {
+      throw new CliError(`installed skill "${coordinate}" is ambiguous`, EXIT.usage, {
+        matches: matches.map(match => `${match.item.registry} @${match.item.namespace}/${match.item.slug}`),
+        next: 'use a full coordinate and --registry to select one installation source'
+      })
+    }
+
+    const match = matches[0]!
+    const key = `${normalizeRegistry(match.item.registry)}\u0000${match.item.namespace}\u0000${match.item.slug}`
+    selected.set(key, match)
+  }
+
+  if (selected.size > MAX_UPGRADE_SELECTION) {
+    throw new CliError(`upgrade resolves to at most ${MAX_UPGRADE_SELECTION} skills`, EXIT.usage)
+  }
+  return [...selected.values()]
+}
+
+async function inspectTargets(item: InventoryItem, targets: InventoryTarget[]): Promise<{
+  hardConflicts: string[]
+  changedFiles: string[]
+  baselineMissing: boolean
+  metadataCurrent: boolean
+}> {
+  const hardConflicts: string[] = []
+  const changedFiles = new Set<string>()
+  let baselineMissing = false
+  let metadataCurrent = true
+
+  for (const target of targets) {
+    if (!(await pathExists(target.installDir))) {
+      hardConflicts.push(`installed target is missing: ${target.installDir}`)
+      continue
+    }
+    const result = await readInstalledSkillMetadata(target.installDir)
+    if (result.status !== 'valid') {
+      hardConflicts.push(`metadata-invalid at ${target.installDir}: ${result.status === 'missing' ? 'missing' : result.reason}`)
+      continue
+    }
+    if (!sameInstalledSkillSource(result.metadata, item)) {
+      hardConflicts.push(`source-conflict at ${target.installDir}`)
+      continue
+    }
+    if (!result.metadata.files) {
+      baselineMissing = true
+    } else {
+      const snapshot = await snapshotSkillDirectory(target.installDir)
+      for (const path of diffSkillFiles(result.metadata.files, snapshot.files)) {
+        changedFiles.add(`${target.installDir}:${path}`)
+      }
+    }
+    if (result.metadata.version !== item.version || result.metadata.fingerprint !== item.fingerprint) {
+      metadataCurrent = false
+    }
+  }
+
+  return {
+    hardConflicts,
+    changedFiles: [...changedFiles].sort(),
+    baselineMissing,
+    metadataCurrent
+  }
+}
+
+function matchesTargetFilters(target: InventoryTarget, agents?: string[], dir?: string): boolean {
+  if (agents?.length && !agents.includes(target.agent)) return false
+  if (!dir) return true
+  const filterPath = resolve(dir)
+  const installPath = resolve(target.installDir)
+  const rootPath = resolve(target.rootDir)
+  return isSameOrWithin(filterPath, installPath) || isSameOrWithin(filterPath, rootPath)
+}
+
+function isSameOrWithin(parent: string, candidate: string): boolean {
+  const rel = relative(parent, candidate)
+  return rel === '' || (!rel.startsWith('..') && !rel.startsWith('/') && !rel.startsWith('\\'))
+}
+
+function normalizeRegistry(registry: string): string {
+  return registry.replace(/\/+$/, '')
+}

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -55,6 +55,8 @@ export interface UpgradeExecutionResult {
     coordinate: string
     action: UpgradeExecutionAction
     reason?: string
+    warnings?: string[]
+    exitCode?: number
   }>
   upgraded: number
   unchanged: number
@@ -242,7 +244,7 @@ export async function executeSkillUpgradePlan(
 
     try {
       const token = await options.tokenForRegistry(item.registry)
-      await installSkill({
+      const installed = await installSkill({
         registry: item.registry,
         token,
         namespace: item.inventoryItem.namespace,
@@ -260,12 +262,17 @@ export async function executeSkillUpgradePlan(
         allowTargetDrift: item.allowTargetDrift,
         requireExistingTargets: true
       })
-      items.push({ coordinate: item.coordinate, action: 'upgraded' })
+      items.push({
+        coordinate: item.coordinate,
+        action: 'upgraded',
+        ...(installed.warnings?.length ? { warnings: installed.warnings } : {})
+      })
     } catch (error) {
       items.push({
         coordinate: item.coordinate,
         action: 'failed',
-        reason: error instanceof Error ? error.message : 'unexpected upgrade failure'
+        reason: error instanceof Error ? error.message : 'unexpected upgrade failure',
+        ...(error instanceof CliError ? { exitCode: error.exitCode } : {})
       })
       stopped = true
     }

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -64,6 +64,10 @@ export interface UpgradeExecutionResult {
   notAttempted: number
 }
 
+type UpgradeExecutionOptions = Pick<UpgradeSelectionOptions, 'home' | 'tokenForRegistry'> & {
+  installSkillFn?: typeof installSkill
+}
+
 export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promise<UpgradePlan> {
   if (options.coordinates.length === 0) {
     throw new CliError('provide at least one installed skill coordinate', EXIT.usage)
@@ -223,7 +227,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
 
 export async function executeSkillUpgradePlan(
   plan: UpgradePlan,
-  options: Pick<UpgradeSelectionOptions, 'home' | 'tokenForRegistry'>
+  options: UpgradeExecutionOptions
 ): Promise<UpgradeExecutionResult> {
   if (plan.blocked > 0) {
     throw new CliError('upgrade plan contains blocked skills', EXIT.validation)
@@ -244,7 +248,7 @@ export async function executeSkillUpgradePlan(
 
     try {
       const token = await options.tokenForRegistry(item.registry)
-      const installed = await installSkill({
+      const installed = await (options.installSkillFn ?? installSkill)({
         registry: item.registry,
         token,
         namespace: item.inventoryItem.namespace,

--- a/cli/src/services/upgrade-service.ts
+++ b/cli/src/services/upgrade-service.ts
@@ -1,6 +1,6 @@
-import { relative, resolve } from 'node:path'
+import { isAbsolute, relative, resolve } from 'node:path'
 import { compare as compareSemver, valid as validSemver } from 'semver'
-import { pathExists } from '../platform/paths'
+import { canonicalizeExistingPath, pathExists } from '../platform/paths'
 import { SkillHubClient, type ResolveResponse } from '../clients/skillhub-client'
 import { InventoryStore, type InventoryItem, type InventoryTarget } from '../stores/inventory-store'
 import { CliError } from '../shared/errors'
@@ -37,6 +37,8 @@ export interface UpgradePlanItem {
   resolved?: ResolveResponse
   inventoryItem: InventoryItem
   selectedTargets: InventoryTarget[]
+  expectedTargetFiles: Record<string, Record<string, string>>
+  allowTargetDrift: boolean
 }
 
 export interface UpgradePlan {
@@ -68,7 +70,9 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
       changedFiles: [] as string[],
       targets: selection.targets.map(target => ({ agent: target.agent, dir: target.installDir })),
       inventoryItem: selection.item,
-      selectedTargets: selection.targets
+      selectedTargets: selection.targets,
+      expectedTargetFiles: {} as Record<string, Record<string, string>>,
+      allowTargetDrift: options.force
     }
 
     if (selection.targets.length !== selection.item.targets.length) {
@@ -113,6 +117,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
         action: 'blocked',
         reason: hardConflict,
         changedFiles: inspection.changedFiles,
+        expectedTargetFiles: inspection.currentFiles,
         resolved
       })
       continue
@@ -124,6 +129,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
         action: 'blocked',
         reason: 'local changes detected; pass --force to replace same-source files',
         changedFiles: inspection.changedFiles,
+        expectedTargetFiles: inspection.currentFiles,
         resolved
       })
       continue
@@ -134,6 +140,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
         remoteVersion: resolved.version,
         action: 'blocked',
         reason: 'installed metadata has no file baseline; pass --force to migrate this same-source installation',
+        expectedTargetFiles: inspection.currentFiles,
         resolved
       })
       continue
@@ -147,6 +154,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
         action: 'blocked',
         reason: 'remote version is older than the installed version; local files were kept',
         changedFiles: inspection.changedFiles,
+        expectedTargetFiles: inspection.currentFiles,
         resolved
       })
       continue
@@ -158,6 +166,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
         action: 'blocked',
         reason: 'cannot determine version order; use explicit install after verifying the release',
         changedFiles: inspection.changedFiles,
+        expectedTargetFiles: inspection.currentFiles,
         resolved
       })
       continue
@@ -173,6 +182,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
         action: 'blocked',
         reason: 'remote content changed without a newer version; use explicit install after verifying the release',
         changedFiles: inspection.changedFiles,
+        expectedTargetFiles: inspection.currentFiles,
         resolved
       })
       continue
@@ -182,6 +192,7 @@ export async function planSkillUpgrades(options: UpgradeSelectionOptions): Promi
       remoteVersion: resolved.version,
       action: unchanged ? 'unchanged' : 'upgrade',
       changedFiles: inspection.changedFiles,
+      expectedTargetFiles: inspection.currentFiles,
       resolved
     })
   }
@@ -218,7 +229,9 @@ export async function executeSkillUpgradePlan(
         source: 'explicit'
       })),
       force: true,
-      home: options.home
+      home: options.home,
+      expectedTargetFiles: item.expectedTargetFiles,
+      allowTargetDrift: item.allowTargetDrift
     })
   }
 }
@@ -272,18 +285,25 @@ async function inspectTargets(item: InventoryItem, targets: InventoryTarget[]): 
   changedFiles: string[]
   baselineMissing: boolean
   metadataCurrent: boolean
+  currentFiles: Record<string, Record<string, string>>
 }> {
   const hardConflicts: string[] = []
   const changedFiles = new Set<string>()
   let baselineMissing = false
   let metadataCurrent = true
+  const currentFiles: Record<string, Record<string, string>> = {}
 
   for (const target of targets) {
-    if (!(await pathExists(target.installDir))) {
+    if (!isAbsolute(target.rootDir) || !isAbsolute(target.installDir)) {
+      hardConflicts.push(`legacy relative target path is unsafe to upgrade: ${target.installDir}`)
+      continue
+    }
+    const installDir = await canonicalizeExistingPath(target.installDir)
+    if (!(await pathExists(installDir))) {
       hardConflicts.push(`installed target is missing: ${target.installDir}`)
       continue
     }
-    const result = await readInstalledSkillMetadata(target.installDir)
+    const result = await readInstalledSkillMetadata(installDir)
     if (result.status !== 'valid') {
       hardConflicts.push(`metadata-invalid at ${target.installDir}: ${result.status === 'missing' ? 'missing' : result.reason}`)
       continue
@@ -295,9 +315,10 @@ async function inspectTargets(item: InventoryItem, targets: InventoryTarget[]): 
     if (!result.metadata.files) {
       baselineMissing = true
     } else {
-      const snapshot = await snapshotSkillDirectory(target.installDir)
+      const snapshot = await snapshotSkillDirectory(installDir)
+      currentFiles[installDir] = snapshot.files
       for (const path of diffSkillFiles(result.metadata.files, snapshot.files)) {
-        changedFiles.add(`${target.installDir}:${path}`)
+        changedFiles.add(`${installDir}:${path}`)
       }
     }
     if (result.metadata.version !== item.version || result.metadata.fingerprint !== item.fingerprint) {
@@ -309,7 +330,8 @@ async function inspectTargets(item: InventoryItem, targets: InventoryTarget[]): 
     hardConflicts,
     changedFiles: [...changedFiles].sort(),
     baselineMissing,
-    metadataCurrent
+    metadataCurrent,
+    currentFiles
   }
 }
 

--- a/cli/src/stores/inventory-store.ts
+++ b/cli/src/stores/inventory-store.ts
@@ -22,6 +22,13 @@ export interface Inventory {
   items: InventoryItem[]
 }
 
+export class InventoryVersionConflictError extends Error {
+  constructor(readonly retainedTargets: InventoryTarget[]) {
+    super('partial-target install would create inconsistent versions')
+    this.name = 'InventoryVersionConflictError'
+  }
+}
+
 export class InventoryStore {
   readonly path: string
 
@@ -214,6 +221,14 @@ export class InventoryStore {
   ): Promise<void> {
     await this.mutateAtomic(inventory => {
       const installDirs = new Set(targets.map(target => target.installDir))
+      const existingItem = inventory.items.find(candidate =>
+        candidate.registry === registry && candidate.namespace === namespace && candidate.slug === slug)
+      const retainedTargets = existingItem?.targets.filter(target => !installDirs.has(target.installDir)) ?? []
+      if (existingItem && retainedTargets.length > 0 &&
+          (existingItem.version !== version || existingItem.fingerprint !== fingerprint)) {
+        throw new InventoryVersionConflictError(retainedTargets)
+      }
+
       for (const item of inventory.items) {
         item.targets = item.targets.filter(existing => !installDirs.has(existing.installDir))
       }

--- a/cli/src/stores/inventory-store.ts
+++ b/cli/src/stores/inventory-store.ts
@@ -1,5 +1,6 @@
-import { open, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { lock } from 'proper-lockfile'
 import { joinPath, userStateDir, ensureDir, pathExists } from '../platform/paths'
 
 export interface InventoryTarget {
@@ -48,34 +49,26 @@ export class InventoryStore {
 
   async writeAtomic(inventory: Inventory): Promise<void> {
     await ensureDir(dirname(this.path))
-    const lockPath = `${this.path}.lock`
-    let lockHandle: Awaited<ReturnType<typeof open>> | null = null
+    let release: (() => Promise<void>) | null = null
     try {
-      lockHandle = await this.acquireLock(lockPath)
+      release = await this.acquireLock()
       await this.writeUnderLock(inventory)
     } finally {
-      if (lockHandle) {
-        await lockHandle.close().catch(() => {})
-        await rm(lockPath, { force: true }).catch(() => {})
-      }
+      if (release) await release().catch(() => {})
     }
   }
 
   private async mutateAtomic<T>(mutate: (inventory: Inventory) => T): Promise<T> {
     await ensureDir(dirname(this.path))
-    const lockPath = `${this.path}.lock`
-    let lockHandle: Awaited<ReturnType<typeof open>> | null = null
+    let release: (() => Promise<void>) | null = null
     try {
-      lockHandle = await this.acquireLock(lockPath)
+      release = await this.acquireLock()
       const inventory = await this.read()
       const result = mutate(inventory)
       await this.writeUnderLock(inventory)
       return result
     } finally {
-      if (lockHandle) {
-        await lockHandle.close().catch(() => {})
-        await rm(lockPath, { force: true }).catch(() => {})
-      }
+      if (release) await release().catch(() => {})
     }
   }
 
@@ -92,50 +85,20 @@ export class InventoryStore {
     }
   }
 
-  private async acquireLock(lockPath: string, maxRetries = 10, retryDelayMs = 100): Promise<Awaited<ReturnType<typeof open>>> {
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-      try {
-        // Try to create lock file with PID and timestamp
-        const lockHandle = await open(lockPath, 'wx')
-        const lockData = JSON.stringify({ pid: process.pid, timestamp: Date.now() })
-        await writeFile(lockPath, lockData)
-        return lockHandle
-      } catch (err) {
-        if (err instanceof Error && 'code' in err && err.code !== 'EEXIST') throw err
-
-        // Lock exists, check if it's stale (older than 30 seconds)
-        // 30s threshold chosen to balance between:
-        // - Allowing slow operations to complete (e.g., large inventory writes)
-        // - Recovering quickly from crashed processes
-        try {
-          const lockContent = await readFile(lockPath, 'utf-8')
-          const lockData = JSON.parse(lockContent) as { pid: number; timestamp: number }
-          const ageMs = Date.now() - lockData.timestamp
-
-          if (ageMs > 30000) {
-            // Stale lock detected - verify the process is actually dead
-            try {
-              // process.kill(pid, 0) throws if process doesn't exist
-              process.kill(lockData.pid, 0)
-              // Process still alive, wait and retry
-            } catch {
-              // Process is dead, safe to remove stale lock
-              await rm(lockPath, { force: true }).catch(() => {})
-              continue
-            }
-          }
-        } catch {
-          // Lock file disappeared or corrupted, retry
-          continue
-        }
-
-        // Lock is held by another active process, wait and retry with exponential backoff
-        if (attempt < maxRetries - 1) {
-          await new Promise(resolve => setTimeout(resolve, retryDelayMs * Math.pow(2, attempt)))
-        }
+  private acquireLock(): Promise<() => Promise<void>> {
+    return lock(this.path, {
+      lockfilePath: `${this.path}.lock`,
+      realpath: false,
+      stale: 30_000,
+      update: 10_000,
+      retries: {
+        retries: 10,
+        factor: 2,
+        minTimeout: 100,
+        maxTimeout: 1_000,
+        randomize: true
       }
-    }
-    throw new Error(`Failed to acquire lock after ${maxRetries} attempts`)
+    })
   }
 
   async upsertTarget(

--- a/cli/src/stores/inventory-store.ts
+++ b/cli/src/stores/inventory-store.ts
@@ -180,10 +180,14 @@ export class InventoryStore {
     slug: string,
     version: string,
     targets: InventoryTarget[],
-    fingerprint?: string
+    fingerprint?: string,
+    replacedInstallDirs: string[] = []
   ): Promise<void> {
     await this.mutateAtomic(inventory => {
-      const installDirs = new Set(targets.map(target => target.installDir))
+      const installDirs = new Set([
+        ...targets.map(target => target.installDir),
+        ...replacedInstallDirs
+      ])
       const existingItem = inventory.items.find(candidate =>
         candidate.registry === registry && candidate.namespace === namespace && candidate.slug === slug)
       const retainedTargets = existingItem?.targets.filter(target => !installDirs.has(target.installDir)) ?? []

--- a/cli/src/stores/inventory-store.ts
+++ b/cli/src/stores/inventory-store.ts
@@ -41,29 +41,47 @@ export class InventoryStore {
 
   async writeAtomic(inventory: Inventory): Promise<void> {
     await ensureDir(dirname(this.path))
-    const payload = JSON.stringify(inventory, null, 2)
-    JSON.parse(payload)
-
     const lockPath = `${this.path}.lock`
-    const tmpPath = `${this.path}.${process.pid}.${Date.now()}.tmp`
-
     let lockHandle: Awaited<ReturnType<typeof open>> | null = null
     try {
-      // Acquire exclusive lock with retry and stale lock detection
       lockHandle = await this.acquireLock(lockPath)
-
-      await writeFile(tmpPath, payload)
-      JSON.parse(await readFile(tmpPath, 'utf-8'))
-      await rename(tmpPath, this.path)
+      await this.writeUnderLock(inventory)
     } finally {
-      // Clean up temp file if it still exists
-      await rm(tmpPath, { force: true }).catch(() => {})
-
-      // Release lock
       if (lockHandle) {
         await lockHandle.close().catch(() => {})
         await rm(lockPath, { force: true }).catch(() => {})
       }
+    }
+  }
+
+  private async mutateAtomic<T>(mutate: (inventory: Inventory) => T): Promise<T> {
+    await ensureDir(dirname(this.path))
+    const lockPath = `${this.path}.lock`
+    let lockHandle: Awaited<ReturnType<typeof open>> | null = null
+    try {
+      lockHandle = await this.acquireLock(lockPath)
+      const inventory = await this.read()
+      const result = mutate(inventory)
+      await this.writeUnderLock(inventory)
+      return result
+    } finally {
+      if (lockHandle) {
+        await lockHandle.close().catch(() => {})
+        await rm(lockPath, { force: true }).catch(() => {})
+      }
+    }
+  }
+
+  private async writeUnderLock(inventory: Inventory): Promise<void> {
+    const payload = JSON.stringify(inventory, null, 2)
+    JSON.parse(payload)
+    const tmpPath = `${this.path}.${process.pid}.${Date.now()}.tmp`
+    try {
+      await writeFile(tmpPath, payload)
+      JSON.parse(await readFile(tmpPath, 'utf-8'))
+      await rename(tmpPath, this.path)
+    } finally {
+      await rm(tmpPath, { force: true }).catch(() => {})
     }
   }
 
@@ -121,52 +139,43 @@ export class InventoryStore {
     target: InventoryTarget,
     fingerprint?: string
   ): Promise<void> {
-    const inventory = await this.read()
-    const existing = inventory.items.find(
-      i => i.registry === registry && i.namespace === namespace && i.slug === slug
-    )
-    const item: InventoryItem = existing ?? { registry, namespace, slug, version, targets: [] }
-    if (!existing) {
-      inventory.items.push(item)
-    }
-    item.version = version
-    if (fingerprint !== undefined) item.fingerprint = fingerprint
-    const existingIdx = item.targets.findIndex(t => t.installDir === target.installDir)
-    if (existingIdx >= 0) {
-      item.targets[existingIdx] = target
-    } else {
-      item.targets.push(target)
-    }
-    await this.writeAtomic(inventory)
+    await this.mutateAtomic(inventory => {
+      const existing = inventory.items.find(
+        i => i.registry === registry && i.namespace === namespace && i.slug === slug
+      )
+      const item: InventoryItem = existing ?? { registry, namespace, slug, version, targets: [] }
+      if (!existing) inventory.items.push(item)
+      item.version = version
+      if (fingerprint !== undefined) item.fingerprint = fingerprint
+      const existingIdx = item.targets.findIndex(t => t.installDir === target.installDir)
+      if (existingIdx >= 0) item.targets[existingIdx] = target
+      else item.targets.push(target)
+    })
   }
 
   async removeTarget(registry: string, namespace: string, slug: string, installDir: string): Promise<boolean> {
-    const inventory = await this.read()
-    const item = inventory.items.find(i => i.registry === registry && i.namespace === namespace && i.slug === slug)
-    if (!item) return false
-    const idx = item.targets.findIndex(t => t.installDir === installDir)
-    if (idx < 0) return false
-    item.targets.splice(idx, 1)
-    if (item.targets.length === 0) {
-      inventory.items = inventory.items.filter(i => i !== item)
-    }
-    await this.writeAtomic(inventory)
-    return true
+    return this.mutateAtomic(inventory => {
+      const item = inventory.items.find(i => i.registry === registry && i.namespace === namespace && i.slug === slug)
+      if (!item) return false
+      const idx = item.targets.findIndex(t => t.installDir === installDir)
+      if (idx < 0) return false
+      item.targets.splice(idx, 1)
+      if (item.targets.length === 0) inventory.items = inventory.items.filter(i => i !== item)
+      return true
+    })
   }
 
   async removeTargetsByInstallDir(installDir: string): Promise<number> {
-    const inventory = await this.read()
-    let removed = 0
-    for (const item of inventory.items) {
-      const before = item.targets.length
-      item.targets = item.targets.filter(t => t.installDir !== installDir)
-      removed += before - item.targets.length
-    }
-    if (removed > 0) {
+    return this.mutateAtomic(inventory => {
+      let removed = 0
+      for (const item of inventory.items) {
+        const before = item.targets.length
+        item.targets = item.targets.filter(t => t.installDir !== installDir)
+        removed += before - item.targets.length
+      }
       inventory.items = inventory.items.filter(item => item.targets.length > 0)
-      await this.writeAtomic(inventory)
-    }
-    return removed
+      return removed
+    })
   }
 
   async replaceTargetAtInstallDir(
@@ -177,21 +186,48 @@ export class InventoryStore {
     target: InventoryTarget,
     fingerprint?: string
   ): Promise<void> {
-    const inventory = await this.read()
-    for (const item of inventory.items) {
-      item.targets = item.targets.filter(existing => existing.installDir !== target.installDir)
-    }
-    inventory.items = inventory.items.filter(item => item.targets.length > 0)
+    await this.mutateAtomic(inventory => {
+      for (const item of inventory.items) {
+        item.targets = item.targets.filter(existing => existing.installDir !== target.installDir)
+      }
+      inventory.items = inventory.items.filter(item => item.targets.length > 0)
 
-    let item = inventory.items.find(candidate =>
-      candidate.registry === registry && candidate.namespace === namespace && candidate.slug === slug)
-    if (!item) {
-      item = { registry, namespace, slug, version, targets: [] }
-      inventory.items.push(item)
-    }
-    item.version = version
-    if (fingerprint !== undefined) item.fingerprint = fingerprint
-    item.targets.push(target)
-    await this.writeAtomic(inventory)
+      let item = inventory.items.find(candidate =>
+        candidate.registry === registry && candidate.namespace === namespace && candidate.slug === slug)
+      if (!item) {
+        item = { registry, namespace, slug, version, targets: [] }
+        inventory.items.push(item)
+      }
+      item.version = version
+      if (fingerprint !== undefined) item.fingerprint = fingerprint
+      item.targets.push(target)
+    })
+  }
+
+  async replaceTargetsAtInstallDirs(
+    registry: string,
+    namespace: string,
+    slug: string,
+    version: string,
+    targets: InventoryTarget[],
+    fingerprint?: string
+  ): Promise<void> {
+    await this.mutateAtomic(inventory => {
+      const installDirs = new Set(targets.map(target => target.installDir))
+      for (const item of inventory.items) {
+        item.targets = item.targets.filter(existing => !installDirs.has(existing.installDir))
+      }
+      inventory.items = inventory.items.filter(item => item.targets.length > 0)
+
+      let item = inventory.items.find(candidate =>
+        candidate.registry === registry && candidate.namespace === namespace && candidate.slug === slug)
+      if (!item) {
+        item = { registry, namespace, slug, version, targets: [] }
+        inventory.items.push(item)
+      }
+      item.version = version
+      if (fingerprint !== undefined) item.fingerprint = fingerprint
+      item.targets.push(...targets)
+    })
   }
 }

--- a/cli/test/helpers/fake-registry.ts
+++ b/cli/test/helpers/fake-registry.ts
@@ -1,3 +1,5 @@
+import { unzipSync } from 'fflate'
+
 type FakeHandler = (req: Request) => Response | Promise<Response>
 
 export function createFakeRegistry(handlers: Record<string, FakeHandler>) {
@@ -103,6 +105,7 @@ export interface CapturedPublish {
   /** Visibility string from the multipart form field. */
   visibility: string
   rejectExistingVersion: boolean
+  archiveEntries: string[]
 }
 
 export interface CapturedValidate {
@@ -203,7 +206,8 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
     delete: CapturedDelete | null
     validate: CapturedValidate | null
     review: CapturedReview | null
-  } = { publish: null, resolve: null, delete: null, validate: null, review: null }
+    downloads: number
+  } = { publish: null, resolve: null, delete: null, validate: null, review: null, downloads: 0 }
 
   // If any endpoint is configured with 'network' failure mode, we need a real
   // TCP-level failure. Start a connection-dropping server and return its URL
@@ -345,6 +349,7 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
         if (!skill) {
           return Response.json({ code: 404, message: 'not found' }, { status: 404 })
         }
+        state.downloads += 1
         const bytes = skill.zipBytes ?? MINIMAL_ZIP
         return new Response(bytes as BodyInit, {
           status: 200,
@@ -364,6 +369,7 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
         if (!skill) {
           return Response.json({ code: 404, message: 'not found' }, { status: 404 })
         }
+        state.downloads += 1
         const bytes = skill.zipBytes ?? MINIMAL_ZIP
         return new Response(bytes as BodyInit, {
           status: 200,
@@ -415,6 +421,7 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
           if (fileField instanceof File) {
             fileName = fileField.name || fileName
           }
+
           state.validate = {
             namespace,
             fileName,
@@ -442,7 +449,7 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
         const namespace = publishMatch[1]!
 
         // Parse multipart form data asynchronously — return a Promise<Response>.
-        return req.formData().then(form => {
+        return req.formData().then(async form => {
           const fileField = form.get('file')
           const visibility = (form.get('visibility') as string | null) ?? 'PUBLIC'
 
@@ -451,13 +458,17 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
           if (fileField instanceof File) {
             fileName = fileField.name || fileName
           }
+          const archiveEntries = fileField instanceof File
+            ? Object.keys(unzipSync(new Uint8Array(await fileField.arrayBuffer()))).sort()
+            : []
 
           // Record for test assertions.
           state.publish = {
             namespace,
             fileName,
             visibility,
-            rejectExistingVersion: form.get('rejectExistingVersion') === 'true'
+            rejectExistingVersion: form.get('rejectExistingVersion') === 'true',
+            archiveEntries
           }
 
           return Response.json({

--- a/cli/test/helpers/fake-registry.ts
+++ b/cli/test/helpers/fake-registry.ts
@@ -206,8 +206,9 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
     delete: CapturedDelete | null
     validate: CapturedValidate | null
     review: CapturedReview | null
+    resolves: number
     downloads: number
-  } = { publish: null, resolve: null, delete: null, validate: null, review: null, downloads: 0 }
+  } = { publish: null, resolve: null, delete: null, validate: null, review: null, resolves: 0, downloads: 0 }
 
   // If any endpoint is configured with 'network' failure mode, we need a real
   // TCP-level failure. Start a connection-dropping server and return its URL
@@ -312,6 +313,7 @@ export async function startFakeRegistry(options: FakeRegistryOptions = {}) {
       // Resolve: GET /api/cli/v1/skills/:namespace/:slug/resolve
       const resolveMatch = path.match(/^\/api\/cli\/v1\/skills\/([^/]+)\/([^/]+)\/resolve$/)
       if (resolveMatch && req.method === 'GET') {
+        state.resolves++
         if (options.failures?.resolve) return failureResponse(options.failures.resolve)
         const namespace = resolveMatch[1]!
         const slug = resolveMatch[2]!

--- a/cli/test/helpers/target-lock-worker.ts
+++ b/cli/test/helpers/target-lock-worker.ts
@@ -2,10 +2,20 @@ import { access, writeFile } from 'node:fs/promises'
 import { acquireSkillTargetLock } from '../../src/services/skill-target-lock'
 import { CliError } from '../../src/shared/errors'
 
-const [rootDir, slug, acquiredPath, releasePath] = process.argv.slice(2)
-if (!rootDir || !slug || !acquiredPath || !releasePath) process.exit(5)
+const [rootDir, slug, readyPath, startPath, acquiredPath, releasePath] = process.argv.slice(2)
+if (!rootDir || !slug || !readyPath || !startPath || !acquiredPath || !releasePath) process.exit(5)
 
 try {
+  await writeFile(readyPath, 'ready')
+  let startRequested = false
+  while (!startRequested) {
+    try {
+      await access(startPath)
+      startRequested = true
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+  }
   const release = await acquireSkillTargetLock(rootDir, slug)
   await writeFile(acquiredPath, 'acquired')
   process.stdout.write('acquired\n')

--- a/cli/test/helpers/target-lock-worker.ts
+++ b/cli/test/helpers/target-lock-worker.ts
@@ -9,10 +9,11 @@ try {
   const release = await acquireSkillTargetLock(rootDir, slug)
   await writeFile(acquiredPath, 'acquired')
   process.stdout.write('acquired\n')
-  while (true) {
+  let releaseRequested = false
+  while (!releaseRequested) {
     try {
       await access(releasePath)
-      break
+      releaseRequested = true
     } catch {
       await new Promise(resolve => setTimeout(resolve, 10))
     }

--- a/cli/test/helpers/target-lock-worker.ts
+++ b/cli/test/helpers/target-lock-worker.ts
@@ -1,13 +1,22 @@
+import { access, writeFile } from 'node:fs/promises'
 import { acquireSkillTargetLock } from '../../src/services/skill-target-lock'
 import { CliError } from '../../src/shared/errors'
 
-const [rootDir, slug, holdMilliseconds] = process.argv.slice(2)
-if (!rootDir || !slug || !holdMilliseconds) process.exit(5)
+const [rootDir, slug, acquiredPath, releasePath] = process.argv.slice(2)
+if (!rootDir || !slug || !acquiredPath || !releasePath) process.exit(5)
 
 try {
   const release = await acquireSkillTargetLock(rootDir, slug)
+  await writeFile(acquiredPath, 'acquired')
   process.stdout.write('acquired\n')
-  await new Promise(resolve => setTimeout(resolve, Number(holdMilliseconds)))
+  while (true) {
+    try {
+      await access(releasePath)
+      break
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+  }
   await release()
   process.exit(0)
 } catch (error) {

--- a/cli/test/helpers/target-lock-worker.ts
+++ b/cli/test/helpers/target-lock-worker.ts
@@ -1,0 +1,19 @@
+import { acquireSkillTargetLock } from '../../src/services/skill-target-lock'
+import { CliError } from '../../src/shared/errors'
+
+const [rootDir, slug, holdMilliseconds] = process.argv.slice(2)
+if (!rootDir || !slug || !holdMilliseconds) process.exit(5)
+
+try {
+  const release = await acquireSkillTargetLock(rootDir, slug)
+  process.stdout.write('acquired\n')
+  await new Promise(resolve => setTimeout(resolve, Number(holdMilliseconds)))
+  await release()
+  process.exit(0)
+} catch (error) {
+  if (error instanceof CliError) {
+    process.stderr.write(`${error.message}\n`)
+    process.exit(error.exitCode)
+  }
+  throw error
+}

--- a/cli/test/integration/concurrency.test.ts
+++ b/cli/test/integration/concurrency.test.ts
@@ -28,17 +28,7 @@ function makeSkillZip(): Uint8Array {
 }
 
 describe('cross-process concurrency on inventory.json', () => {
-  // KNOWN BUG (documented here, not yet fixed):
-  //   inventory-store.upsertTarget() reads inventory, modifies in memory,
-  //   then writeAtomic() acquires the lock only over the write half. Two
-  //   concurrent installs each read the (empty) inventory, each adds their
-  //   own item, and the second writer overwrites the first — a classic
-  //   lost-update.
-  //
-  //   When the fix lands (lock spans read+write, or upsertTarget acquires
-  //   the lock first and re-reads), tighten the inventory assertion to
-  //   `expect(slugs).toEqual(['first', 'second'])`.
-  test('two parallel installs of distinct slugs: filesystem is correct, inventory has at least one (lost-update bug pinned)', async () => {
+  test('two parallel installs of distinct slugs preserve both inventory items', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({
       token: 'sk_ok',
@@ -66,9 +56,6 @@ describe('cross-process concurrency on inventory.json', () => {
       )
     ])
 
-    // Both subprocess installs report success — neither errored at the
-    // protocol level even though the inventory bookkeeping race ate one of
-    // their inventory writes.
     expect(r1.exitCode).toBe(0)
     expect(r2.exitCode).toBe(0)
 
@@ -80,12 +67,7 @@ describe('cross-process concurrency on inventory.json', () => {
       await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8')
     ) as { items: Array<{ slug: string }> }
     const slugs = inv.items.map(i => i.slug).sort()
-    // Today: at least one slug always lands; under the lost-update race
-    // both may NOT be there. When the lock widens to cover read+write,
-    // upgrade this to `toEqual(['first', 'second'])`.
-    expect(slugs.length).toBeGreaterThanOrEqual(1)
-    const lastSlug = slugs[slugs.length - 1]!
-    expect(['first', 'second']).toContain(lastSlug)
+    expect(slugs).toEqual(['first', 'second'])
   })
 
   test('two parallel installs of the same slug to the same dir: exactly one wins, one conflicts', async () => {
@@ -111,15 +93,8 @@ describe('cross-process concurrency on inventory.json', () => {
       )
     ])
 
-    // Two valid outcomes: (a) both succeed because the loser's existence
-    // check ran BEFORE the winner extracted, OR (b) one succeeds and the
-    // other reports already-installed (EXIT.filesystem).
-    // Either way, inventory must end up coherent (single item, single
-    // target — no duplicates).
     const codes = [r1.exitCode, r2.exitCode].sort((a, b) => a - b)
-    expect(codes[0]).toBe(0) // at least one succeeded
-    const otherCode = codes[1]!
-    expect([0, 4]).toContain(otherCode) // other either succeeded or got conflict
+    expect(codes).toEqual([0, 4])
 
     const inv = JSON.parse(
       await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8')

--- a/cli/test/integration/concurrency.test.ts
+++ b/cli/test/integration/concurrency.test.ts
@@ -9,7 +9,7 @@
  * The unit test in test/unit/stores/inventory-store.test.ts pins the
  * single-process lock recovery; here we cover the cross-process case.
  */
-import { mkdir, readFile, utimes } from 'node:fs/promises'
+import { access, mkdir, readFile, readdir, utimes } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { zipSync, strToU8 } from 'fflate'
@@ -73,6 +73,9 @@ describe('cross-process concurrency on inventory.json', () => {
     ) as { items: Array<{ slug: string }> }
     const slugs = inv.items.map(i => i.slug).sort()
     expect(slugs).toEqual(['first', 'second'])
+    await expect(access(staleLockPath)).rejects.toThrow()
+    expect((await readdir(join(env.home, '.skillhub')))
+      .filter(name => name.startsWith('inventory.json.') && name.endsWith('.tmp'))).toEqual([])
   })
 
   test('two parallel installs of the same slug to the same dir: exactly one wins, one conflicts', async () => {

--- a/cli/test/integration/concurrency.test.ts
+++ b/cli/test/integration/concurrency.test.ts
@@ -113,14 +113,12 @@ describe('cross-process concurrency on inventory.json', () => {
     })
     await runCli(['login', '--registry', registry.url, '--token', 'sk_ok'], { HOME: env.home, USERPROFILE: env.home })
 
-    // Plant a stale lock file: PID 1 (init, never the same as our test
-    // child, and won't match the spawned subprocess's PID), with a very
-    // old timestamp so the store treats it as stale.
+    // Plant a stale lock file owned by a PID that does not exist.
     const skillhubDir = join(env.home, '.skillhub')
     await mkdir(skillhubDir, { recursive: true })
     const lockPath = join(skillhubDir, 'inventory.json.lock')
     const ancientTimestamp = Date.now() - 600_000 // 10 minutes ago — past the 30s stale threshold
-    await writeFile(lockPath, JSON.stringify({ pid: 1, timestamp: ancientTimestamp }))
+    await writeFile(lockPath, JSON.stringify({ pid: 999999, timestamp: ancientTimestamp }))
 
     const installDir = join(env.cwd, 'stale')
     await mkdir(installDir, { recursive: true })

--- a/cli/test/integration/concurrency.test.ts
+++ b/cli/test/integration/concurrency.test.ts
@@ -9,7 +9,7 @@
  * The unit test in test/unit/stores/inventory-store.test.ts pins the
  * single-process lock recovery; here we cover the cross-process case.
  */
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, utimes } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { zipSync, strToU8 } from 'fflate'
@@ -28,7 +28,7 @@ function makeSkillZip(): Uint8Array {
 }
 
 describe('cross-process concurrency on inventory.json', () => {
-  test('two parallel installs of distinct slugs preserve both inventory items', async () => {
+  test('two parallel installs recover the same stale lock and preserve both inventory items', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({
       token: 'sk_ok',
@@ -39,6 +39,11 @@ describe('cross-process concurrency on inventory.json', () => {
       ]
     })
     await runCli(['login', '--registry', registry.url, '--token', 'sk_ok'], { HOME: env.home, USERPROFILE: env.home })
+
+    const staleLockPath = join(env.home, '.skillhub', 'inventory.json.lock')
+    await mkdir(staleLockPath)
+    const staleTime = new Date(Date.now() - 60_000)
+    await utimes(staleLockPath, staleTime, staleTime)
 
     const dirA = join(env.cwd, 'A')
     const dirB = join(env.cwd, 'B')
@@ -113,12 +118,13 @@ describe('cross-process concurrency on inventory.json', () => {
     })
     await runCli(['login', '--registry', registry.url, '--token', 'sk_ok'], { HOME: env.home, USERPROFILE: env.home })
 
-    // Plant a stale lock file owned by a PID that does not exist.
+    // Plant a stale proper-lockfile directory.
     const skillhubDir = join(env.home, '.skillhub')
     await mkdir(skillhubDir, { recursive: true })
     const lockPath = join(skillhubDir, 'inventory.json.lock')
-    const ancientTimestamp = Date.now() - 600_000 // 10 minutes ago — past the 30s stale threshold
-    await writeFile(lockPath, JSON.stringify({ pid: 999999, timestamp: ancientTimestamp }))
+    await mkdir(lockPath)
+    const staleTime = new Date(Date.now() - 60_000)
+    await utimes(lockPath, staleTime, staleTime)
 
     const installDir = join(env.cwd, 'stale')
     await mkdir(installDir, { recursive: true })

--- a/cli/test/integration/help-command.test.ts
+++ b/cli/test/integration/help-command.test.ts
@@ -34,6 +34,23 @@ describe('help command', () => {
     expect(result.stdout).toContain('skillhub search')
   })
 
+  test('distinguishes skill upgrade from CLI self-update and namespace sync', async () => {
+    const upgrade = await runCli(['help', 'upgrade'])
+    expect(upgrade.exitCode).toBe(0)
+    expect(upgrade.stdout).toContain('Upgrade explicitly selected installed skills')
+    expect(upgrade.stdout).toContain('skillhub upgrade <coordinate...>')
+    expect(upgrade.stdout).toContain('--check')
+    expect(upgrade.stdout).toContain('--force')
+
+    const update = await runCli(['help', 'update'])
+    expect(update.exitCode).toBe(0)
+    expect(update.stdout).toContain('Check or update CLI itself')
+
+    const sync = await runCli(['help', 'sync'])
+    expect(sync.exitCode).toBe(0)
+    expect(sync.stdout).toContain('namespace workspaces')
+  })
+
   // P1: bare `skillhub help` (no topic) prints the directory of all commands
   test('bare help lists all commands in human format', async () => {
     const result = await runCli(['help'])

--- a/cli/test/integration/publish-command.test.ts
+++ b/cli/test/integration/publish-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
@@ -115,6 +115,25 @@ describe('publish command — P0', () => {
     expect(registry.received.publish!.namespace).toBe('global')
     expect(registry.received.publish!.fileName).toMatch(/\.zip$/)
     expect(registry.received.publish!.visibility).toBe('PUBLIC')
+  })
+
+  test('directory publish excludes local SkillHub installation metadata', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok' })
+    await login(env, registry.url)
+
+    const dir = await makeTempDir(['SKILL.md', '# Demo'])
+    await mkdir(join(dir, '.skillhub'), { recursive: true })
+    await writeFile(join(dir, '.skillhub', 'metadata.json'), '{"registry":"private"}')
+
+    const result = await runCli(['publish', dir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(registry.received.publish!.archiveEntries).toContain('SKILL.md')
+    expect(registry.received.publish!.archiveEntries.some(path => path.startsWith('.skillhub'))).toBe(false)
   })
 
   test('zip file happy path: exit 0, fileName matches passed file', async () => {

--- a/cli/test/integration/publish-command.test.ts
+++ b/cli/test/integration/publish-command.test.ts
@@ -261,7 +261,6 @@ describe('publish command — P1', () => {
 // P1 — content shape: directory layout and edge files
 // ---------------------------------------------------------------------------
 
-import { mkdir } from 'node:fs/promises'
 import { unzipSync, strFromU8 } from 'fflate'
 
 describe('publish command — content shape', () => {

--- a/cli/test/integration/sync-command.test.ts
+++ b/cli/test/integration/sync-command.test.ts
@@ -8,6 +8,7 @@ import { runCli } from '../helpers/run-cli'
 import { createTempHome } from '../helpers/temp-env'
 import { SkillHubClient } from '../../src/clients/skillhub-client'
 import { pullNamespace } from '../../src/services/sync-service'
+import { renderPullResult } from '../../src/commands/sync'
 
 function makeSkill(body: string): { zipBytes: Uint8Array; fingerprint: string } {
   const content = strToU8(body)
@@ -47,6 +48,8 @@ describe('sync command', () => {
         slug: 'demo',
         message: 'target lock cleanup failed: simulated release failure'
       }])
+      expect(JSON.parse(renderPullResult(result, true, false)).warnings).toEqual(result.warnings)
+      expect(renderPullResult(result, false, false)).toContain('warning    demo: target lock cleanup failed')
     } finally {
       registry.stop()
     }

--- a/cli/test/integration/sync-command.test.ts
+++ b/cli/test/integration/sync-command.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from 'bun:test'
 import { startFakeRegistry, type FakeSkill } from '../helpers/fake-registry'
 import { runCli } from '../helpers/run-cli'
 import { createTempHome } from '../helpers/temp-env'
+import { SkillHubClient } from '../../src/clients/skillhub-client'
+import { pullNamespace } from '../../src/services/sync-service'
 
 function makeSkill(body: string): { zipBytes: Uint8Array; fingerprint: string } {
   const content = strToU8(body)
@@ -15,6 +17,41 @@ function makeSkill(body: string): { zipBytes: Uint8Array; fingerprint: string } 
 }
 
 describe('sync command', () => {
+  test('pull propagates committed install warnings', async () => {
+    const env = await createTempHome()
+    const skillsDir = join(env.cwd, 'team-skills')
+    const fixture = makeSkill('---\nname: demo\ndescription: Demo\nversion: 1.0.0\n---\n')
+    const registry = await startFakeRegistry({
+      token: 'token',
+      skills: [{ namespace: 'team-a', slug: 'demo', ...fixture }]
+    })
+
+    try {
+      const result = await pullNamespace({
+        client: new SkillHubClient(registry.url, 'token'),
+        registry: registry.url,
+        token: 'token',
+        namespace: 'team-a',
+        rootDir: skillsDir,
+        check: false,
+        prune: false,
+        force: false,
+        installSkillFn: async () => ({
+          installed: [{ agent: 'workspace', dir: join(skillsDir, 'demo') }],
+          warnings: ['target lock cleanup failed: simulated release failure']
+        })
+      })
+
+      expect(result.actions).toEqual([{ slug: 'demo', action: 'installed' }])
+      expect(result.warnings).toEqual([{
+        slug: 'demo',
+        message: 'target lock cleanup failed: simulated release failure'
+      }])
+    } finally {
+      registry.stop()
+    }
+  })
+
   test('pull installs a namespace incrementally and writes workspace metadata', async () => {
     const env = await createTempHome()
     const skillsDir = join(env.cwd, 'team-skills')

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -169,8 +169,9 @@ describe('upgrade command', () => {
     })
     await writeFile(join(rootDir, 'late-edit', 'SKILL.md'), '# edited after planning')
 
-    await expect(executeSkillUpgradePlan(plan, { home: env.home, tokenForRegistry }))
-      .rejects.toThrow('local changes detected after upgrade planning')
+    const result = await executeSkillUpgradePlan(plan, { home: env.home, tokenForRegistry })
+    expect(result.items[0]).toMatchObject({ action: 'failed' })
+    expect(result.items[0]?.reason).toContain('local changes detected after upgrade planning')
     expect(await readFile(join(rootDir, 'late-edit', 'SKILL.md'), 'utf-8'))
       .toBe('# edited after planning')
     const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
@@ -211,8 +212,9 @@ describe('upgrade command', () => {
     const skillDir = join(rootDir, 'removed-late')
     await rm(skillDir, { recursive: true })
 
-    await expect(executeSkillUpgradePlan(plan, { home: env.home, tokenForRegistry }))
-      .rejects.toThrow('installed target disappeared before upgrade commit')
+    const result = await executeSkillUpgradePlan(plan, { home: env.home, tokenForRegistry })
+    expect(result.items[0]).toMatchObject({ action: 'failed' })
+    expect(result.items[0]?.reason).toContain('installed target disappeared before upgrade commit')
     expect(await exists(skillDir)).toBe(false)
     const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
     expect(inventory.items[0]).toMatchObject({ version: '1.0.0', fingerprint: 'fp-v1' })

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { strToU8, zipSync } from 'fflate'
@@ -16,6 +16,15 @@ afterEach(() => {
 
 function makeSkillZip(content: string): Uint8Array {
   return zipSync({ 'SKILL.md': strToU8(content) })
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
 }
 
 describe('upgrade command', () => {
@@ -162,6 +171,47 @@ describe('upgrade command', () => {
       .rejects.toThrow('local changes detected after upgrade planning')
     expect(await readFile(join(rootDir, 'late-edit', 'SKILL.md'), 'utf-8'))
       .toBe('# edited after planning')
+    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items[0]).toMatchObject({ version: '1.0.0', fingerprint: 'fp-v1' })
+  })
+
+  test('a target removed after planning is not recreated by upgrade', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'global',
+      slug: 'removed-late',
+      version: '1.0.0',
+      versionId: 1,
+      fingerprint: 'fp-v1',
+      zipBytes: makeSkillZip('# v1')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/removed-late', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    }, { cwd: env.cwd })
+
+    skill.version = '1.1.0'
+    skill.versionId = 2
+    skill.fingerprint = 'fp-v2'
+    skill.zipBytes = makeSkillZip('# v2')
+    const tokenForRegistry = async () => undefined
+    const plan = await planSkillUpgrades({
+      coordinates: ['@global/removed-late'],
+      registry: registry.url,
+      force: false,
+      home: env.home,
+      tokenForRegistry
+    })
+    const skillDir = join(rootDir, 'removed-late')
+    await rm(skillDir, { recursive: true })
+
+    await expect(executeSkillUpgradePlan(plan, { home: env.home, tokenForRegistry }))
+      .rejects.toThrow('installed target disappeared before upgrade commit')
+    expect(await exists(skillDir)).toBe(false)
     const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
     expect(inventory.items[0]).toMatchObject({ version: '1.0.0', fingerprint: 'fp-v1' })
   })

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { isAbsolute, join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { strToU8, zipSync } from 'fflate'
@@ -242,6 +242,10 @@ describe('upgrade command', () => {
     expect(isAbsolute(inventory.items[0].targets[0].rootDir)).toBe(true)
     expect(inventory.items[0].targets[0].installDir)
       .toBe(join(inventory.items[0].targets[0].rootDir, 'portable'))
+    expect(await realpath(inventory.items[0].targets[0].rootDir))
+      .toBe(await realpath(join(env.cwd, 'skills')))
+    expect(await realpath(inventory.items[0].targets[0].installDir))
+      .toBe(await realpath(join(env.cwd, 'skills', 'portable')))
 
     inventory.items[0].targets[0].rootDir = 'skills'
     inventory.items[0].targets[0].installDir = join('skills', 'portable')

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -44,7 +44,7 @@ describe('upgrade command', () => {
     skill.zipBytes = makeSkillZip('# v2')
 
     const checked = await runCli([
-      'upgrade', '@global/skillhub-registry', '--registry', registry.url, '--check', '--json'
+      'upgrade', '@global/skillhub-registry', '--registry', registry.url, '--dir', rootDir, '--check', '--json'
     ], { HOME: env.home, USERPROFILE: env.home })
     expect(checked.exitCode).toBe(0)
     expect(JSON.parse(checked.stdout).items[0]).toMatchObject({
@@ -69,6 +69,9 @@ describe('upgrade command', () => {
       'utf-8'
     ))
     expect(metadata).toMatchObject({ schemaVersion: 1, version: '1.1.0', versionId: 2, fingerprint: 'fp-v2' })
+    expect(Object.keys(metadata.files)).toContain('SKILL.md')
+    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items[0]).toMatchObject({ version: '1.1.0', fingerprint: 'fp-v2' })
   })
 
   test('local changes block by default and --force replaces only the same source', async () => {
@@ -95,7 +98,7 @@ describe('upgrade command', () => {
     skill.zipBytes = makeSkillZip('# v2')
 
     const blocked = await runCli([
-      'upgrade', '@team/code-review', '--registry', registry.url, '--check', '--json'
+      'upgrade', '@team/code-review', '--registry', registry.url, '--agent', 'custom', '--check', '--json'
     ], { HOME: env.home, USERPROFILE: env.home })
     expect(blocked.exitCode).toBe(6)
     expect(JSON.parse(blocked.stdout).items[0]).toMatchObject({ action: 'blocked' })
@@ -175,6 +178,13 @@ describe('upgrade command', () => {
     })
     expect(selected.exitCode).toBe(0)
     expect(selected.stdout).toContain('@team-a/demo')
+
+    const noNamespaceMatch = await runCli(['upgrade', 'demo', '--namespace', 'missing', '--check'], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    expect(noNamespaceMatch.exitCode).toBe(5)
+    expect(noNamespaceMatch.stderr).toContain('not installed')
   })
 
   test('one resolved archive is reused for every managed target', async () => {
@@ -214,6 +224,13 @@ describe('upgrade command', () => {
     expect(registry.received.downloads).toBe(2)
     expect(await readFile(join(env.home, '.codex', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
     expect(await readFile(join(env.home, '.claude', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items[0]).toMatchObject({ version: '1.1.0', fingerprint: 'fp-v2' })
+    expect(inventory.items[0].targets).toHaveLength(2)
+
+    const listed = await runCli(['list', '--json'], { HOME: env.home, USERPROFILE: env.home })
+    expect(listed.exitCode).toBe(0)
+    expect(JSON.parse(listed.stdout).items[0]).toMatchObject({ version: '1.1.0' })
   })
 
   test('never downgrades when the registry latest version moves backwards', async () => {
@@ -313,6 +330,9 @@ describe('upgrade command', () => {
     ], { HOME: env.home, USERPROFILE: env.home })
     expect(migrated.exitCode).toBe(0)
     expect(await readFile(join(rootDir, 'legacy', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    const migratedMetadata = JSON.parse(await readFile(metadataPath, 'utf-8'))
+    expect(migratedMetadata.schemaVersion).toBe(1)
+    expect(Object.keys(migratedMetadata.files)).toContain('SKILL.md')
   })
 
   test('never installs a missing skill and never offers an implicit upgrade-all', async () => {
@@ -333,5 +353,54 @@ describe('upgrade command', () => {
     ], { HOME: env.home, USERPROFILE: env.home })
     expect(tooMany.exitCode).toBe(5)
     expect(tooMany.stderr).toContain('at most 50')
+  })
+
+  test('accepts exactly fifty explicitly installed coordinates', async () => {
+    const env = await createTempHome()
+    const skills = Array.from({ length: 50 }, (_, index) => ({
+      namespace: 'global',
+      slug: `skill-${index}`,
+      version: '1.0.0',
+      fingerprint: `fp-${index}`,
+      zipBytes: makeSkillZip(`# skill ${index}`)
+    }))
+    const registry = await startFakeRegistry({ skills })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    const items = []
+    for (const skill of skills) {
+      const skillDir = join(rootDir, skill.slug)
+      await mkdir(join(skillDir, '.skillhub'), { recursive: true })
+      await writeFile(join(skillDir, 'SKILL.md'), `# ${skill.slug}`)
+      await writeFile(join(skillDir, '.skillhub', 'metadata.json'), JSON.stringify({
+        registry: registry.url,
+        namespace: skill.namespace,
+        slug: skill.slug,
+        version: skill.version,
+        fingerprint: skill.fingerprint,
+        source: 'skillhub'
+      }))
+      items.push({
+        registry: registry.url,
+        namespace: skill.namespace,
+        slug: skill.slug,
+        version: skill.version,
+        fingerprint: skill.fingerprint,
+        targets: [{
+          agent: 'custom', rootDir, installDir: skillDir, installedAt: '2026-09-01T00:00:00Z'
+        }]
+      })
+    }
+    await mkdir(join(env.home, '.skillhub'), { recursive: true })
+    await writeFile(join(env.home, '.skillhub', 'inventory.json'), JSON.stringify({ items }))
+
+    const result = await runCli([
+      'upgrade', ...skills.map(skill => `@global/${skill.slug}`),
+      '--registry', registry.url, '--force', '--check', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(result.exitCode).toBe(0)
+    expect(JSON.parse(result.stdout).summary).toMatchObject({ unchanged: 50, blocked: 0 })
+    expect(registry.received.downloads).toBe(0)
   })
 })

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -1,0 +1,224 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { strToU8, zipSync } from 'fflate'
+import { createTempHome } from '../helpers/temp-env'
+import { startFakeRegistry } from '../helpers/fake-registry'
+import { runCli } from '../helpers/run-cli'
+
+let registries: Array<Awaited<ReturnType<typeof startFakeRegistry>>> = []
+
+afterEach(() => {
+  for (const registry of registries) registry.stop()
+  registries = []
+})
+
+function makeSkillZip(content: string): Uint8Array {
+  return zipSync({ 'SKILL.md': strToU8(content) })
+}
+
+describe('upgrade command', () => {
+  test('check is side-effect free and execute upgrades an installed skill', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'global',
+      slug: 'skillhub-registry',
+      version: '1.0.0',
+      versionId: 1,
+      fingerprint: 'fp-v1',
+      zipBytes: makeSkillZip('# v1')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+
+    const installed = await runCli([
+      'install', '@global/skillhub-registry', '--dir', rootDir, '--registry', registry.url
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(installed.exitCode).toBe(0)
+
+    skill.version = '1.1.0'
+    skill.versionId = 2
+    skill.fingerprint = 'fp-v2'
+    skill.zipBytes = makeSkillZip('# v2')
+
+    const checked = await runCli([
+      'upgrade', '@global/skillhub-registry', '--registry', registry.url, '--check', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(checked.exitCode).toBe(0)
+    expect(JSON.parse(checked.stdout).items[0]).toMatchObject({
+      coordinate: '@global/skillhub-registry',
+      currentVersion: '1.0.0',
+      remoteVersion: '1.1.0',
+      action: 'upgrade'
+    })
+    expect(await readFile(join(rootDir, 'skillhub-registry', 'SKILL.md'), 'utf-8')).toBe('# v1')
+    expect(registry.received.downloads).toBe(1)
+
+    const upgraded = await runCli([
+      'upgrade', '@global/skillhub-registry', '--registry', registry.url, '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(upgraded.exitCode).toBe(0)
+    expect(JSON.parse(upgraded.stdout).items[0].action).toBe('upgraded')
+    expect(await readFile(join(rootDir, 'skillhub-registry', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    expect(registry.received.downloads).toBe(2)
+
+    const metadata = JSON.parse(await readFile(
+      join(rootDir, 'skillhub-registry', '.skillhub', 'metadata.json'),
+      'utf-8'
+    ))
+    expect(metadata).toMatchObject({ schemaVersion: 1, version: '1.1.0', versionId: 2, fingerprint: 'fp-v2' })
+  })
+
+  test('local changes block by default and --force replaces only the same source', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'team',
+      slug: 'code-review',
+      version: '1.0.0',
+      fingerprint: 'fp-v1',
+      zipBytes: makeSkillZip('# v1')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@team/code-review', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    await writeFile(join(rootDir, 'code-review', 'SKILL.md'), '# locally edited')
+    skill.version = '1.1.0'
+    skill.fingerprint = 'fp-v2'
+    skill.zipBytes = makeSkillZip('# v2')
+
+    const blocked = await runCli([
+      'upgrade', '@team/code-review', '--registry', registry.url, '--check', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(blocked.exitCode).toBe(6)
+    expect(JSON.parse(blocked.stdout).items[0]).toMatchObject({ action: 'blocked' })
+    expect(JSON.parse(blocked.stdout).items[0].reason).toContain('local changes')
+    expect(await readFile(join(rootDir, 'code-review', 'SKILL.md'), 'utf-8')).toBe('# locally edited')
+
+    const forced = await runCli([
+      'upgrade', '@team/code-review', '--registry', registry.url, '--force', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(forced.exitCode).toBe(0)
+    expect(await readFile(join(rootDir, 'code-review', 'SKILL.md'), 'utf-8')).toBe('# v2')
+  })
+
+  test('source conflict is a hard block even with --force', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'global',
+      slug: 'demo',
+      version: '1.0.0',
+      fingerprint: 'fp-v1',
+      zipBytes: makeSkillZip('# v1')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/demo', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    const metadataPath = join(rootDir, 'demo', '.skillhub', 'metadata.json')
+    const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'))
+    metadata.namespace = 'another-team'
+    await writeFile(metadataPath, JSON.stringify(metadata))
+    skill.version = '2.0.0'
+    skill.fingerprint = 'fp-v2'
+
+    const result = await runCli([
+      'upgrade', '@global/demo', '--registry', registry.url, '--force', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(result.exitCode).toBe(6)
+    expect(JSON.parse(result.stdout).items[0].reason).toContain('source-conflict')
+    expect(await readFile(join(rootDir, 'demo', 'SKILL.md'), 'utf-8')).toBe('# v1')
+  })
+
+  test('a bare slug must identify exactly one installed source', async () => {
+    const env = await createTempHome()
+    const skillA = { namespace: 'team-a', slug: 'demo', version: '1.0.0', fingerprint: 'a', zipBytes: makeSkillZip('# A') }
+    const skillB = { namespace: 'team-b', slug: 'demo', version: '1.0.0', fingerprint: 'b', zipBytes: makeSkillZip('# B') }
+    const registryA = await startFakeRegistry({ skills: [skillA] })
+    const registryB = await startFakeRegistry({ skills: [skillB] })
+    registries.push(registryA, registryB)
+    const rootA = join(env.cwd, 'a')
+    const rootB = join(env.cwd, 'b')
+    await mkdir(rootA, { recursive: true })
+    await mkdir(rootB, { recursive: true })
+    await runCli(['install', '@team-a/demo', '--dir', rootA, '--registry', registryA.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    await runCli(['install', '@team-b/demo', '--dir', rootB, '--registry', registryB.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    const ambiguous = await runCli(['upgrade', 'demo', '--check'], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    expect(ambiguous.exitCode).toBe(5)
+    expect(ambiguous.stderr).toContain('ambiguous')
+
+    const selected = await runCli(['upgrade', 'demo', '--namespace', 'team-a', '--registry', registryA.url, '--check'], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    expect(selected.exitCode).toBe(0)
+    expect(selected.stdout).toContain('@team-a/demo')
+  })
+
+  test('one resolved archive is reused for every managed target', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'global',
+      slug: 'shared',
+      version: '1.0.0',
+      fingerprint: 'fp-v1',
+      zipBytes: makeSkillZip('# v1')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+
+    const installed = await runCli([
+      'install', '@global/shared', '--agent', 'codex', '--agent', 'claude-code', '--registry', registry.url
+    ], { HOME: env.home, USERPROFILE: env.home }, { cwd: env.cwd })
+    expect(installed.exitCode).toBe(0)
+    expect(registry.received.downloads).toBe(1)
+
+    skill.version = '1.1.0'
+    skill.fingerprint = 'fp-v2'
+    skill.zipBytes = makeSkillZip('# v2')
+    const upgraded = await runCli(['upgrade', '@global/shared', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    }, { cwd: env.cwd })
+    expect(upgraded.exitCode).toBe(0)
+    expect(registry.received.downloads).toBe(2)
+    expect(await readFile(join(env.cwd, '.codex', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    expect(await readFile(join(env.cwd, '.claude', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
+  })
+
+  test('never installs a missing skill and never offers an implicit upgrade-all', async () => {
+    const env = await createTempHome()
+    const missing = await runCli(['upgrade', '@global/missing', '--check'], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    expect(missing.exitCode).toBe(5)
+    expect(missing.stderr).toContain('use skillhub install')
+
+    const empty = await runCli(['upgrade'], { HOME: env.home, USERPROFILE: env.home })
+    expect(empty.exitCode).toBe(5)
+    expect(empty.stderr).toContain('at least one')
+  })
+})

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -6,6 +6,8 @@ import { createTempHome } from '../helpers/temp-env'
 import { startFakeRegistry } from '../helpers/fake-registry'
 import { runCli } from '../helpers/run-cli'
 import { executeSkillUpgradePlan, planSkillUpgrades } from '../../src/services/upgrade-service'
+import { installSkill } from '../../src/services/install-service'
+import { renderUpgradeResult } from '../../src/commands/upgrade'
 
 let registries: Array<Awaited<ReturnType<typeof startFakeRegistry>>> = []
 
@@ -573,6 +575,49 @@ describe('upgrade command', () => {
     expect(inventory.items.find((item: { slug: string }) => item.slug === 'second').version).toBe('1.0.0')
     expect(inventory.items.find((item: { slug: string }) => item.slug === 'third').version).toBe('1.0.0')
     expect(registry.received.downloads).toBe(5)
+  })
+
+  test('a committed upgrade keeps success and renders a post-commit warning', async () => {
+    const env = await createTempHome()
+    const skill = { namespace: 'global', slug: 'warned', version: '1.0.0', fingerprint: 'v1', zipBytes: makeSkillZip('# v1') }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/warned', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    skill.version = '1.1.0'
+    skill.fingerprint = 'v2'
+    skill.zipBytes = makeSkillZip('# v2')
+    const tokenForRegistry = async () => undefined
+    const plan = await planSkillUpgrades({
+      coordinates: ['@global/warned'],
+      registry: registry.url,
+      force: false,
+      home: env.home,
+      tokenForRegistry
+    })
+
+    const result = await executeSkillUpgradePlan(plan, {
+      home: env.home,
+      tokenForRegistry,
+      installSkillFn: options => installSkill({
+        ...options,
+        acquireTargetLock: async () => async () => { throw new Error('simulated release failure') }
+      })
+    })
+
+    expect(result).toMatchObject({ upgraded: 1, failed: 0 })
+    expect(result.items[0]).toMatchObject({ action: 'upgraded' })
+    expect(result.items[0]?.warnings).toEqual(['target lock cleanup failed: simulated release failure'])
+    expect(JSON.parse(renderUpgradeResult(plan, result, true)).items[0].warnings).toHaveLength(1)
+    expect(renderUpgradeResult(plan, result, false)).toContain('upgraded')
+    expect(renderUpgradeResult(plan, result, false)).toContain('[warning: target lock cleanup failed')
+    expect(await readFile(join(rootDir, 'warned', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items[0]).toMatchObject({ version: '1.1.0', fingerprint: 'v2' })
   })
 
   test('legacy metadata without a file baseline requires explicit force migration', async () => {

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -530,6 +530,46 @@ describe('upgrade command', () => {
     expect(await readFile(join(rootDir, 'first', 'SKILL.md'), 'utf-8')).toBe('# first v1')
   })
 
+  test('a runtime batch failure reports committed, failed, and unattempted skills', async () => {
+    const env = await createTempHome()
+    const first = { namespace: 'global', slug: 'first', version: '1.0.0', fingerprint: 'first-v1', zipBytes: makeSkillZip('# first v1') }
+    const second = { namespace: 'global', slug: 'second', version: '1.0.0', fingerprint: 'second-v1', zipBytes: makeSkillZip('# second v1') }
+    const third = { namespace: 'global', slug: 'third', version: '1.0.0', fingerprint: 'third-v1', zipBytes: makeSkillZip('# third v1') }
+    const registry = await startFakeRegistry({ skills: [first, second, third] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    for (const slug of ['first', 'second', 'third']) {
+      await runCli(['install', `@global/${slug}`, '--dir', rootDir, '--registry', registry.url], {
+        HOME: env.home,
+        USERPROFILE: env.home
+      })
+    }
+
+    first.version = '1.1.0'
+    first.fingerprint = 'first-v2'
+    first.zipBytes = makeSkillZip('# first v2')
+    second.version = '1.1.0'
+    second.fingerprint = 'second-v2'
+    second.zipBytes = strToU8('not a zip archive')
+    third.version = '1.1.0'
+    third.fingerprint = 'third-v2'
+    third.zipBytes = makeSkillZip('# third v2')
+
+    const result = await runCli([
+      'upgrade', '@global/first', '@global/second', '@global/third',
+      '--registry', registry.url, '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(result.exitCode).toBe(1)
+    const output = JSON.parse(result.stdout)
+    expect(output.summary).toEqual({ upgraded: 1, unchanged: 0, failed: 1, notAttempted: 1 })
+    expect(output.items.map((item: { action: string }) => item.action))
+      .toEqual(['upgraded', 'failed', 'not-attempted'])
+    expect(await readFile(join(rootDir, 'first', 'SKILL.md'), 'utf-8')).toBe('# first v2')
+    expect(await readFile(join(rootDir, 'second', 'SKILL.md'), 'utf-8')).toBe('# second v1')
+    expect(await readFile(join(rootDir, 'third', 'SKILL.md'), 'utf-8')).toBe('# third v1')
+  })
+
   test('legacy metadata without a file baseline requires explicit force migration', async () => {
     const env = await createTempHome()
     const skill = { namespace: 'global', slug: 'legacy', version: '1.0.0', fingerprint: 'v1', zipBytes: makeSkillZip('# v1') }

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -187,6 +187,47 @@ describe('upgrade command', () => {
     expect(noNamespaceMatch.stderr).toContain('not installed')
   })
 
+  test('target filters select deterministically and missing matches never install', async () => {
+    const env = await createTempHome()
+    const skill = { namespace: 'global', slug: 'filtered', version: '1.0.0', fingerprint: 'fp', zipBytes: makeSkillZip('# v1') }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/filtered', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    for (const args of [
+      ['--dir', rootDir],
+      ['--agent', 'custom'],
+      ['--namespace', 'global'],
+      ['--registry', registry.url]
+    ]) {
+      const result = await runCli(['upgrade', 'filtered', ...args, '--force', '--check'], {
+        HOME: env.home,
+        USERPROFILE: env.home
+      })
+      expect(result.exitCode).toBe(0)
+    }
+
+    for (const args of [
+      ['--dir', join(env.cwd, 'missing')],
+      ['--agent', 'codex'],
+      ['--namespace', 'missing'],
+      ['--registry', 'http://unmatched.invalid']
+    ]) {
+      const result = await runCli(['upgrade', 'filtered', ...args, '--check'], {
+        HOME: env.home,
+        USERPROFILE: env.home
+      })
+      expect(result.exitCode).toBe(5)
+      expect(result.stderr).toContain('not installed')
+    }
+    expect(registry.received.downloads).toBe(1)
+  })
+
   test('one resolved archive is reused for every managed target', async () => {
     const env = await createTempHome()
     const skill = {
@@ -263,6 +304,39 @@ describe('upgrade command', () => {
     expect(result.exitCode).toBe(6)
     expect(JSON.parse(result.stdout).items[0].reason).toContain('older')
     expect(await readFile(join(rootDir, 'stable', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    expect(registry.received.downloads).toBe(1)
+  })
+
+  test('keeps local files when resolve is unavailable or same-version content drifts', async () => {
+    const env = await createTempHome()
+    const failures: { resolve?: 'server_error' } = {}
+    const skill = { namespace: 'global', slug: 'resilient', version: '1.0.0', fingerprint: 'fp-v1', zipBytes: makeSkillZip('# v1') }
+    const registry = await startFakeRegistry({ skills: [skill], failures })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/resilient', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    failures.resolve = 'server_error'
+    const unavailable = await runCli([
+      'upgrade', '@global/resilient', '--registry', registry.url, '--force', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(unavailable.exitCode).toBe(6)
+    expect(JSON.parse(unavailable.stdout).items[0].action).toBe('blocked')
+    expect(await readFile(join(rootDir, 'resilient', 'SKILL.md'), 'utf-8')).toBe('# v1')
+
+    delete failures.resolve
+    skill.fingerprint = 'fp-drift'
+    skill.zipBytes = makeSkillZip('# changed without version bump')
+    const drifted = await runCli([
+      'upgrade', '@global/resilient', '--registry', registry.url, '--force', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(drifted.exitCode).toBe(6)
+    expect(JSON.parse(drifted.stdout).items[0].reason).toContain('without a newer version')
+    expect(await readFile(join(rootDir, 'resilient', 'SKILL.md'), 'utf-8')).toBe('# v1')
     expect(registry.received.downloads).toBe(1)
   })
 

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -198,14 +198,121 @@ describe('upgrade command', () => {
     skill.version = '1.1.0'
     skill.fingerprint = 'fp-v2'
     skill.zipBytes = makeSkillZip('# v2')
+
+    const partial = await runCli([
+      'upgrade', '@global/shared', '--registry', registry.url, '--agent', 'codex', '--check', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home }, { cwd: env.cwd })
+    expect(partial.exitCode).toBe(6)
+    expect(JSON.parse(partial.stdout).items[0].reason).toContain('partial-target')
+    expect(registry.received.downloads).toBe(1)
+
     const upgraded = await runCli(['upgrade', '@global/shared', '--registry', registry.url], {
       HOME: env.home,
       USERPROFILE: env.home
     }, { cwd: env.cwd })
     expect(upgraded.exitCode).toBe(0)
     expect(registry.received.downloads).toBe(2)
-    expect(await readFile(join(env.cwd, '.codex', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
-    expect(await readFile(join(env.cwd, '.claude', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    expect(await readFile(join(env.home, '.codex', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    expect(await readFile(join(env.home, '.claude', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
+  })
+
+  test('never downgrades when the registry latest version moves backwards', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'global',
+      slug: 'stable',
+      version: '2.0.0',
+      versionId: 2,
+      fingerprint: 'fp-v2',
+      zipBytes: makeSkillZip('# v2')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/stable', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+
+    skill.version = '1.0.0'
+    skill.versionId = 1
+    skill.fingerprint = 'fp-v1'
+    skill.zipBytes = makeSkillZip('# v1')
+
+    const result = await runCli([
+      'upgrade', '@global/stable', '--registry', registry.url, '--force', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(result.exitCode).toBe(6)
+    expect(JSON.parse(result.stdout).items[0].reason).toContain('older')
+    expect(await readFile(join(rootDir, 'stable', 'SKILL.md'), 'utf-8')).toBe('# v2')
+    expect(registry.received.downloads).toBe(1)
+  })
+
+  test('a blocked batch reports a plan and does not claim successful writes', async () => {
+    const env = await createTempHome()
+    const first = { namespace: 'global', slug: 'first', version: '1.0.0', fingerprint: 'first-v1', zipBytes: makeSkillZip('# first v1') }
+    const second = { namespace: 'global', slug: 'second', version: '1.0.0', fingerprint: 'second-v1', zipBytes: makeSkillZip('# second v1') }
+    const registry = await startFakeRegistry({ skills: [first, second] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    for (const slug of ['first', 'second']) {
+      await runCli(['install', `@global/${slug}`, '--dir', rootDir, '--registry', registry.url], {
+        HOME: env.home,
+        USERPROFILE: env.home
+      })
+    }
+
+    first.version = '1.1.0'
+    first.fingerprint = 'first-v2'
+    first.zipBytes = makeSkillZip('# first v2')
+    second.version = '1.1.0'
+    second.fingerprint = 'second-v2'
+    second.zipBytes = makeSkillZip('# second v2')
+    await writeFile(join(rootDir, 'second', 'SKILL.md'), '# local change')
+
+    const result = await runCli([
+      'upgrade', '@global/first', '@global/second', '--registry', registry.url, '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(result.exitCode).toBe(6)
+    const output = JSON.parse(result.stdout)
+    expect(output.items.find((item: { coordinate: string }) => item.coordinate.endsWith('/first')).action).toBe('upgrade')
+    expect(output.items.find((item: { coordinate: string }) => item.coordinate.endsWith('/second')).action).toBe('blocked')
+    expect(await readFile(join(rootDir, 'first', 'SKILL.md'), 'utf-8')).toBe('# first v1')
+  })
+
+  test('legacy metadata without a file baseline requires explicit force migration', async () => {
+    const env = await createTempHome()
+    const skill = { namespace: 'global', slug: 'legacy', version: '1.0.0', fingerprint: 'v1', zipBytes: makeSkillZip('# v1') }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/legacy', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    const metadataPath = join(rootDir, 'legacy', '.skillhub', 'metadata.json')
+    const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'))
+    delete metadata.files
+    delete metadata.schemaVersion
+    await writeFile(metadataPath, JSON.stringify(metadata))
+    skill.version = '1.1.0'
+    skill.fingerprint = 'v2'
+    skill.zipBytes = makeSkillZip('# v2')
+
+    const blocked = await runCli([
+      'upgrade', '@global/legacy', '--registry', registry.url, '--check', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(blocked.exitCode).toBe(6)
+    expect(JSON.parse(blocked.stdout).items[0].reason).toContain('no file baseline')
+
+    const migrated = await runCli([
+      'upgrade', '@global/legacy', '--registry', registry.url, '--force', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(migrated.exitCode).toBe(0)
+    expect(await readFile(join(rootDir, 'legacy', 'SKILL.md'), 'utf-8')).toBe('# v2')
   })
 
   test('never installs a missing skill and never offers an implicit upgrade-all', async () => {
@@ -220,5 +327,11 @@ describe('upgrade command', () => {
     const empty = await runCli(['upgrade'], { HOME: env.home, USERPROFILE: env.home })
     expect(empty.exitCode).toBe(5)
     expect(empty.stderr).toContain('at least one')
+
+    const tooMany = await runCli([
+      'upgrade', ...Array.from({ length: 51 }, (_, index) => `@global/skill-${index}`)
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(tooMany.exitCode).toBe(5)
+    expect(tooMany.stderr).toContain('at most 50')
   })
 })

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -43,6 +43,10 @@ describe('upgrade command', () => {
     skill.fingerprint = 'fp-v2'
     skill.zipBytes = makeSkillZip('# v2')
 
+    const inventoryPath = join(env.home, '.skillhub', 'inventory.json')
+    const metadataPath = join(rootDir, 'skillhub-registry', '.skillhub', 'metadata.json')
+    const inventoryBeforeCheck = await readFile(inventoryPath, 'utf-8')
+    const metadataBeforeCheck = await readFile(metadataPath, 'utf-8')
     const checked = await runCli([
       'upgrade', '@global/skillhub-registry', '--registry', registry.url, '--dir', rootDir, '--check', '--json'
     ], { HOME: env.home, USERPROFILE: env.home })
@@ -55,6 +59,17 @@ describe('upgrade command', () => {
     })
     expect(await readFile(join(rootDir, 'skillhub-registry', 'SKILL.md'), 'utf-8')).toBe('# v1')
     expect(registry.received.downloads).toBe(1)
+    expect(await readFile(inventoryPath, 'utf-8')).toBe(inventoryBeforeCheck)
+    expect(await readFile(metadataPath, 'utf-8')).toBe(metadataBeforeCheck)
+
+    const checkedAgain = await runCli([
+      'upgrade', '@global/skillhub-registry', '--registry', registry.url, '--dir', rootDir, '--check', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home })
+    expect(checkedAgain.exitCode).toBe(0)
+    expect(checkedAgain.stdout).toBe(checked.stdout)
+    expect(await readFile(inventoryPath, 'utf-8')).toBe(inventoryBeforeCheck)
+    expect(await readFile(metadataPath, 'utf-8')).toBe(metadataBeforeCheck)
+    expect(registry.received.downloads).toBe(1)
 
     const upgraded = await runCli([
       'upgrade', '@global/skillhub-registry', '--registry', registry.url, '--json'
@@ -64,13 +79,10 @@ describe('upgrade command', () => {
     expect(await readFile(join(rootDir, 'skillhub-registry', 'SKILL.md'), 'utf-8')).toBe('# v2')
     expect(registry.received.downloads).toBe(2)
 
-    const metadata = JSON.parse(await readFile(
-      join(rootDir, 'skillhub-registry', '.skillhub', 'metadata.json'),
-      'utf-8'
-    ))
+    const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'))
     expect(metadata).toMatchObject({ schemaVersion: 1, version: '1.1.0', versionId: 2, fingerprint: 'fp-v2' })
     expect(Object.keys(metadata.files)).toContain('SKILL.md')
-    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
+    const inventory = JSON.parse(await readFile(inventoryPath, 'utf-8'))
     expect(inventory.items[0]).toMatchObject({ version: '1.1.0', fingerprint: 'fp-v2' })
   })
 
@@ -179,6 +191,14 @@ describe('upgrade command', () => {
     expect(selected.exitCode).toBe(0)
     expect(selected.stdout).toContain('@team-a/demo')
 
+    const fullCoordinate = await runCli(['upgrade', '@team-a/demo', '--check'], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    expect(fullCoordinate.exitCode).toBe(0)
+    expect(fullCoordinate.stdout).toContain('@team-a/demo')
+    expect(fullCoordinate.stdout).not.toContain('@team-b/demo')
+
     const noNamespaceMatch = await runCli(['upgrade', 'demo', '--namespace', 'missing', '--check'], {
       HOME: env.home,
       USERPROFILE: env.home
@@ -244,6 +264,7 @@ describe('upgrade command', () => {
       'install', '@global/shared', '--agent', 'codex', '--agent', 'claude-code', '--registry', registry.url
     ], { HOME: env.home, USERPROFILE: env.home }, { cwd: env.cwd })
     expect(installed.exitCode).toBe(0)
+    expect(registry.received.resolves).toBe(1)
     expect(registry.received.downloads).toBe(1)
 
     skill.version = '1.1.0'
@@ -262,6 +283,7 @@ describe('upgrade command', () => {
       USERPROFILE: env.home
     }, { cwd: env.cwd })
     expect(upgraded.exitCode).toBe(0)
+    expect(registry.received.resolves).toBe(2)
     expect(registry.received.downloads).toBe(2)
     expect(await readFile(join(env.home, '.codex', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')
     expect(await readFile(join(env.home, '.claude', 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('# v2')

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -291,7 +291,10 @@ describe('upgrade command', () => {
     expect(inventory.items[0]).toMatchObject({ version: '1.1.0', fingerprint: 'fp-v2' })
     expect(inventory.items[0].targets).toHaveLength(2)
 
-    const listed = await runCli(['list', '--json'], { HOME: env.home, USERPROFILE: env.home })
+    const listed = await runCli(['list', '--json', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
     expect(listed.exitCode).toBe(0)
     expect(JSON.parse(listed.stdout).items[0]).toMatchObject({ version: '1.1.0' })
   })

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -568,6 +568,11 @@ describe('upgrade command', () => {
     expect(await readFile(join(rootDir, 'first', 'SKILL.md'), 'utf-8')).toBe('# first v2')
     expect(await readFile(join(rootDir, 'second', 'SKILL.md'), 'utf-8')).toBe('# second v1')
     expect(await readFile(join(rootDir, 'third', 'SKILL.md'), 'utf-8')).toBe('# third v1')
+    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items.find((item: { slug: string }) => item.slug === 'first').version).toBe('1.1.0')
+    expect(inventory.items.find((item: { slug: string }) => item.slug === 'second').version).toBe('1.0.0')
+    expect(inventory.items.find((item: { slug: string }) => item.slug === 'third').version).toBe('1.0.0')
+    expect(registry.received.downloads).toBe(5)
   })
 
   test('legacy metadata without a file baseline requires explicit force migration', async () => {

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -5,6 +5,7 @@ import { strToU8, zipSync } from 'fflate'
 import { createTempHome } from '../helpers/temp-env'
 import { startFakeRegistry } from '../helpers/fake-registry'
 import { runCli } from '../helpers/run-cli'
+import { executeSkillUpgradePlan, planSkillUpgrades } from '../../src/services/upgrade-service'
 
 let registries: Array<Awaited<ReturnType<typeof startFakeRegistry>>> = []
 
@@ -122,6 +123,87 @@ describe('upgrade command', () => {
     ], { HOME: env.home, USERPROFILE: env.home })
     expect(forced.exitCode).toBe(0)
     expect(await readFile(join(rootDir, 'code-review', 'SKILL.md'), 'utf-8')).toBe('# v2')
+  })
+
+  test('a local edit made after planning is rechecked before replacement', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'global',
+      slug: 'late-edit',
+      version: '1.0.0',
+      versionId: 1,
+      fingerprint: 'fp-v1',
+      zipBytes: makeSkillZip('# v1')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const rootDir = join(env.cwd, 'skills')
+    await mkdir(rootDir, { recursive: true })
+    await runCli(['install', '@global/late-edit', '--dir', rootDir, '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    }, { cwd: env.cwd })
+
+    skill.version = '1.1.0'
+    skill.versionId = 2
+    skill.fingerprint = 'fp-v2'
+    skill.zipBytes = makeSkillZip('# v2')
+    const tokenForRegistry = async () => undefined
+    const plan = await planSkillUpgrades({
+      coordinates: ['@global/late-edit'],
+      registry: registry.url,
+      force: false,
+      home: env.home,
+      tokenForRegistry
+    })
+    await writeFile(join(rootDir, 'late-edit', 'SKILL.md'), '# edited after planning')
+
+    await expect(executeSkillUpgradePlan(plan, { home: env.home, tokenForRegistry }))
+      .rejects.toThrow('local changes detected after upgrade planning')
+    expect(await readFile(join(rootDir, 'late-edit', 'SKILL.md'), 'utf-8'))
+      .toBe('# edited after planning')
+    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items[0]).toMatchObject({ version: '1.0.0', fingerprint: 'fp-v1' })
+  })
+
+  test('new installs persist absolute targets and legacy relative targets are blocked safely', async () => {
+    const env = await createTempHome()
+    const skill = {
+      namespace: 'global',
+      slug: 'portable',
+      version: '1.0.0',
+      versionId: 1,
+      fingerprint: 'fp-v1',
+      zipBytes: makeSkillZip('# v1')
+    }
+    const registry = await startFakeRegistry({ skills: [skill] })
+    registries.push(registry)
+    const installed = await runCli([
+      'install', '@global/portable', '--dir', 'skills', '--registry', registry.url
+    ], { HOME: env.home, USERPROFILE: env.home }, { cwd: env.cwd })
+    expect(installed.exitCode).toBe(0)
+
+    const inventoryPath = join(env.home, '.skillhub', 'inventory.json')
+    const inventory = JSON.parse(await readFile(inventoryPath, 'utf-8'))
+    expect(inventory.items[0].targets[0].rootDir).toBe(join(env.cwd, 'skills'))
+    expect(inventory.items[0].targets[0].installDir).toBe(join(env.cwd, 'skills', 'portable'))
+
+    inventory.items[0].targets[0].rootDir = 'skills'
+    inventory.items[0].targets[0].installDir = join('skills', 'portable')
+    await writeFile(inventoryPath, JSON.stringify(inventory))
+    skill.version = '1.1.0'
+    skill.versionId = 2
+    skill.fingerprint = 'fp-v2'
+    skill.zipBytes = makeSkillZip('# v2')
+
+    const otherCwd = join(env.cwd, 'other')
+    await mkdir(otherCwd, { recursive: true })
+    const result = await runCli([
+      'upgrade', '@global/portable', '--registry', registry.url, '--check', '--json'
+    ], { HOME: env.home, USERPROFILE: env.home }, { cwd: otherCwd })
+    expect(result.exitCode).toBe(6)
+    expect(JSON.parse(result.stdout).items[0].reason).toContain('legacy relative target path')
+    expect(await readFile(join(env.cwd, 'skills', 'portable', 'SKILL.md'), 'utf-8')).toBe('# v1')
   })
 
   test('source conflict is a hard block even with --force', async () => {

--- a/cli/test/integration/upgrade-command.test.ts
+++ b/cli/test/integration/upgrade-command.test.ts
@@ -1,5 +1,5 @@
 import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { strToU8, zipSync } from 'fflate'
 import { createTempHome } from '../helpers/temp-env'
@@ -239,8 +239,9 @@ describe('upgrade command', () => {
 
     const inventoryPath = join(env.home, '.skillhub', 'inventory.json')
     const inventory = JSON.parse(await readFile(inventoryPath, 'utf-8'))
-    expect(inventory.items[0].targets[0].rootDir).toBe(join(env.cwd, 'skills'))
-    expect(inventory.items[0].targets[0].installDir).toBe(join(env.cwd, 'skills', 'portable'))
+    expect(isAbsolute(inventory.items[0].targets[0].rootDir)).toBe(true)
+    expect(inventory.items[0].targets[0].installDir)
+      .toBe(join(inventory.items[0].targets[0].rootDir, 'portable'))
 
     inventory.items[0].targets[0].rootDir = 'skills'
     inventory.items[0].targets[0].installDir = join('skills', 'portable')

--- a/cli/test/integration/version-upgrade-flow.test.ts
+++ b/cli/test/integration/version-upgrade-flow.test.ts
@@ -37,23 +37,25 @@ describe('version upgrade flow', () => {
   // -------------------------------------------------------------------------
   // VU1 — full upgrade lifecycle:
   //   1. Registry serves pdf-parser@1.0.0 → install → metadata=v1, content=v1
-  //   2. Stop registry, start a new one serving pdf-parser@2.0.0
-  //   3. Install --force using the new registry URL
+  //   2. The same registry serves pdf-parser@2.0.0
+  //   3. Install --force from the same source identity
   //   4. metadata.json, inventory.json AND on-disk SKILL.md all reflect v2
   // -------------------------------------------------------------------------
   test('VU1 install v1 then upgrade to v2 with --force replaces metadata, inventory, and content', async () => {
     const env = await createTempHome()
 
     // --- Stage 1: install v1 ----------------------------------------------
+    const skill = {
+      namespace: 'global',
+      slug: 'pdf-parser',
+      version: '1.0.0',
+      versionId: 1,
+      zipBytes: makeSkillZipWithBody('# pdf-parser v1\n\nVersion one body.')
+    }
     registry = await startFakeRegistry({
       token: 'sk_ok',
       user: { handle: 'u1', displayName: 'User One' },
-      skills: [{
-        namespace: 'global',
-        slug: 'pdf-parser',
-        version: '1.0.0',
-        zipBytes: makeSkillZipWithBody('# pdf-parser v1\n\nVersion one body.')
-      }]
+      skills: [skill]
     })
     await runCli(['login', '--registry', registry.url, '--token', 'sk_ok'], { HOME: env.home, USERPROFILE: env.home })
 
@@ -77,22 +79,10 @@ describe('version upgrade flow', () => {
       expect(body).toContain('Version one body.')
     }
 
-    // --- Stage 2: swap registry to v2 -------------------------------------
-    registry.stop()
-    registry = await startFakeRegistry({
-      token: 'sk_ok',
-      user: { handle: 'u1', displayName: 'User One' },
-      skills: [{
-        namespace: 'global',
-        slug: 'pdf-parser',
-        version: '2.0.0',
-        zipBytes: makeSkillZipWithBody('# pdf-parser v2\n\nVersion two body.')
-      }]
-    })
-
-    // Re-login against the new registry (URL changed, so credentials are
-    // keyed differently).
-    await runCli(['login', '--registry', registry.url, '--token', 'sk_ok'], { HOME: env.home, USERPROFILE: env.home })
+    // --- Stage 2: publish v2 from the same source --------------------------
+    skill.version = '2.0.0'
+    skill.versionId = 2
+    skill.zipBytes = makeSkillZipWithBody('# pdf-parser v2\n\nVersion two body.')
 
     const r2 = await runCli(
       ['install', 'pdf-parser', '--dir', installDir, '--registry', registry.url, '--token', 'sk_ok', '--force'],

--- a/cli/test/unit/commands/install-command.test.ts
+++ b/cli/test/unit/commands/install-command.test.ts
@@ -146,6 +146,25 @@ describe('installCommand dependency injection', () => {
     }] as AgentCandidate[]
   }
 
+  test('renders post-commit warnings in human and JSON output', async () => {
+    const deps: InstallCommandDeps = {
+      isTTY: () => false,
+      resolveInstallTargets: fakeResolveInstallTargets(),
+      installSkill: async () => ({
+        installed: [{ agent: 'codex', dir: '/home/u/.codex/skills/foo' }],
+        warnings: ['target lock cleanup failed: simulated release failure']
+      })
+    }
+
+    const human = await installCommand('@global/foo', { registry: 'http://localhost' }, deps)
+    expect(human).toContain('Warning: target lock cleanup failed')
+    const json = JSON.parse(await installCommand('@global/foo', {
+      registry: 'http://localhost',
+      json: true
+    }, deps))
+    expect(json.warnings).toEqual(['target lock cleanup failed: simulated release failure'])
+  })
+
   test('passes a namespaced coordinate to installSkill', async () => {
     let received: Parameters<NonNullable<InstallCommandDeps['installSkill']>>[0] | undefined
     const deps: InstallCommandDeps = {

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -167,6 +167,28 @@ describe('installSkill', () => {
     expect(await exists(join(skillDir, 'stale.txt'))).toBe(false)
   })
 
+  test('reports lock cleanup failure as a warning after committing the installation', async () => {
+    globalThis.fetch = installFetch({ 'SKILL.md': '# Committed' })
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
+    const skillDir = join(rootDir, 'demo')
+
+    const result = await installSkill({
+      registry: 'http://registry.test',
+      namespace: 'global',
+      slug: 'demo',
+      targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
+      force: false,
+      home,
+      acquireTargetLock: async () => async () => { throw new Error('simulated release failure') }
+    })
+
+    expect(result.warnings).toEqual(['target lock cleanup failed: simulated release failure'])
+    expect(await readFile(join(skillDir, 'SKILL.md'), 'utf-8')).toBe('# Committed')
+    const inventory = JSON.parse(await readFile(join(home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items[0]).toMatchObject({ version: '1.0.0', fingerprint: 'fp' })
+  })
+
   test('force rejects a different namespace at the same install directory', async () => {
     globalThis.fetch = installFetch({ 'SKILL.md': '# Team Demo' })
     const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -172,6 +172,7 @@ describe('installSkill', () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), '# Manual')
     await writeManagedMetadata(skillDir)
     const inventoryPath = join(home, '.skillhub', 'inventory.json')
     await mkdir(join(home, '.skillhub'), { recursive: true })
@@ -217,6 +218,7 @@ describe('installSkill', () => {
     const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'))
     metadata.source = 'manual'
     await writeFile(metadataPath, JSON.stringify(metadata))
+    const metadataBefore = await readFile(metadataPath, 'utf-8')
 
     await expect(installSkill({
       registry: 'http://registry.test',
@@ -226,6 +228,12 @@ describe('installSkill', () => {
       force: true,
       home
     })).rejects.toThrow('cannot verify SkillHub ownership')
+    expect(await readFile(join(skillDir, 'SKILL.md'), 'utf-8')).toBe('# Manual')
+    expect(await readFile(metadataPath, 'utf-8')).toBe(metadataBefore)
+    expect(await exists(join(home, '.skillhub', 'inventory.json'))).toBe(false)
+    const entries = await readdir(rootDir)
+    expect(entries.some(name => name.includes('skillhub-backup'))).toBe(false)
+    expect(entries.some(name => name.includes('skillhub-install.lock'))).toBe(false)
   })
 
   test('force rejects a directory without installation metadata', async () => {

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { zipSync } from 'fflate'
 import { installSkill } from '../../../src/services/install-service'
+import { skillTargetLockPath } from '../../../src/services/skill-target-lock'
 
 const originalFetch = globalThis.fetch
 
@@ -327,7 +328,7 @@ describe('installSkill', () => {
     const metadata = JSON.parse(await readFile(join(skillDir, '.skillhub', 'metadata.json'), 'utf-8'))
     expect(metadata.registry).toBe('http://other-registry.test')
     expect((await readdir(rootDir)).some(name => name.includes('skillhub-backup'))).toBe(false)
-    expect(await exists(join(rootDir, '.demo.skillhub-install.lock'))).toBe(false)
+    expect(await exists(await skillTargetLockPath(rootDir, 'demo'))).toBe(false)
     expect(await exists(join(home, '.skillhub', 'inventory.json'))).toBe(false)
   })
 
@@ -397,7 +398,7 @@ describe('installSkill', () => {
     for (const rootDir of [firstRoot, secondRoot]) {
       const entries = await readdir(rootDir)
       expect(entries.some(name => name.includes('skillhub-backup'))).toBe(false)
-      expect(entries.some(name => name.includes('skillhub-install.lock'))).toBe(false)
+      expect(await exists(await skillTargetLockPath(rootDir, 'demo'))).toBe(false)
     }
   })
 
@@ -405,7 +406,7 @@ describe('installSkill', () => {
     globalThis.fetch = installFetch({ 'SKILL.md': '# New' })
     const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
-    const lockPath = join(rootDir, '.demo.skillhub-install.lock')
+    const lockPath = await skillTargetLockPath(rootDir, 'demo')
     await writeFile(lockPath, JSON.stringify({ pid: process.pid }))
 
     await expect(installSkill({

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -228,6 +228,43 @@ describe('installSkill', () => {
     })).rejects.toThrow('cannot verify SkillHub ownership')
   })
 
+  test('force rejects a directory without installation metadata', async () => {
+    globalThis.fetch = installFetch({ 'SKILL.md': '# New' })
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
+    const skillDir = join(rootDir, 'demo')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'local.txt'), 'keep')
+
+    await expect(installSkill({
+      registry: 'http://registry.test', namespace: 'global', slug: 'demo',
+      targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
+      force: true, home
+    })).rejects.toThrow('cannot verify SkillHub ownership')
+    expect(await readFile(join(skillDir, 'local.txt'), 'utf-8')).toBe('keep')
+    expect(await exists(join(home, '.skillhub', 'inventory.json'))).toBe(false)
+  })
+
+  test('force rejects a different slug in installation metadata', async () => {
+    globalThis.fetch = installFetch({ 'SKILL.md': '# New' })
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
+    const skillDir = join(rootDir, 'demo')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), '# Other')
+    await writeManagedMetadata(skillDir, {
+      registry: 'http://registry.test', namespace: 'global', slug: 'other'
+    })
+
+    await expect(installSkill({
+      registry: 'http://registry.test', namespace: 'global', slug: 'demo',
+      targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
+      force: true, home
+    })).rejects.toThrow('source conflict')
+    expect(await readFile(join(skillDir, 'SKILL.md'), 'utf-8')).toBe('# Other')
+    expect(await exists(join(home, '.skillhub', 'inventory.json'))).toBe(false)
+  })
+
   test('revalidates ownership after download before replacing the target', async () => {
     const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
@@ -281,6 +318,7 @@ describe('installSkill', () => {
     expect(metadata.registry).toBe('http://other-registry.test')
     expect((await readdir(rootDir)).some(name => name.includes('skillhub-backup'))).toBe(false)
     expect(await exists(join(rootDir, '.demo.skillhub-install.lock'))).toBe(false)
+    expect(await exists(join(home, '.skillhub', 'inventory.json'))).toBe(false)
   })
 
   test('rolls back every target when a later target changes source before commit', async () => {

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -206,6 +206,75 @@ describe('installSkill', () => {
     expect(inventory.items[0].targets[0].installDir).toBe(skillDir)
   })
 
+  test('force rejects metadata explicitly owned by another installer', async () => {
+    globalThis.fetch = installFetch({ 'SKILL.md': '# New' })
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
+    const skillDir = join(rootDir, 'demo')
+    await mkdir(skillDir, { recursive: true })
+    await writeManagedMetadata(skillDir)
+    const metadataPath = join(skillDir, '.skillhub', 'metadata.json')
+    const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'))
+    metadata.source = 'manual'
+    await writeFile(metadataPath, JSON.stringify(metadata))
+
+    await expect(installSkill({
+      registry: 'http://registry.test',
+      namespace: 'global',
+      slug: 'demo',
+      targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
+      force: true
+    })).rejects.toThrow('cannot verify SkillHub ownership')
+  })
+
+  test('revalidates ownership after download before replacing the target', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
+    const skillDir = join(rootDir, 'demo')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), '# Old')
+    await writeManagedMetadata(skillDir)
+    const archive = zipSync({ 'SKILL.md': new TextEncoder().encode('# New') })
+
+    globalThis.fetch = (async (input: URL | RequestInfo) => {
+      const path = new URL(String(input)).pathname
+      if (path.endsWith('/resolve')) {
+        return Response.json({
+          code: 0,
+          data: {
+            namespace: 'global',
+            slug: 'demo',
+            version: '1.0.0',
+            versionId: 1,
+            fingerprint: 'fp',
+            downloadUrl: '/download'
+          }
+        })
+      }
+      if (path.endsWith('/download')) {
+        await writeManagedMetadata(skillDir, {
+          registry: 'http://other-registry.test',
+          namespace: 'global',
+          slug: 'demo'
+        })
+        await writeFile(join(skillDir, 'SKILL.md'), '# Replaced during download')
+        return new Response(
+          archive.buffer.slice(archive.byteOffset, archive.byteOffset + archive.byteLength) as ArrayBuffer,
+          { status: 200 }
+        )
+      }
+      return Response.json({ code: 404 }, { status: 404 })
+    }) as typeof fetch
+
+    await expect(installSkill({
+      registry: 'http://registry.test',
+      namespace: 'global',
+      slug: 'demo',
+      targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
+      force: true
+    })).rejects.toThrow('source conflict')
+
+    expect(await readFile(join(skillDir, 'SKILL.md'), 'utf-8')).toBe('# Replaced during download')
+  })
+
   test('force keeps old installation and inventory when replacement extraction fails', async () => {
     globalThis.fetch = installFetchWithDownloadResponse(new Response(new TextEncoder().encode('not a zip'), { status: 200 }))
     const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readFile, readdir, rm, symlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
@@ -407,7 +407,7 @@ describe('installSkill', () => {
     const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
     const lockPath = await skillTargetLockPath(rootDir, 'demo')
-    await writeFile(lockPath, JSON.stringify({ pid: process.pid }))
+    await mkdir(lockPath)
 
     await expect(installSkill({
       registry: 'http://registry.test', namespace: 'global', slug: 'demo',
@@ -416,7 +416,10 @@ describe('installSkill', () => {
     })).rejects.toThrow('install target is busy')
     expect(await exists(join(rootDir, 'demo'))).toBe(false)
 
-    await writeFile(lockPath, JSON.stringify({ pid: 999999 }))
+    await rm(lockPath, { recursive: true })
+    await mkdir(lockPath)
+    const staleTime = new Date(Date.now() - 60_000)
+    await utimes(lockPath, staleTime, staleTime)
     await installSkill({
       registry: 'http://registry.test', namespace: 'global', slug: 'demo',
       targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
@@ -208,6 +208,7 @@ describe('installSkill', () => {
 
   test('force rejects metadata explicitly owned by another installer', async () => {
     globalThis.fetch = installFetch({ 'SKILL.md': '# New' })
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
@@ -222,11 +223,13 @@ describe('installSkill', () => {
       namespace: 'global',
       slug: 'demo',
       targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
-      force: true
+      force: true,
+      home
     })).rejects.toThrow('cannot verify SkillHub ownership')
   })
 
   test('revalidates ownership after download before replacing the target', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
@@ -269,10 +272,109 @@ describe('installSkill', () => {
       namespace: 'global',
       slug: 'demo',
       targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
-      force: true
+      force: true,
+      home
     })).rejects.toThrow('source conflict')
 
     expect(await readFile(join(skillDir, 'SKILL.md'), 'utf-8')).toBe('# Replaced during download')
+    const metadata = JSON.parse(await readFile(join(skillDir, '.skillhub', 'metadata.json'), 'utf-8'))
+    expect(metadata.registry).toBe('http://other-registry.test')
+    expect((await readdir(rootDir)).some(name => name.includes('skillhub-backup'))).toBe(false)
+    expect(await exists(join(rootDir, '.demo.skillhub-install.lock'))).toBe(false)
+  })
+
+  test('rolls back every target when a later target changes source before commit', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
+    const parent = await mkdtemp(join(tmpdir(), 'skillhub-install-targets-'))
+    const firstRoot = join(parent, 'a')
+    const secondRoot = join(parent, 'b')
+    const firstSkillDir = join(firstRoot, 'demo')
+    const secondSkillDir = join(secondRoot, 'demo')
+    for (const skillDir of [firstSkillDir, secondSkillDir]) {
+      await mkdir(skillDir, { recursive: true })
+      await writeFile(join(skillDir, 'SKILL.md'), `# Old ${skillDir === firstSkillDir ? 'A' : 'B'}`)
+      await writeManagedMetadata(skillDir)
+    }
+    await mkdir(join(home, '.skillhub'), { recursive: true })
+    await writeFile(join(home, '.skillhub', 'inventory.json'), JSON.stringify({
+      items: [{
+        registry: 'http://registry.test',
+        namespace: 'global',
+        slug: 'demo',
+        version: '0.1.0',
+        targets: [
+          { agent: 'codex', rootDir: firstRoot, installDir: firstSkillDir, installedAt: '2026-09-01T00:00:00Z' },
+          { agent: 'claude-code', rootDir: secondRoot, installDir: secondSkillDir, installedAt: '2026-09-01T00:00:00Z' }
+        ]
+      }]
+    }))
+    const archive = zipSync({ 'SKILL.md': new TextEncoder().encode('# New') })
+    globalThis.fetch = (async (input: URL | RequestInfo) => {
+      const path = new URL(String(input)).pathname
+      if (path.endsWith('/resolve')) {
+        return Response.json({ code: 0, data: {
+          namespace: 'global', slug: 'demo', version: '1.0.0', versionId: 1,
+          fingerprint: 'fp', downloadUrl: '/download'
+        } })
+      }
+      if (path.endsWith('/download')) {
+        await writeManagedMetadata(secondSkillDir, {
+          registry: 'http://other-registry.test', namespace: 'global', slug: 'demo'
+        })
+        return new Response(
+          archive.buffer.slice(archive.byteOffset, archive.byteOffset + archive.byteLength) as ArrayBuffer,
+          { status: 200 }
+        )
+      }
+      return Response.json({ code: 404 }, { status: 404 })
+    }) as typeof fetch
+
+    await expect(installSkill({
+      registry: 'http://registry.test',
+      namespace: 'global',
+      slug: 'demo',
+      targets: [
+        { agent: 'codex', rootDir: firstRoot, scope: 'project', source: 'explicit' },
+        { agent: 'claude-code', rootDir: secondRoot, scope: 'project', source: 'explicit' }
+      ],
+      force: true,
+      home
+    })).rejects.toThrow('source conflict')
+
+    expect(await readFile(join(firstSkillDir, 'SKILL.md'), 'utf-8')).toBe('# Old A')
+    expect(await readFile(join(secondSkillDir, 'SKILL.md'), 'utf-8')).toBe('# Old B')
+    const inventory = JSON.parse(await readFile(join(home, '.skillhub', 'inventory.json'), 'utf-8'))
+    expect(inventory.items[0]).toMatchObject({ version: '0.1.0' })
+    expect(inventory.items[0].targets).toHaveLength(2)
+    for (const rootDir of [firstRoot, secondRoot]) {
+      const entries = await readdir(rootDir)
+      expect(entries.some(name => name.includes('skillhub-backup'))).toBe(false)
+      expect(entries.some(name => name.includes('skillhub-install.lock'))).toBe(false)
+    }
+  })
+
+  test('rejects an active target lock and recovers a dead-process lock', async () => {
+    globalThis.fetch = installFetch({ 'SKILL.md': '# New' })
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
+    const lockPath = join(rootDir, '.demo.skillhub-install.lock')
+    await writeFile(lockPath, JSON.stringify({ pid: process.pid }))
+
+    await expect(installSkill({
+      registry: 'http://registry.test', namespace: 'global', slug: 'demo',
+      targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
+      force: false, home
+    })).rejects.toThrow('install target is busy')
+    expect(await exists(join(rootDir, 'demo'))).toBe(false)
+
+    await writeFile(lockPath, JSON.stringify({ pid: 999999 }))
+    await installSkill({
+      registry: 'http://registry.test', namespace: 'global', slug: 'demo',
+      targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
+      force: false, home
+    })
+    expect(await readFile(join(rootDir, 'demo', 'SKILL.md'), 'utf-8')).toBe('# New')
+    expect(await exists(lockPath)).toBe(false)
   })
 
   test('force keeps old installation and inventory when replacement extraction fails', async () => {

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { zipSync } from 'fflate'
 import { installSkill } from '../../../src/services/install-service'
+import { planSkillUpgrades } from '../../../src/services/upgrade-service'
+import { removeLocalSkill } from '../../../src/services/remove-service'
 import { skillTargetLockPath } from '../../../src/services/skill-target-lock'
 
 const originalFetch = globalThis.fetch
@@ -143,6 +145,70 @@ describe('installSkill', () => {
       await rm(home, { recursive: true, force: true })
       await rm(targetParent, { recursive: true, force: true })
     }
+  })
+
+  test('migrates a canonical inventory target to its selected path alias without duplication', async () => {
+    globalThis.fetch = installFetch({ 'SKILL.md': '# Reinstalled' })
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
+    const parent = await mkdtemp(join(tmpdir(), 'skillhub-install-alias-'))
+    const realRoot = join(parent, 'real')
+    const aliasRoot = join(parent, 'alias')
+    const realSkillDir = join(realRoot, 'demo')
+    const aliasSkillDir = join(aliasRoot, 'demo')
+    await mkdir(realSkillDir, { recursive: true })
+    await writeFile(join(realSkillDir, 'SKILL.md'), '# Old')
+    await writeManagedMetadata(realSkillDir)
+    await symlink(realRoot, aliasRoot, process.platform === 'win32' ? 'junction' : 'dir')
+
+    const inventoryPath = join(home, '.skillhub', 'inventory.json')
+    await mkdir(join(home, '.skillhub'), { recursive: true })
+    await writeFile(inventoryPath, JSON.stringify({
+      items: [{
+        registry: 'http://registry.test',
+        namespace: 'global',
+        slug: 'demo',
+        version: '0.1.0',
+        targets: [{
+          agent: 'codex',
+          rootDir: realRoot,
+          installDir: realSkillDir,
+          installedAt: '2026-09-01T00:00:00Z'
+        }]
+      }]
+    }))
+
+    await installSkill({
+      registry: 'http://registry.test',
+      namespace: 'global',
+      slug: 'demo',
+      targets: [{ agent: 'codex', rootDir: aliasRoot, scope: 'project', source: 'explicit' }],
+      force: true,
+      home
+    })
+
+    const inventory = JSON.parse(await readFile(inventoryPath, 'utf-8'))
+    expect(inventory.items).toHaveLength(1)
+    expect(inventory.items[0].targets).toEqual([
+      expect.objectContaining({ rootDir: aliasRoot, installDir: aliasSkillDir })
+    ])
+
+    const plan = await planSkillUpgrades({
+      coordinates: ['@global/demo'],
+      registry: 'http://registry.test',
+      force: false,
+      home,
+      tokenForRegistry: async () => undefined
+    })
+    expect(plan).toMatchObject({ blocked: 0, unchanged: 1 })
+
+    await removeLocalSkill({
+      registry: 'http://registry.test',
+      namespace: 'global',
+      slug: 'demo',
+      home
+    })
+    expect(await exists(realSkillDir)).toBe(false)
+    expect((JSON.parse(await readFile(inventoryPath, 'utf-8'))).items).toEqual([])
   })
 
   test('force replaces the old skill directory instead of overlaying files', async () => {

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -172,7 +172,7 @@ describe('installSkill', () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
-    await writeFile(join(skillDir, 'SKILL.md'), '# Manual')
+    await writeFile(join(skillDir, 'SKILL.md'), '# Global Demo')
     await writeManagedMetadata(skillDir)
     const inventoryPath = join(home, '.skillhub', 'inventory.json')
     await mkdir(join(home, '.skillhub'), { recursive: true })
@@ -205,6 +205,7 @@ describe('installSkill', () => {
     expect(inventory.items[0]).toMatchObject({ namespace: 'global', slug: 'demo' })
     expect(inventory.items[0].targets).toHaveLength(1)
     expect(inventory.items[0].targets[0].installDir).toBe(skillDir)
+    expect(await readFile(join(skillDir, 'SKILL.md'), 'utf-8')).toBe('# Global Demo')
   })
 
   test('force rejects metadata explicitly owned by another installer', async () => {
@@ -213,6 +214,7 @@ describe('installSkill', () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), '# Manual')
     await writeManagedMetadata(skillDir)
     const metadataPath = join(skillDir, '.skillhub', 'metadata.json')
     const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'))

--- a/cli/test/unit/services/install-service.test.ts
+++ b/cli/test/unit/services/install-service.test.ts
@@ -51,6 +51,22 @@ function installFetchWithDownloadResponse(downloadResponse: Response): typeof fe
   return fakeFetch as unknown as typeof fetch
 }
 
+async function writeManagedMetadata(
+  skillDir: string,
+  identity: { registry: string; namespace: string; slug: string } = {
+    registry: 'http://registry.test',
+    namespace: 'global',
+    slug: 'demo'
+  }
+): Promise<void> {
+  await mkdir(join(skillDir, '.skillhub'), { recursive: true })
+  await writeFile(join(skillDir, '.skillhub', 'metadata.json'), JSON.stringify({
+    ...identity,
+    version: '0.1.0',
+    source: 'skillhub'
+  }))
+}
+
 describe('installSkill', () => {
   afterEach(() => {
     globalThis.fetch = originalFetch
@@ -135,6 +151,7 @@ describe('installSkill', () => {
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
     await writeFile(join(skillDir, 'stale.txt'), 'old')
+    await writeManagedMetadata(skillDir)
 
     await installSkill({
       registry: 'http://registry.test',
@@ -149,12 +166,13 @@ describe('installSkill', () => {
     expect(await exists(join(skillDir, 'stale.txt'))).toBe(false)
   })
 
-  test('force removes stale inventory records that point at the replaced install directory', async () => {
+  test('force rejects a different namespace at the same install directory', async () => {
     globalThis.fetch = installFetch({ 'SKILL.md': '# Team Demo' })
     const home = await mkdtemp(join(tmpdir(), 'skillhub-install-home-'))
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-install-root-'))
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
+    await writeManagedMetadata(skillDir)
     const inventoryPath = join(home, '.skillhub', 'inventory.json')
     await mkdir(join(home, '.skillhub'), { recursive: true })
     await writeFile(inventoryPath, JSON.stringify({
@@ -172,18 +190,18 @@ describe('installSkill', () => {
       }]
     }))
 
-    await installSkill({
+    await expect(installSkill({
       registry: 'http://registry.test',
       namespace: 'team',
       slug: 'demo',
       targets: [{ agent: 'codex', rootDir, scope: 'project', source: 'explicit' }],
       force: true,
       home
-    })
+    })).rejects.toThrow('source conflict')
 
     const inventory = JSON.parse(await readFile(inventoryPath, 'utf-8'))
     expect(inventory.items).toHaveLength(1)
-    expect(inventory.items[0]).toMatchObject({ namespace: 'team', slug: 'demo' })
+    expect(inventory.items[0]).toMatchObject({ namespace: 'global', slug: 'demo' })
     expect(inventory.items[0].targets).toHaveLength(1)
     expect(inventory.items[0].targets[0].installDir).toBe(skillDir)
   })
@@ -195,6 +213,7 @@ describe('installSkill', () => {
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
     await writeFile(join(skillDir, 'SKILL.md'), '# Old')
+    await writeManagedMetadata(skillDir)
     const inventoryPath = join(home, '.skillhub', 'inventory.json')
     await mkdir(join(home, '.skillhub'), { recursive: true })
     await writeFile(inventoryPath, JSON.stringify({
@@ -234,6 +253,7 @@ describe('installSkill', () => {
     const skillDir = join(rootDir, 'demo')
     await mkdir(skillDir, { recursive: true })
     await writeFile(join(skillDir, 'SKILL.md'), '# Old')
+    await writeManagedMetadata(skillDir)
     const invalidHome = join(rootDir, 'home-is-a-file')
     await writeFile(invalidHome, 'not a directory')
 

--- a/cli/test/unit/services/remove-service.test.ts
+++ b/cli/test/unit/services/remove-service.test.ts
@@ -123,6 +123,7 @@ describe('removeLocalSkill', () => {
     expect(removed.removed).toHaveLength(1)
     expect(await exists(skillDir)).toBe(false)
     expect((await store.read()).items).toEqual([])
+    expect(await exists(join(rootDir, '.demo.skillhub-install.lock'))).toBe(false)
   })
 
   test('throws on path traversal in installDir', async () => {

--- a/cli/test/unit/services/remove-service.test.ts
+++ b/cli/test/unit/services/remove-service.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
 import { removeLocalSkill } from '../../../src/services/remove-service'
+import { acquireSkillTargetLock } from '../../../src/services/skill-target-lock'
 import { InventoryStore } from '../../../src/stores/inventory-store'
 
 async function exists(path: string): Promise<boolean> {
@@ -90,6 +91,38 @@ describe('removeLocalSkill', () => {
     expect(await exists(globalDir)).toBe(true)
     expect(await exists(teamDir)).toBe(false)
     expect((await store.read()).items.map(item => item.namespace)).toEqual(['global'])
+  })
+
+  test('does not remove a target while install or upgrade holds its lifecycle lock', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-remove-lock-home-'))
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-remove-lock-root-'))
+    const skillDir = join(rootDir, 'demo')
+    await mkdir(skillDir, { recursive: true })
+    const store = new InventoryStore(home)
+    await store.write({
+      items: [{
+        registry: 'https://skill.xfyun.cn',
+        namespace: 'global',
+        slug: 'demo',
+        version: '1.0.0',
+        targets: [{ agent: 'codex', rootDir, installDir: skillDir, installedAt: '2026-09-01T00:00:00Z' }]
+      }]
+    })
+
+    const release = await acquireSkillTargetLock(rootDir, 'demo')
+    try {
+      await expect(removeLocalSkill({ registry: 'https://skill.xfyun.cn', slug: 'demo', home }))
+        .rejects.toThrow('install target is busy')
+      expect(await exists(skillDir)).toBe(true)
+      expect((await store.read()).items[0]?.targets).toHaveLength(1)
+    } finally {
+      await release()
+    }
+
+    const removed = await removeLocalSkill({ registry: 'https://skill.xfyun.cn', slug: 'demo', home })
+    expect(removed.removed).toHaveLength(1)
+    expect(await exists(skillDir)).toBe(false)
+    expect((await store.read()).items).toEqual([])
   })
 
   test('throws on path traversal in installDir', async () => {

--- a/cli/test/unit/services/remove-service.test.ts
+++ b/cli/test/unit/services/remove-service.test.ts
@@ -147,8 +147,8 @@ describe('removeLocalSkill', () => {
       }]
     })
 
-    expect(await skillTargetLockPath(aliasRoot, 'demo'))
-      .toBe(await skillTargetLockPath(realRoot, 'demo'))
+    const lockPath = await skillTargetLockPath(realRoot, 'demo')
+    expect(await skillTargetLockPath(aliasRoot, 'demo')).toBe(lockPath)
     const release = await acquireSkillTargetLock(realRoot, 'demo')
     try {
       await expect(removeLocalSkill({ registry: 'https://skill.xfyun.cn', slug: 'demo', home }))
@@ -158,6 +158,7 @@ describe('removeLocalSkill', () => {
     } finally {
       await release()
     }
+    expect(await exists(lockPath)).toBe(false)
   })
 
   test('removes a stale inventory target when the recorded root directory is missing', async () => {

--- a/cli/test/unit/services/remove-service.test.ts
+++ b/cli/test/unit/services/remove-service.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
 import { removeLocalSkill } from '../../../src/services/remove-service'
-import { acquireSkillTargetLock } from '../../../src/services/skill-target-lock'
+import { acquireSkillTargetLock, skillTargetLockPath } from '../../../src/services/skill-target-lock'
 import { InventoryStore } from '../../../src/stores/inventory-store'
 
 async function exists(path: string): Promise<boolean> {
@@ -123,7 +123,31 @@ describe('removeLocalSkill', () => {
     expect(removed.removed).toHaveLength(1)
     expect(await exists(skillDir)).toBe(false)
     expect((await store.read()).items).toEqual([])
-    expect(await exists(join(rootDir, '.demo.skillhub-install.lock'))).toBe(false)
+    expect(await exists(await skillTargetLockPath(rootDir, 'demo'))).toBe(false)
+  })
+
+  test('removes a stale inventory target when the recorded root directory is missing', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-remove-stale-home-'))
+    const parent = await mkdtemp(join(tmpdir(), 'skillhub-remove-stale-parent-'))
+    const rootDir = join(parent, 'missing-root')
+    const skillDir = join(rootDir, 'demo')
+    const store = new InventoryStore(home)
+    await store.write({
+      items: [{
+        registry: 'https://skill.xfyun.cn',
+        namespace: 'global',
+        slug: 'demo',
+        version: '1.0.0',
+        targets: [{ agent: 'codex', rootDir, installDir: skillDir, installedAt: '2026-09-01T00:00:00Z' }]
+      }]
+    })
+
+    const result = await removeLocalSkill({ registry: 'https://skill.xfyun.cn', slug: 'demo', home })
+
+    expect(result.removed).toEqual([{ namespace: 'global', agent: 'codex', dir: skillDir, existed: false }])
+    expect(await exists(rootDir)).toBe(false)
+    expect((await store.read()).items).toEqual([])
+    expect(await exists(await skillTargetLockPath(rootDir, 'demo'))).toBe(false)
   })
 
   test('throws on path traversal in installDir', async () => {

--- a/cli/test/unit/services/remove-service.test.ts
+++ b/cli/test/unit/services/remove-service.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
@@ -124,6 +124,40 @@ describe('removeLocalSkill', () => {
     expect(await exists(skillDir)).toBe(false)
     expect((await store.read()).items).toEqual([])
     expect(await exists(await skillTargetLockPath(rootDir, 'demo'))).toBe(false)
+  })
+
+  test('legacy symlink roots use the same lifecycle lock as their real target', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-remove-alias-home-'))
+    const parent = await mkdtemp(join(tmpdir(), 'skillhub-remove-alias-parent-'))
+    const realRoot = join(parent, 'real-root')
+    const aliasRoot = join(parent, 'legacy-alias')
+    const realSkillDir = join(realRoot, 'demo')
+    const aliasSkillDir = join(aliasRoot, 'demo')
+    await mkdir(realSkillDir, { recursive: true })
+    await symlink(realRoot, aliasRoot, 'dir')
+
+    const store = new InventoryStore(home)
+    await store.write({
+      items: [{
+        registry: 'https://skill.xfyun.cn',
+        namespace: 'global',
+        slug: 'demo',
+        version: '1.0.0',
+        targets: [{ agent: 'codex', rootDir: aliasRoot, installDir: aliasSkillDir, installedAt: '2026-09-01T00:00:00Z' }]
+      }]
+    })
+
+    expect(await skillTargetLockPath(aliasRoot, 'demo'))
+      .toBe(await skillTargetLockPath(realRoot, 'demo'))
+    const release = await acquireSkillTargetLock(realRoot, 'demo')
+    try {
+      await expect(removeLocalSkill({ registry: 'https://skill.xfyun.cn', slug: 'demo', home }))
+        .rejects.toThrow('install target is busy')
+      expect(await exists(realSkillDir)).toBe(true)
+      expect((await store.read()).items[0]?.targets).toHaveLength(1)
+    } finally {
+      await release()
+    }
   })
 
   test('removes a stale inventory target when the recorded root directory is missing', async () => {

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,9 +1,9 @@
-import { access, writeFile } from 'node:fs/promises'
-import { mkdtemp } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, utimes } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'bun:test'
-import { acquireSkillTargetLock, skillTargetLockPath } from '../../../src/services/skill-target-lock'
+import { skillTargetLockPath } from '../../../src/services/skill-target-lock'
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -15,24 +15,28 @@ async function exists(path: string): Promise<boolean> {
 }
 
 describe('skill target lifecycle lock', () => {
-  test('simultaneous stale recovery admits exactly one owner', async () => {
+  test('simultaneous stale recovery admits exactly one owner across processes', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-lock-root-'))
     const lockPath = await skillTargetLockPath(rootDir, 'demo')
-    await writeFile(lockPath, JSON.stringify({ pid: 2_147_483_647, createdAt: '2026-09-01T00:00:00Z' }))
+    await mkdir(lockPath)
+    const staleTime = new Date(Date.now() - 60_000)
+    await utimes(lockPath, staleTime, staleTime)
+    const worker = fileURLToPath(new URL('../../helpers/target-lock-worker.ts', import.meta.url))
+    const bunPath = (await Bun.which('bun')) ?? process.execPath
 
-    const outcomes = await Promise.allSettled([
-      acquireSkillTargetLock(rootDir, 'demo'),
-      acquireSkillTargetLock(rootDir, 'demo')
-    ])
-    const winners = outcomes.filter(
-      (outcome): outcome is PromiseFulfilledResult<() => Promise<void>> => outcome.status === 'fulfilled'
-    )
-    const losers = outcomes.filter(outcome => outcome.status === 'rejected')
+    const processes = [0, 1].map(() => Bun.spawn({
+      cmd: [bunPath, worker, rootDir, 'demo', '1000'],
+      stdout: 'pipe',
+      stderr: 'pipe'
+    }))
+    const results = await Promise.all(processes.map(async process => ({
+      exitCode: await process.exited,
+      stdout: (await new Response(process.stdout).text()).trim(),
+      stderr: (await new Response(process.stderr).text()).trim()
+    })))
 
-    expect(winners).toHaveLength(1)
-    expect(losers).toHaveLength(1)
-    expect(await exists(lockPath)).toBe(true)
-    await winners[0]!.value()
+    expect(results.map(result => result.exitCode).sort()).toEqual([0, 4])
+    expect(results.filter(result => result.stdout === 'acquired')).toHaveLength(1)
     expect(await exists(lockPath)).toBe(false)
   })
 })

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, utimes } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -14,6 +14,14 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+async function waitForFile(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 500; attempt++) {
+    if (await exists(path)) return
+    await Bun.sleep(10)
+  }
+  throw new Error(`timed out waiting for ${path}`)
+}
+
 describe('skill target lifecycle lock', () => {
   test('simultaneous stale recovery admits exactly one owner across processes', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-lock-root-'))
@@ -23,12 +31,21 @@ describe('skill target lifecycle lock', () => {
     await utimes(lockPath, staleTime, staleTime)
     const worker = fileURLToPath(new URL('../../helpers/target-lock-worker.ts', import.meta.url))
     const bunPath = (await Bun.which('bun')) ?? process.execPath
+    const acquiredPath = join(rootDir, 'acquired')
+    const releasePath = join(rootDir, 'release')
 
     const processes = [0, 1].map(() => Bun.spawn({
-      cmd: [bunPath, worker, rootDir, 'demo', '1000'],
+      cmd: [bunPath, worker, rootDir, 'demo', acquiredPath, releasePath],
       stdout: 'pipe',
       stderr: 'pipe'
     }))
+    await waitForFile(acquiredPath)
+    const loserExitCode = await Promise.race([
+      ...processes.map(process => process.exited),
+      Bun.sleep(5_000).then(() => { throw new Error('timed out waiting for the lock loser') })
+    ])
+    expect(loserExitCode).toBe(4)
+    await writeFile(releasePath, 'release')
     const results = await Promise.all(processes.map(async process => ({
       exitCode: await process.exited,
       stdout: (await new Response(process.stdout).text()).trim(),

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -69,13 +69,17 @@ describe('skill target lifecycle lock', () => {
     const bunPath = (await Bun.which('bun')) ?? process.execPath
     const acquiredPath = join(rootDir, 'acquired')
     const releasePath = join(rootDir, 'release')
+    const startPath = join(rootDir, 'start')
+    const readyPaths = [join(rootDir, 'ready-0'), join(rootDir, 'ready-1')]
 
-    const processes = [0, 1].map(() => Bun.spawn({
-      cmd: [bunPath, worker, rootDir, 'demo', acquiredPath, releasePath],
+    const processes = readyPaths.map(readyPath => Bun.spawn({
+      cmd: [bunPath, worker, rootDir, 'demo', readyPath, startPath, acquiredPath, releasePath],
       stdout: 'pipe',
       stderr: 'pipe'
     }))
     try {
+      await Promise.all(readyPaths.map(waitForFile))
+      await writeFile(startPath, 'start')
       await waitForFile(acquiredPath)
       const loserExitCode = await Promise.race([
         ...processes.map(process => process.exited),

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,6 +1,6 @@
-import { access, mkdir, mkdtemp, utimes, writeFile } from 'node:fs/promises'
+import { access, lstat, mkdir, mkdtemp, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'bun:test'
 import { skillTargetLockPath } from '../../../src/services/skill-target-lock'
@@ -69,5 +69,8 @@ describe('skill target lifecycle lock', () => {
     expect(results.map(result => result.exitCode).sort()).toEqual([0, 4])
     expect(results.filter(result => result.stdout === 'acquired')).toHaveLength(1)
     expect(await exists(lockPath)).toBe(false)
+    if (process.platform !== 'win32') {
+      expect((await lstat(dirname(lockPath))).mode & 0o077).toBe(0)
+    }
   })
 })

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,0 +1,38 @@
+import { access, writeFile } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, test } from 'bun:test'
+import { acquireSkillTargetLock, skillTargetLockPath } from '../../../src/services/skill-target-lock'
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('skill target lifecycle lock', () => {
+  test('simultaneous stale recovery admits exactly one owner', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-lock-root-'))
+    const lockPath = await skillTargetLockPath(rootDir, 'demo')
+    await writeFile(lockPath, JSON.stringify({ pid: 2_147_483_647, createdAt: '2026-09-01T00:00:00Z' }))
+
+    const outcomes = await Promise.allSettled([
+      acquireSkillTargetLock(rootDir, 'demo'),
+      acquireSkillTargetLock(rootDir, 'demo')
+    ])
+    const winners = outcomes.filter(
+      (outcome): outcome is PromiseFulfilledResult<() => Promise<void>> => outcome.status === 'fulfilled'
+    )
+    const losers = outcomes.filter(outcome => outcome.status === 'rejected')
+
+    expect(winners).toHaveLength(1)
+    expect(losers).toHaveLength(1)
+    expect(await exists(lockPath)).toBe(true)
+    await winners[0]!.value()
+    expect(await exists(lockPath)).toBe(false)
+  })
+})

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,9 +1,13 @@
-import { access, lstat, mkdir, mkdtemp, utimes, writeFile } from 'node:fs/promises'
+import { access, chmod, lstat, mkdir, mkdtemp, symlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'bun:test'
-import { skillTargetLockPath } from '../../../src/services/skill-target-lock'
+import {
+  assertPrivateLockDir,
+  ensurePrivateLockDir,
+  skillTargetLockPath
+} from '../../../src/services/skill-target-lock'
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -23,6 +27,37 @@ async function waitForFile(path: string): Promise<void> {
 }
 
 describe('skill target lifecycle lock', () => {
+  test('creates or repairs a private lock root and rejects unsafe roots', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'skillhub-lock-root-'))
+    const privateRoot = join(parent, 'private')
+    await ensurePrivateLockDir(privateRoot)
+    if (process.platform !== 'win32') {
+      expect((await lstat(privateRoot)).mode & 0o077).toBe(0)
+      await chmod(privateRoot, 0o755)
+      await ensurePrivateLockDir(privateRoot)
+      expect((await lstat(privateRoot)).mode & 0o077).toBe(0)
+    }
+
+    const fileRoot = join(parent, 'file')
+    await writeFile(fileRoot, 'keep')
+    await expect(ensurePrivateLockDir(fileRoot)).rejects.toThrow('unsafe SkillHub CLI lock directory')
+    expect(await Bun.file(fileRoot).text()).toBe('keep')
+
+    const symlinkTarget = join(parent, 'symlink-target')
+    const symlinkRoot = join(parent, 'symlink')
+    await mkdir(symlinkTarget)
+    await symlink(symlinkTarget, symlinkRoot, 'dir')
+    await expect(ensurePrivateLockDir(symlinkRoot)).rejects.toThrow('unsafe SkillHub CLI lock directory')
+    expect((await lstat(symlinkRoot)).isSymbolicLink()).toBe(true)
+
+    expect(() => assertPrivateLockDir('/foreign', {
+      isDirectory: () => true,
+      isSymbolicLink: () => false,
+      uid: 2000,
+      mode: 0o40700
+    }, 1000)).toThrow('owned by another user')
+  })
+
   test('simultaneous stale recovery admits exactly one owner across processes', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-lock-root-'))
     const lockPath = await skillTargetLockPath(rootDir, 'demo')

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -39,13 +39,27 @@ describe('skill target lifecycle lock', () => {
       stdout: 'pipe',
       stderr: 'pipe'
     }))
-    await waitForFile(acquiredPath)
-    const loserExitCode = await Promise.race([
-      ...processes.map(process => process.exited),
-      Bun.sleep(5_000).then(() => { throw new Error('timed out waiting for the lock loser') })
-    ])
-    expect(loserExitCode).toBe(4)
-    await writeFile(releasePath, 'release')
+    try {
+      await waitForFile(acquiredPath)
+      const loserExitCode = await Promise.race([
+        ...processes.map(process => process.exited),
+        Bun.sleep(5_000).then(() => { throw new Error('timed out waiting for the lock loser') })
+      ])
+      expect(loserExitCode).toBe(4)
+    } finally {
+      try {
+        await writeFile(releasePath, 'release')
+      } finally {
+        const exited = await Promise.race([
+          Promise.all(processes.map(process => process.exited)).then(() => true),
+          Bun.sleep(5_000).then(() => false)
+        ])
+        if (!exited) {
+          for (const process of processes) process.kill()
+          await Promise.all(processes.map(process => process.exited))
+        }
+      }
+    }
     const results = await Promise.all(processes.map(async process => ({
       exitCode: await process.exited,
       stdout: (await new Response(process.stdout).text()).trim(),

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,9 +1,10 @@
-import { access, chmod, lstat, mkdir, mkdtemp, symlink, utimes, writeFile } from 'node:fs/promises'
+import { access, chmod, lstat, mkdir, mkdtemp, rm, symlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'bun:test'
 import {
+  acquireSkillTargetLock,
   assertPrivateLockDir,
   ensurePrivateLockDir,
   skillTargetLockPath
@@ -107,5 +108,23 @@ describe('skill target lifecycle lock', () => {
     if (process.platform !== 'win32') {
       expect((await lstat(dirname(lockPath))).mode & 0o077).toBe(0)
     }
+  })
+
+  test('keeps one lock identity when a symlink target is removed', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-symlink-root-'))
+    const linkedDir = await mkdtemp(join(tmpdir(), 'skillhub-target-symlink-value-'))
+    const skillDir = join(rootDir, 'demo')
+    await symlink(linkedDir, skillDir, 'dir')
+
+    const lockPathBeforeRemoval = await skillTargetLockPath(rootDir, 'demo')
+    const release = await acquireSkillTargetLock(rootDir, 'demo')
+    try {
+      await rm(skillDir)
+      expect(await skillTargetLockPath(rootDir, 'demo')).toBe(lockPathBeforeRemoval)
+      await expect(acquireSkillTargetLock(rootDir, 'demo')).rejects.toThrow('install target is busy')
+    } finally {
+      await release()
+    }
+    expect(await exists(lockPathBeforeRemoval)).toBe(false)
   })
 })

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,4 +1,4 @@
-import { access, chmod, lstat, mkdir, mkdtemp, rm, symlink, utimes, writeFile } from 'node:fs/promises'
+import { access, chmod, lstat, mkdir, mkdtemp, symlink, unlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -108,18 +108,18 @@ describe('skill target lifecycle lock', () => {
     if (process.platform !== 'win32') {
       expect((await lstat(dirname(lockPath))).mode & 0o077).toBe(0)
     }
-  })
+  }, 15_000)
 
   test('keeps one lock identity when a symlink target is removed', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-symlink-root-'))
     const linkedDir = await mkdtemp(join(tmpdir(), 'skillhub-target-symlink-value-'))
     const skillDir = join(rootDir, 'demo')
-    await symlink(linkedDir, skillDir, 'dir')
+    await symlink(linkedDir, skillDir, process.platform === 'win32' ? 'junction' : 'dir')
 
     const lockPathBeforeRemoval = await skillTargetLockPath(rootDir, 'demo')
     const release = await acquireSkillTargetLock(rootDir, 'demo')
     try {
-      await rm(skillDir)
+      await unlink(skillDir)
       expect(await skillTargetLockPath(rootDir, 'demo')).toBe(lockPathBeforeRemoval)
       await expect(acquireSkillTargetLock(rootDir, 'demo')).rejects.toThrow('install target is busy')
     } finally {

--- a/cli/test/unit/stores/inventory-store.test.ts
+++ b/cli/test/unit/stores/inventory-store.test.ts
@@ -98,4 +98,33 @@ describe('InventoryStore', () => {
     const inventory = await store.read()
     expect(inventory.items).toHaveLength(1)
   })
+
+  test('rejects a version change while an unselected target is retained', async () => {
+    const home = await makeTempHome()
+    const store = new InventoryStore(home)
+    const retained = makeTarget('shared-a')
+    await store.upsertTarget(
+      'https://skill.xfyun.cn',
+      'global',
+      'shared',
+      '1.0.0',
+      retained,
+      'fp-v1',
+    )
+
+    const replacement = makeTarget('shared-b')
+    await expect(store.replaceTargetsAtInstallDirs(
+      'https://skill.xfyun.cn',
+      'global',
+      'shared',
+      '1.1.0',
+      [replacement],
+      'fp-v2',
+    )).rejects.toThrow('partial-target install would create inconsistent versions')
+
+    const inventory = await store.read()
+    expect(inventory.items).toHaveLength(1)
+    expect(inventory.items[0]).toMatchObject({ version: '1.0.0', fingerprint: 'fp-v1' })
+    expect(inventory.items[0]?.targets).toEqual([retained])
+  })
 })

--- a/cli/test/unit/stores/inventory-store.test.ts
+++ b/cli/test/unit/stores/inventory-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, utimes } from 'node:fs/promises'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
@@ -37,19 +37,16 @@ describe('InventoryStore', () => {
     expect(inventory.items).toHaveLength(5)
   })
 
-  test('recovers from stale lock file', async () => {
+  test('recovers from a stale lock directory', async () => {
     const home = await makeTempHome()
     const store = new InventoryStore(home)
 
-    // Ensure the directory for the lock file exists
+    // proper-lockfile uses atomic mkdir and an mtime lease.
     await mkdir(dirname(store.path), { recursive: true })
-
-    // Write a stale lock: dead PID + old timestamp
     const lockPath = `${store.path}.lock`
-    await writeFile(
-      lockPath,
-      JSON.stringify({ pid: 999999, timestamp: Date.now() - 60000 }),
-    )
+    await mkdir(lockPath)
+    const staleTime = new Date(Date.now() - 60_000)
+    await utimes(lockPath, staleTime, staleTime)
 
     // upsertTarget should recover from the stale lock and succeed
     await store.upsertTarget(

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -251,6 +251,8 @@ matches.
 All targets in one inventory entry are upgraded together. A filter that selects only part of that
 entry is rejected because the current inventory format stores one shared version for all targets.
 The command also keeps the local files when the registry resolves to an older version.
+If a multi-Skill run fails after an earlier upgrade commits, execution stops and reports each item
+as `upgraded`, `failed`, or `not-attempted`; a committed upgrade is never rolled back implicitly.
 New installations store absolute target paths. Reinstall an older entry that still contains relative
 target paths before upgrading it; the CLI cannot safely infer the original working directory.
 

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -251,6 +251,8 @@ matches.
 All targets in one inventory entry are upgraded together. A filter that selects only part of that
 entry is rejected because the current inventory format stores one shared version for all targets.
 The command also keeps the local files when the registry resolves to an older version.
+New installations store absolute target paths. Reinstall an older entry that still contains relative
+target paths before upgrading it; the CLI cannot safely infer the original working directory.
 
 ## Local Management
 

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -157,7 +157,7 @@ skillhub install pdf-parser --agent codex --agent claude-code
 # Install to custom directory
 skillhub install pdf-parser --dir ~/.claude/skills
 
-# Force overwrite existing installation
+# Reinstall a SkillHub-managed installation from the same source
 skillhub install pdf-parser --force
 ```
 
@@ -214,14 +214,39 @@ For a custom path or an unsupported Agent directory, use `--dir` to specify the 
 
 ```json
 {
+  "schemaVersion": 1,
   "registry": "https://skill.xfyun.cn",
   "namespace": "global",
   "slug": "pdf-parser",
   "version": "1.0.0",
+  "versionId": 123,
+  "fingerprint": "sha256:...",
+  "files": { "SKILL.md": "sha256..." },
   "agent": "codex",
   "installedAt": "2026-04-28T06:00:00.000Z"
 }
 ```
+
+The CLI creates this file after extracting the registry package. It is not included in the downloaded
+ZIP, and `.skillhub/` is excluded when an installed directory is published again.
+
+## Upgrade Installed Skills
+
+```bash
+# Preview without changing files
+skillhub upgrade @global/skillhub-registry --check
+
+# Upgrade one or a bounded list of installed Skills
+skillhub upgrade @global/skillhub-registry
+skillhub upgrade @team/code-review @team/java-guide
+
+# Deterministic machine-readable plan
+skillhub upgrade @team/code-review --check --json
+```
+
+`upgrade` never installs a missing Skill and has no implicit upgrade-all mode. Local changes require
+`--force`; it only replaces a managed installation whose full `registry + namespace + slug` source
+matches.
 
 ## Local Management
 
@@ -504,9 +529,24 @@ Options:
 - `--version <v>` — Version (default: latest)
 - `--agent <profile>` — Agent profile (repeatable)
 - `--dir <path>` — Custom installation directory (mutually exclusive with `--scope` and `--agent`)
-- `--force` — Overwrite existing installation
+- `--force` — Replace an existing SkillHub-managed installation from the same source
 - `--registry <url>` — Registry URL
 - `--token <token>` — API token
+- `--json` — JSON output
+
+### upgrade
+
+```bash
+skillhub upgrade <coordinate...> [options]
+```
+
+Options:
+- `--namespace <slug>` — Filter a bare slug by namespace
+- `--agent <profile>` — Filter installed targets by Agent (repeatable)
+- `--dir <path>` — Filter installed targets by directory
+- `--registry <url>` — Filter by installation source registry
+- `--check` — Print the exact plan without modifying files
+- `--force` — Replace local changes only for the same full source identity
 - `--json` — JSON output
 
 ### list
@@ -604,13 +644,16 @@ skillhub search test --registry https://skillhub.example.com
 ### Installation Directory Conflict
 
 ```bash
-# Use --force to overwrite
+# Reinstall only when the existing directory has matching SkillHub source metadata
 skillhub install pdf-parser --force
 
 # Or remove first then install
 skillhub remove pdf-parser
 skillhub install pdf-parser
 ```
+
+`--force` never overwrites an unmanaged directory or a Skill installed from another registry,
+namespace, or slug. Move or explicitly remove that directory first.
 
 ### Corrupted Inventory
 

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -248,6 +248,10 @@ skillhub upgrade @team/code-review --check --json
 `--force`; it only replaces a managed installation whose full `registry + namespace + slug` source
 matches.
 
+All targets in one inventory entry are upgraded together. A filter that selects only part of that
+entry is rejected because the current inventory format stores one shared version for all targets.
+The command also keeps the local files when the registry resolves to an older version.
+
 ## Local Management
 
 ### List Installed Skills


### PR DESCRIPTION
## Summary

- add `skillhub upgrade <coordinate...>` for explicitly selected managed installations
- preserve local content on source conflicts, local modifications, version regressions, and failed replacement
- serialize install, remove, and upgrade mutations for the same target
- add CLI tests and user documentation

## Scope

This is the first delivery slice of #789. It does not implement bounded namespace browsing, selected `sync pull`, server-side namespace membership APIs, or `sync diff` redesign. The parent issue must remain open.

## Validation

- [x] independent exact-diff review completed with no blocker/high finding
- [ ] current-SHA CLI typecheck, lint, build, and tests
- [ ] built CLI exercised against local registry
- [ ] exact-SHA local runtime/auth smoke

Part of #789