### PR TITLE
fix: allow super admin skill lifecycle changes

### DIFF
--- a/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/admin/AdminSkillController.java
+++ b/server/skillhub-app/src/main/java/com/iflytek/skillhub/controller/admin/AdminSkillController.java
@@ -2,11 +2,17 @@ package com.iflytek.skillhub.controller.admin;
 
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
 import com.iflytek.skillhub.controller.BaseApiController;
+import com.iflytek.skillhub.domain.namespace.Namespace;
+import com.iflytek.skillhub.domain.namespace.NamespaceRepository;
+import com.iflytek.skillhub.domain.shared.exception.DomainBadRequestException;
+import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.dto.AdminSkillActionRequest;
 import com.iflytek.skillhub.dto.AdminSkillMutationResponse;
 import com.iflytek.skillhub.dto.ApiResponse;
 import com.iflytek.skillhub.dto.ApiResponseFactory;
+import com.iflytek.skillhub.dto.SkillLifecycleMutationResponse;
 import com.iflytek.skillhub.domain.skill.service.SkillGovernanceService;
+import com.iflytek.skillhub.domain.skill.service.SkillSlugResolutionService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,11 +31,53 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminSkillController extends BaseApiController {
 
     private final SkillGovernanceService skillGovernanceService;
+    private final NamespaceRepository namespaceRepository;
+    private final SkillSlugResolutionService skillSlugResolutionService;
 
     public AdminSkillController(ApiResponseFactory responseFactory,
-                                SkillGovernanceService skillGovernanceService) {
+                                SkillGovernanceService skillGovernanceService,
+                                NamespaceRepository namespaceRepository,
+                                SkillSlugResolutionService skillSlugResolutionService) {
         super(responseFactory);
         this.skillGovernanceService = skillGovernanceService;
+        this.namespaceRepository = namespaceRepository;
+        this.skillSlugResolutionService = skillSlugResolutionService;
+    }
+
+    @PostMapping("/{namespace}/{slug}/archive")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    public ApiResponse<SkillLifecycleMutationResponse> archiveSkill(@PathVariable String namespace,
+                                                                     @PathVariable String slug,
+                                                                     @RequestBody(required = false) AdminSkillActionRequest request,
+                                                                     @AuthenticationPrincipal PlatformPrincipal principal,
+                                                                     HttpServletRequest httpRequest) {
+        Skill skill = findSkill(namespace, slug);
+        Skill archived = skillGovernanceService.archiveSkillAsAdmin(
+            skill.getId(),
+            principal.userId(),
+            httpRequest.getRemoteAddr(),
+            httpRequest.getHeader("User-Agent"),
+            request != null ? request.reason() : null
+        );
+        return ok("response.success.updated", new SkillLifecycleMutationResponse(
+            archived.getId(), null, "ARCHIVE", archived.getStatus().name()));
+    }
+
+    @PostMapping("/{namespace}/{slug}/unarchive")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    public ApiResponse<SkillLifecycleMutationResponse> unarchiveSkill(@PathVariable String namespace,
+                                                                       @PathVariable String slug,
+                                                                       @AuthenticationPrincipal PlatformPrincipal principal,
+                                                                       HttpServletRequest httpRequest) {
+        Skill skill = findSkill(namespace, slug);
+        Skill restored = skillGovernanceService.unarchiveSkillAsAdmin(
+            skill.getId(),
+            principal.userId(),
+            httpRequest.getRemoteAddr(),
+            httpRequest.getHeader("User-Agent")
+        );
+        return ok("response.success.updated", new SkillLifecycleMutationResponse(
+            restored.getId(), null, "UNARCHIVE", restored.getStatus().name()));
     }
 
     @PostMapping("/{skillId}/hide")
@@ -76,5 +124,13 @@ public class AdminSkillController extends BaseApiController {
             request != null ? request.reason() : null
         );
         return ok("response.success.updated", new AdminSkillMutationResponse(version.getSkillId(), versionId, "YANK", version.getStatus().name()));
+    }
+
+    private Skill findSkill(String namespaceSlug, String skillSlug) {
+        String cleanNamespace = namespaceSlug.startsWith("@") ? namespaceSlug.substring(1) : namespaceSlug;
+        Namespace namespace = namespaceRepository.findBySlug(cleanNamespace)
+            .orElseThrow(() -> new DomainBadRequestException("error.namespace.slug.notFound", cleanNamespace));
+        return skillSlugResolutionService.resolve(
+            namespace.getId(), skillSlug, null, SkillSlugResolutionService.Preference.PUBLISHED);
     }
 }

--- a/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/admin/AdminSkillControllerTest.java
+++ b/server/skillhub-app/src/test/java/com/iflytek/skillhub/controller/admin/AdminSkillControllerTest.java
@@ -9,12 +9,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.iflytek.skillhub.auth.device.DeviceAuthService;
 import com.iflytek.skillhub.auth.rbac.PlatformPrincipal;
+import com.iflytek.skillhub.domain.namespace.Namespace;
 import com.iflytek.skillhub.domain.namespace.NamespaceMemberRepository;
+import com.iflytek.skillhub.domain.namespace.NamespaceRepository;
 import com.iflytek.skillhub.domain.skill.Skill;
 import com.iflytek.skillhub.domain.skill.SkillVersion;
 import com.iflytek.skillhub.domain.skill.SkillVisibility;
 import com.iflytek.skillhub.domain.skill.SkillVersionStatus;
 import com.iflytek.skillhub.domain.skill.service.SkillGovernanceService;
