### PR TITLE
fix(web): preserve dashboard return path from skill details

### DIFF
--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -393,6 +393,9 @@ const dashboardStarsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'dashboard/stars',
   beforeLoad: requireAuth,
+  validateSearch: (search: Record<string, unknown>): { page?: number } => ({
+    page: typeof search.page === 'number' && search.page > 0 ? search.page : undefined,
+  }),
   component: MyStarsPage,
 })
 
@@ -400,6 +403,9 @@ const dashboardSubscriptionsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'dashboard/subscriptions',
   beforeLoad: requireAuth,
+  validateSearch: (search: Record<string, unknown>): { page?: number } => ({
+    page: typeof search.page === 'number' && search.page > 0 ? search.page : undefined,
+  }),
   component: MySubscriptionsPage,
 })
 

--- a/web/src/pages/dashboard/stars.test.ts
+++ b/web/src/pages/dashboard/stars.test.ts
@@ -5,9 +5,21 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const navigate = vi.fn()
+const { useMyStarsPage } = vi.hoisted(() => ({
+  useMyStarsPage: vi.fn(() => ({
+    data: {
+      items: [{ id: 1, namespace: 'team-a', slug: 'demo skill' }],
+      total: 1,
+      page: 0,
+      size: 12,
+    },
+    isLoading: false,
+  })),
+}))
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigate,
+  useSearch: () => ({ page: 2 }),
   useLocation: () => ({
     pathname: '/dashboard/stars',
     searchStr: '?page=2',
@@ -34,15 +46,7 @@ vi.mock('@/shared/components/pagination', () => ({
 }))
 
 vi.mock('@/shared/hooks/use-user-queries', () => ({
-  useMyStarsPage: () => ({
-    data: {
-      items: [{ id: 1, namespace: 'team-a', slug: 'demo skill' }],
-      total: 1,
-      page: 0,
-      size: 12,
-    },
-    isLoading: false,
-  }),
+  useMyStarsPage,
 }))
 
 vi.mock('@/shared/ui/card', () => ({
@@ -71,5 +75,11 @@ describe('MyStarsPage', () => {
       to: '/space/team-a/demo%20skill',
       search: { returnTo: '/dashboard/stars?page=2#saved' },
     })
+  })
+
+  it('uses the URL page as the query source', () => {
+    render(createElement(MyStarsPage))
+
+    expect(useMyStarsPage).toHaveBeenCalledWith({ page: 2, size: 12 })
   })
 })

--- a/web/src/pages/dashboard/stars.tsx
+++ b/web/src/pages/dashboard/stars.tsx
@@ -1,17 +1,19 @@
 import { useState } from 'react'
-import { useNavigate } from '@tanstack/react-router'
+import { useLocation, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { SkillCard } from '@/features/skill/skill-card'
 import { Pagination } from '@/shared/components/pagination'
 import { useMyStarsPage } from '@/shared/hooks/use-user-queries'
 import { Card } from '@/shared/ui/card'
 import { DashboardPageHeader } from '@/shared/components/dashboard-page-header'
+import { buildReturnTo } from '@/shared/lib/auth-route'
 
 const PAGE_SIZE = 12
 
 export function MyStarsPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const location = useLocation()
   const [page, setPage] = useState(0)
   const { data, isLoading } = useMyStarsPage({ page, size: PAGE_SIZE })
   const skills = data?.items ?? []
@@ -40,7 +42,10 @@ export function MyStarsPage() {
               <SkillCard
                 key={skill.id}
                 skill={skill}
-                onClick={() => navigate({ to: `/space/${skill.namespace}/${encodeURIComponent(skill.slug)}` })}
+                onClick={() => navigate({
+                  to: `/space/${skill.namespace}/${encodeURIComponent(skill.slug)}`,
+                  search: { returnTo: buildReturnTo(location) },
+                })}
               />
             ))}
           </div>

--- a/web/src/pages/dashboard/stars.tsx
+++ b/web/src/pages/dashboard/stars.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react'
-import { useLocation, useNavigate } from '@tanstack/react-router'
+import { useLocation, useNavigate, useSearch } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { SkillCard } from '@/features/skill/skill-card'
 import { Pagination } from '@/shared/components/pagination'
@@ -14,7 +13,8 @@ export function MyStarsPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const location = useLocation()
-  const [page, setPage] = useState(0)
+  const search = useSearch({ from: '/dashboard/stars' })
+  const page = search.page ?? 0
   const { data, isLoading } = useMyStarsPage({ page, size: PAGE_SIZE })
   const skills = data?.items ?? []
   const totalPages = data ? Math.max(Math.ceil(data.total / data.size), 1) : 1
