### PR TITLE
fix(publish): ignore runtime secret expressions

### DIFF
--- a/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidator.java
+++ b/server/skillhub-domain/src/main/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidator.java
@@ -17,6 +17,12 @@ import java.util.regex.Pattern;
 @Component
 public class BasicPrePublishValidator implements PrePublishValidator {
 
+    private static final Pattern ASSIGNMENT_WITH_SENSITIVE_KEY = Pattern.compile(
+            "(?i)(api[_-]?key|access[_-]?key|secret|password|token)\\s*[:=]\\s*(.+)$"
+    );
+    private static final Pattern QUOTED_LITERAL = Pattern.compile("^(['\"])(.*)\\1$");
+    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+    private static final Pattern BARE_LITERAL = Pattern.compile("[A-Za-z0-9_\\-]{12,}");
     private static final Set<String> PLACEHOLDER_MARKERS = Set.of(
             "your", "example", "sample", "placeholder", "changeme", "replace", "dummy",
             "mock", "test", "fake", "todo", "xxx", "redacted");
@@ -24,10 +30,7 @@ public class BasicPrePublishValidator implements PrePublishValidator {
             new SecretRule(Pattern.compile("(AKIA[0-9A-Z]{16})"), 1, "cloud access key"),
             new SecretRule(Pattern.compile("(ghp_[A-Za-z0-9]{20,})"), 1, "GitHub token"),
             new SecretRule(Pattern.compile("(sk-[A-Za-z0-9]{20,})"), 1, "API key"),
-            new SecretRule(
-                    Pattern.compile("(?i)(api[_-]?key|access[_-]?key|secret|password|token)\\s*[:=]\\s*['\\\"]?([A-Za-z0-9_\\-]{12,})"),
-                    2,
-                    "secret or token")
+            new SecretRule(ASSIGNMENT_WITH_SENSITIVE_KEY, 0, "secret or token")
     );
 
     @Override
@@ -47,7 +50,10 @@ public class BasicPrePublishValidator implements PrePublishValidator {
                     if (!matcher.find()) {
                         continue;
                     }
-                    String matchedValue = matcher.group(rule.valueGroup());
+                    String matchedValue = extractMatchedValue(line, matcher, rule);
+                    if (matchedValue == null) {
+                        continue;
+                    }
                     if (isPlaceholderValue(matchedValue)) {
                         continue;
                     }
@@ -87,6 +93,66 @@ public class BasicPrePublishValidator implements PrePublishValidator {
         String normalizedValue = value.toLowerCase(Locale.ROOT);
         return PLACEHOLDER_MARKERS.stream().anyMatch(normalizedValue::contains)
                 || value.chars().allMatch(ch -> ch == 'x' || ch == 'X' || ch == '*' || ch == '-');
+    }
+
+    private String extractMatchedValue(String line, Matcher matcher, SecretRule rule) {
+        if (rule.valueGroup() > 0) {
+            return matcher.group(rule.valueGroup());
+        }
+
+        Matcher assignmentMatcher = ASSIGNMENT_WITH_SENSITIVE_KEY.matcher(line);
+        if (!assignmentMatcher.find()) {
+            return null;
+        }
+
+        String rawValue = assignmentMatcher.group(2).trim();
+        if (rawValue.isBlank()) {
+            return null;
+        }
+
+        Matcher quotedLiteralMatcher = QUOTED_LITERAL.matcher(rawValue);
+        if (quotedLiteralMatcher.matches()) {
+            return quotedLiteralMatcher.group(2);
+        }
+
+        rawValue = stripInlineComment(rawValue);
+        if (rawValue.isBlank()) {
+            return null;
+        }
+
+        quotedLiteralMatcher = QUOTED_LITERAL.matcher(rawValue);
+        if (quotedLiteralMatcher.matches()) {
+            return quotedLiteralMatcher.group(2);
+        }
+
+        if (looksLikeExpression(rawValue) || IDENTIFIER.matcher(rawValue).matches()) {
+            return null;
+        }
+
+        return BARE_LITERAL.matcher(rawValue).matches() ? rawValue : null;
+    }
+
+    private String stripInlineComment(String rawValue) {
+        int commentIndex = rawValue.indexOf('#');
+        int slashCommentIndex = rawValue.indexOf(" //");
+        if (slashCommentIndex >= 0 && (commentIndex < 0 || slashCommentIndex < commentIndex)) {
+            commentIndex = slashCommentIndex;
+        }
+        return commentIndex >= 0 ? rawValue.substring(0, commentIndex).trim() : rawValue;
+    }
+
+    private boolean looksLikeExpression(String rawValue) {
+        return rawValue.contains("(")
+                || rawValue.contains(")")
+                || rawValue.contains(".")
+                || rawValue.contains("[")
+                || rawValue.contains("]")
+                || rawValue.contains("{")
+                || rawValue.contains("}")
+                || rawValue.contains(",")
+                || rawValue.contains(" ")
+                || rawValue.contains("+")
+                || rawValue.contains("/");
     }
 
     private record SecretRule(Pattern pattern, int valueGroup, String label) {}

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidatorTest.java
@@ -132,7 +132,7 @@ class BasicPrePublishValidatorTest {
                 "scripts/config.py",
                 """
                 client_secret = "abcdefghijklmnop"  // hardcoded
-                refresh_token=zyxwvutsrqponmlk # hardcoded
+                refresh_token=zyxwvuts-12345678 # hardcoded
                 """.getBytes(StandardCharsets.UTF_8),
                 96,
                 "text/x-python"

--- a/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidatorTest.java
+++ b/server/skillhub-domain/src/test/java/com/iflytek/skillhub/domain/skill/validation/BasicPrePublishValidatorTest.java
@@ -98,4 +98,80 @@ class BasicPrePublishValidatorTest {
 
         assertTrue(result.passed());
     }
+
+    @Test
+    void shouldAllowRuntimeExpressionsAssignedToSensitiveVariables() {
+        PackageEntry script = new PackageEntry(
+                "scripts/oauth.py",
+                """
+                refresh_token = token_response.get("refresh_token")
+                client_secret = client_secret
+                self._client_secret = client_secret
+                access_token = ensure_valid_access_token(config)
+                headers = build_headers(access_token=access_token)
+                token = response.data["token"]
+                """.getBytes(StandardCharsets.UTF_8),
+                256,
+                "text/x-python"
+        );
+
+        ValidationResult result = validator.validate(new PrePublishValidator.SkillPackageContext(
+                List.of(script),
+                new SkillMetadata("Safe Skill", "desc", "1.0.0", "body", Map.of()),
+                "user-1",
+                1L
+        ));
+
+        assertTrue(result.passed());
+        assertTrue(result.warnings().isEmpty());
+    }
+
+    @Test
+    void shouldWarnOnQuotedAndBareCredentialLiterals() {
+        PackageEntry script = new PackageEntry(
+                "scripts/config.py",
+                """
+                client_secret = "abcdefghijklmnop"  // hardcoded
+                refresh_token=zyxwvutsrqponmlk # hardcoded
+                """.getBytes(StandardCharsets.UTF_8),
+                96,
+                "text/x-python"
+        );
+
+        ValidationResult result = validator.validate(new PrePublishValidator.SkillPackageContext(
+                List.of(script),
+                new SkillMetadata("Unsafe Skill", "desc", "1.0.0", "body", Map.of()),
+                "user-1",
+                1L
+        ));
+
+        assertTrue(result.passed());
+        assertTrue(result.warnings().stream().anyMatch(warning ->
+                warning.contains("scripts/config.py line 1")));
+        assertTrue(result.warnings().stream().anyMatch(warning ->
+                warning.contains("scripts/config.py line 2")));
+    }
+
+    @Test
+    void shouldStillWarnOnProviderSpecificTokensInsideExpressions() {
+        PackageEntry script = new PackageEntry(
+                "scripts/client.py",
+                """
+                headers = build_headers("ghp_abcdefghijklmnopqrstuvwxyz1234")
+                """.getBytes(StandardCharsets.UTF_8),
+                68,
+                "text/x-python"
+        );
+
+        ValidationResult result = validator.validate(new PrePublishValidator.SkillPackageContext(
+                List.of(script),
+                new SkillMetadata("Unsafe Skill", "desc", "1.0.0", "body", Map.of()),
+                "user-1",
+                1L
+        ));
+
+        assertTrue(result.passed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().getFirst().contains("GitHub token"));
+    }
 }


### PR DESCRIPTION
## Summary

- restore the literal-versus-expression classification introduced by #253 and accidentally removed by #288
- ignore identifiers, function calls, attribute/index access, environment expansion, and nested runtime arguments assigned to sensitive variable names
- preserve the current warning-only result and `confirmWarnings` flow from #288
- continue warning on quoted and bare credential literals and on high-confidence provider token formats wherever they appear
- cover every representative false positive from #827 plus positive hardcoded-secret cases

Closes #827.

## Why

The broad assignment regex currently captures values such as `token_response`, `client_secret`, and `ensure_valid_access_token` as if they were credential literals. Severity and value classification are separate concerns: this change restores classification while retaining confirmable warnings for actual literals.

## Validation

- `git diff --check` — passes
- regression tests added for identifiers, calls, attributes, indexing, nested keyword arguments, quoted literals with comments, bare literals, and embedded GitHub tokens
- local Maven execution could not reach JUnit because this host only has JDK 17 while the repository compiles with `--release 21`; GitHub Java 21 CI is the authoritative test run
- no API contract or generated files changed