+import com.iflytek.skillhub.domain.skill.service.SkillSlugResolutionService;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -27,6 +30,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -40,10 +44,81 @@ class AdminSkillControllerTest {
     private SkillGovernanceService skillGovernanceService;
 
     @MockBean
+    private NamespaceRepository namespaceRepository;
+
+    @MockBean
+    private SkillSlugResolutionService skillSlugResolutionService;
+
+    @MockBean
     private NamespaceMemberRepository namespaceMemberRepository;
 
     @MockBean
     private DeviceAuthService deviceAuthService;
+
+    @Test
+    void archiveSkill_returnsUpdatedResponse() throws Exception {
+        Namespace namespace = new Namespace("global", "Global", "owner");
+        ReflectionTestUtils.setField(namespace, "id", 1L);
+        Skill skill = new Skill(1L, "demo", "owner", SkillVisibility.PUBLIC);
+        ReflectionTestUtils.setField(skill, "id", 10L);
+        skill.setStatus(com.iflytek.skillhub.domain.skill.SkillStatus.ARCHIVED);
+        given(namespaceRepository.findBySlug("global")).willReturn(java.util.Optional.of(namespace));
+        given(skillSlugResolutionService.resolve(
+                1L, "demo", null, SkillSlugResolutionService.Preference.PUBLISHED))
+            .willReturn(skill);
+        given(skillGovernanceService.archiveSkillAsAdmin(
+                org.mockito.ArgumentMatchers.eq(10L),
+                org.mockito.ArgumentMatchers.eq("admin"),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.eq("policy")))
+            .willReturn(skill);
+
+        PlatformPrincipal principal = new PlatformPrincipal("admin", "admin", "a@example.com", "", "github", Set.of("SUPER_ADMIN"));
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, List.of(new SimpleGrantedAuthority("ROLE_SUPER_ADMIN")));
+
+        mockMvc.perform(post("/api/v1/admin/skills/global/demo/archive")
+                .with(authentication(auth))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"reason\":\"policy\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.data.skillId").value(10))
+            .andExpect(jsonPath("$.data.action").value("ARCHIVE"))
+            .andExpect(jsonPath("$.data.status").value("ARCHIVED"));
+    }
+
+    @Test
+    void unarchiveSkill_returnsUpdatedResponse() throws Exception {
+        Namespace namespace = new Namespace("global", "Global", "owner");
+        ReflectionTestUtils.setField(namespace, "id", 1L);
+        Skill skill = new Skill(1L, "demo", "owner", SkillVisibility.PUBLIC);
+        ReflectionTestUtils.setField(skill, "id", 10L);
+        skill.setStatus(com.iflytek.skillhub.domain.skill.SkillStatus.ACTIVE);
+        given(namespaceRepository.findBySlug("global")).willReturn(java.util.Optional.of(namespace));
+        given(skillSlugResolutionService.resolve(
+                1L, "demo", null, SkillSlugResolutionService.Preference.PUBLISHED))
+            .willReturn(skill);
+        given(skillGovernanceService.unarchiveSkillAsAdmin(
+                org.mockito.ArgumentMatchers.eq(10L),
+                org.mockito.ArgumentMatchers.eq("admin"),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()))
+            .willReturn(skill);
+
+        PlatformPrincipal principal = new PlatformPrincipal("admin", "admin", "a@example.com", "", "github", Set.of("SUPER_ADMIN"));
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, List.of(new SimpleGrantedAuthority("ROLE_SUPER_ADMIN")));
+
+        mockMvc.perform(post("/api/v1/admin/skills/global/demo/unarchive")
+                .with(authentication(auth))
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.data.skillId").value(10))
+            .andExpect(jsonPath("$.data.action").value("UNARCHIVE"))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
 
     @Test
     void hideSkill_returnsUpdatedResponse() throws Exception {

--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillGovernanceService.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/service/SkillGovernanceService.java
@@ -157,6 +157,23 @@ public class SkillGovernanceService {
     }
 
     @Transactional
+    public Skill unarchiveSkillAsAdmin(Long skillId,
+                                       String actorUserId,
+                                       String clientIp,
+                                       String userAgent) {
+        Skill skill = skillRepository.findById(skillId)
+                .orElseThrow(() -> new DomainNotFoundException("error.skill.notFound", skillId));
+
+        SkillStatus previousStatus = skill.getStatus();
+        skill.setStatus(SkillStatus.ACTIVE);
+        skill.setUpdatedBy(actorUserId);
+        Skill saved = skillRepository.save(skill);
+        auditLogService.record(actorUserId, "UNARCHIVE_SKILL", "SKILL", skillId, null, clientIp, userAgent, null);
+        eventPublisher.publishEvent(new SkillStatusChangedEvent(skillId, previousStatus, SkillStatus.ACTIVE));
+        return saved;
+    }
+
+    @Transactional
     public void deleteVersion(Skill skill,
                               SkillVersion version,
                               String actorUserId,


### PR DESCRIPTION
## Summary\n- Add the SUPER_ADMIN admin endpoint for skill unarchive, complementing the existing admin archive endpoint.\n- Delegate both mutations to admin governance methods while preserving audit and status events.\n- Add controller coverage for archive and unarchive.\n\n## Test plan\n- AdminSkillControllerTest: 6 tests passed with JDK 21.