@@ -50,7 +50,14 @@ export function MyStarsPage() {
             ))}
           </div>
           {data && data.total > PAGE_SIZE ? (
-            <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              onPageChange={(nextPage) => navigate({
+                to: '/dashboard/stars',
+                search: { page: nextPage > 0 ? nextPage : undefined },
+              })}
+            />
           ) : null}
         </>
       )}

--- a/web/src/pages/dashboard/subscriptions.test.ts
+++ b/web/src/pages/dashboard/subscriptions.test.ts
@@ -9,9 +9,9 @@ const navigate = vi.fn()
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigate,
   useLocation: () => ({
-    pathname: '/dashboard/stars',
-    searchStr: '?page=2',
-    hash: '#saved',
+    pathname: '/dashboard/subscriptions',
+    searchStr: '?page=1',
+    hash: '',
   }),
 }))
 
@@ -19,9 +19,7 @@ vi.mock('react-i18next', async () => {
   const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next')
   return {
     ...actual,
-    useTranslation: () => ({
-      t: (key: string) => key,
-    }),
+    useTranslation: () => ({ t: (key: string) => key }),
   }
 })
 
@@ -29,14 +27,11 @@ vi.mock('@/features/skill/skill-card', () => ({
   SkillCard: ({ onClick }: { onClick?: () => void }) => createElement('button', { onClick }, 'skill-card'),
 }))
 
