### PR TITLE
chore(deploy): pin MinIO runtime image

### DIFF
--- a/.github/workflows/pr-scripts.yml
+++ b/.github/workflows/pr-scripts.yml
@@ -7,6 +7,9 @@ on:
       - '.env.release.example'
       - '.env.release.draft'
       - 'compose.release.yml'
+      - 'docker-compose.yml'
+      - 'deploy/runtime-mirror-images.txt'
+      - 'charts/skillhub/tests/install-upgrade-smoke.sh'
       - 'server/Dockerfile'
       - 'Makefile'
       - 'web/Dockerfile'
@@ -46,3 +49,4 @@ jobs:
       - run: bash scripts/tests/dev-web-host-test.sh
       - run: bash scripts/tests/server-image-compat-test.sh
       - run: bash scripts/tests/workflow-security-test.sh
+      - run: bash scripts/tests/runtime-image-pins-test.sh

--- a/charts/skillhub/tests/install-upgrade-smoke.sh
+++ b/charts/skillhub/tests/install-upgrade-smoke.sh
@@ -84,7 +84,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: docker.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+          image: docker.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
           args:
             - server
             - /data

--- a/deploy/runtime-mirror-images.txt
+++ b/deploy/runtime-mirror-images.txt
@@ -1,7 +1,7 @@
 # source_image target_image
 postgres:16-alpine postgres:16-alpine
 redis:7-alpine redis:7-alpine
-minio/minio:latest minio:latest
+minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e minio:RELEASE.2025-09-07T16-13-09Z
 prom/prometheus:latest prometheus:latest
 grafana/grafana:latest grafana:latest
 nginx:alpine nginx:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       retries: 5
 
   minio:
-    image: ${MINIO_IMAGE:-minio/minio:latest}
+    image: ${MINIO_IMAGE:-minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e}
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/scripts/tests/runtime-image-pins-test.sh
+++ b/scripts/tests/runtime-image-pins-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MINIO_RELEASE="RELEASE.2025-09-07T16-13-09Z"
+MINIO_DIGEST="sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+MINIO_IMAGE="minio/minio:${MINIO_RELEASE}@${MINIO_DIGEST}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+grep -Fq "image: \${MINIO_IMAGE:-${MINIO_IMAGE}}" "$REPO_ROOT/docker-compose.yml" \
+  || fail "docker-compose.yml must default to the pinned MinIO release and digest"
+
+grep -Fxq "${MINIO_IMAGE} minio:${MINIO_RELEASE}" "$REPO_ROOT/deploy/runtime-mirror-images.txt" \
+  || fail "runtime mirror mapping must use the pinned MinIO source and release target"
+
+grep -Fq "image: docker.io/${MINIO_IMAGE}" "$REPO_ROOT/charts/skillhub/tests/install-upgrade-smoke.sh" \
+  || fail "Helm S3 smoke must use the same pinned MinIO release and digest"
+
+if grep -Fq 'minio/minio:latest' \
+  "$REPO_ROOT/docker-compose.yml" \
+  "$REPO_ROOT/deploy/runtime-mirror-images.txt" \
+  "$REPO_ROOT/charts/skillhub/tests/install-upgrade-smoke.sh"; then
+  fail "validated MinIO runtime surfaces must not use the floating latest tag"
+fi
+
+echo "PASS: MinIO runtime images are pinned to ${MINIO_RELEASE}@${MINIO_DIGEST}"


### PR DESCRIPTION
## What
- pin development Compose, runtime mirroring, and Helm S3 smoke to MinIO `RELEASE.2025-09-07T16-13-09Z`
- bind the release tag to the currently validated digest `sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e`
- add a script regression check that rejects `minio/minio:latest` on validated runtime surfaces

## Why
The MinIO preview used to validate PRs #792 and #793 resolved `latest` to this release. Keeping a floating tag would make later preview and deployment behavior non-reproducible.

## How
Use a readable release tag plus an immutable digest. Runtime mirroring publishes the same versioned target tag instead of `minio:latest`.

## Testing
- `bash scripts/tests/runtime-image-pins-test.sh`
- `docker compose config --images`
- `python3 /home/ylhu16/.agents/skills/handle-skillhub-issue-pr/tests/test_validation_methodology.py` (local workflow skill)

## Impact
No data migration or application API change. Operators overriding `MINIO_IMAGE` keep the existing override behavior. Full exact-SHA runtime validation is in progress.