-vi.mock('@/shared/components/pagination', () => ({
-  Pagination: () => null,
-}))
-
+vi.mock('@/shared/components/pagination', () => ({ Pagination: () => null }))
 vi.mock('@/shared/hooks/use-user-queries', () => ({
-  useMyStarsPage: () => ({
+  useMySubscriptionsPage: () => ({
     data: {
-      items: [{ id: 1, namespace: 'team-a', slug: 'demo skill' }],
+      items: [{ id: 1, namespace: 'team-a', slug: 'demo-skill' }],
       total: 1,
       page: 0,
       size: 12,
@@ -44,32 +39,22 @@ vi.mock('@/shared/hooks/use-user-queries', () => ({
     isLoading: false,
   }),
 }))
+vi.mock('@/shared/ui/card', () => ({ Card: ({ children }: { children: unknown }) => children }))
+vi.mock('@/shared/components/dashboard-page-header', () => ({ DashboardPageHeader: () => null }))
 
-vi.mock('@/shared/ui/card', () => ({
-  Card: ({ children }: { children: unknown }) => children,
-}))
+import { MySubscriptionsPage } from './subscriptions'
 
-vi.mock('@/shared/components/dashboard-page-header', () => ({
-  DashboardPageHeader: () => null,
-}))
-
-import { MyStarsPage } from './stars'
-
-describe('MyStarsPage', () => {
+describe('MySubscriptionsPage', () => {
   beforeEach(() => navigate.mockClear())
 
-  it('exports a named component function', () => {
-    expect(typeof MyStarsPage).toBe('function')
-  })
-
-  it('preserves the favorites page when opening a skill', () => {
-    render(createElement(MyStarsPage))
+  it('preserves the subscriptions page when opening a skill', () => {
+    render(createElement(MySubscriptionsPage))
 
     fireEvent.click(screen.getByRole('button', { name: 'skill-card' }))
 
     expect(navigate).toHaveBeenCalledWith({
-      to: '/space/team-a/demo%20skill',
-      search: { returnTo: '/dashboard/stars?page=2#saved' },
+      to: '/space/team-a/demo-skill',
+      search: { returnTo: '/dashboard/subscriptions?page=1' },
     })
   })
 })

--- a/web/src/pages/dashboard/subscriptions.test.ts
+++ b/web/src/pages/dashboard/subscriptions.test.ts
@@ -5,9 +5,21 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const navigate = vi.fn()
+const { useMySubscriptionsPage } = vi.hoisted(() => ({
+  useMySubscriptionsPage: vi.fn(() => ({
+    data: {
+      items: [{ id: 1, namespace: 'team-a', slug: 'demo-skill' }],
+      total: 1,
+      page: 0,
+      size: 12,
+    },
+    isLoading: false,
+  })),
+}))
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigate,
+  useSearch: () => ({ page: 1 }),
   useLocation: () => ({
     pathname: '/dashboard/subscriptions',
     searchStr: '?page=1',
@@ -29,15 +41,7 @@ vi.mock('@/features/skill/skill-card', () => ({
 
 vi.mock('@/shared/components/pagination', () => ({ Pagination: () => null }))
 vi.mock('@/shared/hooks/use-user-queries', () => ({
-  useMySubscriptionsPage: () => ({
-    data: {
-      items: [{ id: 1, namespace: 'team-a', slug: 'demo-skill' }],
-      total: 1,
-      page: 0,
-      size: 12,
-    },
-    isLoading: false,
-  }),
+  useMySubscriptionsPage,
 }))
 vi.mock('@/shared/ui/card', () => ({ Card: ({ children }: { children: unknown }) => children }))
 vi.mock('@/shared/components/dashboard-page-header', () => ({ DashboardPageHeader: () => null }))
@@ -56,5 +60,11 @@ describe('MySubscriptionsPage', () => {
       to: '/space/team-a/demo-skill',
       search: { returnTo: '/dashboard/subscriptions?page=1' },
     })
+  })
+
+  it('uses the URL page as the query source', () => {
+    render(createElement(MySubscriptionsPage))
+
+    expect(useMySubscriptionsPage).toHaveBeenCalledWith({ page: 1, size: 12 })
   })
 })

--- a/web/src/pages/dashboard/subscriptions.tsx
+++ b/web/src/pages/dashboard/subscriptions.tsx
@@ -1,17 +1,19 @@
 import { useState } from 'react'
-import { useNavigate } from '@tanstack/react-router'
+import { useLocation, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { SkillCard } from '@/features/skill/skill-card'
 import { Pagination } from '@/shared/components/pagination'
 import { useMySubscriptionsPage } from '@/shared/hooks/use-user-queries'
 import { Card } from '@/shared/ui/card'
 import { DashboardPageHeader } from '@/shared/components/dashboard-page-header'
+import { buildReturnTo } from '@/shared/lib/auth-route'
 
 const PAGE_SIZE = 12
 
 export function MySubscriptionsPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const location = useLocation()
   const [page, setPage] = useState(0)
   const { data, isLoading } = useMySubscriptionsPage({ page, size: PAGE_SIZE })
   const skills = data?.items ?? []
@@ -40,7 +42,10 @@ export function MySubscriptionsPage() {
               <SkillCard
                 key={skill.id}
                 skill={skill}
-                onClick={() => navigate({ to: `/space/${skill.namespace}/${encodeURIComponent(skill.slug)}` })}
+                onClick={() => navigate({
+                  to: `/space/${skill.namespace}/${encodeURIComponent(skill.slug)}`,
+                  search: { returnTo: buildReturnTo(location) },
+                })}
               />
             ))}
           </div>

--- a/web/src/pages/dashboard/subscriptions.tsx
+++ b/web/src/pages/dashboard/subscriptions.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react'
-import { useLocation, useNavigate } from '@tanstack/react-router'
+import { useLocation, useNavigate, useSearch } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { SkillCard } from '@/features/skill/skill-card'
 import { Pagination } from '@/shared/components/pagination'
@@ -14,7 +13,8 @@ export function MySubscriptionsPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const location = useLocation()
-  const [page, setPage] = useState(0)
+  const search = useSearch({ from: '/dashboard/subscriptions' })
+  const page = search.page ?? 0
   const { data, isLoading } = useMySubscriptionsPage({ page, size: PAGE_SIZE })
   const skills = data?.items ?? []
   const totalPages = data ? Math.max(Math.ceil(data.total / data.size), 1) : 1
@@ -50,7 +50,14 @@ export function MySubscriptionsPage() {
             ))}
           </div>
           {data && data.total > PAGE_SIZE ? (
-            <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              onPageChange={(nextPage) => navigate({
+                to: '/dashboard/subscriptions',
+                search: { page: nextPage > 0 ? nextPage : undefined },
+              })}
+            />
           ) : null}
         </>
       )}


### PR DESCRIPTION
## Problem

Opening a skill from My Stars or My Subscriptions discarded the dashboard origin, so the detail back button always fell back to search.

## Solution

- pass the full current dashboard URL through the existing validated `returnTo` search parameter
- cover both favorites and subscriptions navigation, including query/hash preservation

## Validation

- targeted Vitest: 3 passed
- targeted ESLint: passed
- TypeScript typecheck: passed

Closes #800
