### PR TITLE
fix(cli): preserve shared SkillHub state fields

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable CLI behavior changes are documented in this file.
 
 ### Fixed
 
+- Preserve unknown fields in shared `~/.skillhub/config.json` and `credentials.json` files, and
+  treat a compatible credentials document without first-party `tokens` as logged out instead of
+  failing. Login and logout now modify only the first-party registry state.
 - Return structured JSON from `help --json` and topic help, report unknown help topics as usage
   errors, and support `--version` / `-v` alongside the existing `version` command.
 - Report successful publish and sync push requests as submissions, preserving the registry's raw

--- a/cli/README.md
+++ b/cli/README.md
@@ -86,6 +86,10 @@ skillhub login --token sk_xxx --registry https://skillhub.example.com
 
 `login` validates the token, stores it in `~/.skillhub/credentials.json`, and writes the registry to `~/.skillhub/config.json`.
 
+Both files are updated non-destructively: SkillHub CLI changes only its own `tokens` and `registry`
+fields and preserves unknown fields written by other compatible tools. This allows tools that share
+the `~/.skillhub` directory to keep independently named state in the same JSON documents.
+
 ### Check Current Identity
 
 ```bash

--- a/cli/src/stores/config-store.ts
+++ b/cli/src/stores/config-store.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { joinPath, userStateDir, ensureDir, pathExists } from '../platform/paths'
 
-export interface CliConfig {
+export interface CliConfig extends Record<string, unknown> {
   registry?: string
   defaultAgent?: string
   lastUpdateCheckAt?: string

--- a/cli/src/stores/credentials-store.ts
+++ b/cli/src/stores/credentials-store.ts
@@ -2,8 +2,8 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { joinPath, userStateDir, ensureDir, applyCredentialPermissions, pathExists } from '../platform/paths'
 
-interface CredentialsFile {
-  tokens: Record<string, string>
+interface CredentialsFile extends Record<string, unknown> {
+  tokens?: Record<string, unknown>
 }
 
 export class CredentialsStore {
@@ -14,18 +14,22 @@ export class CredentialsStore {
   }
 
   async read(): Promise<CredentialsFile> {
-    if (!(await pathExists(this.path))) return { tokens: {} }
+    if (!(await pathExists(this.path))) return {}
     return JSON.parse(await readFile(this.path, 'utf-8')) as CredentialsFile
   }
 
   async getToken(registry: string): Promise<string | undefined> {
-    return (await this.read()).tokens[registry]
+    const token = (await this.read()).tokens?.[registry]
+    return typeof token === 'string' ? token : undefined
   }
 
   async setToken(registry: string, token: string): Promise<void> {
     const current = await this.read()
     await ensureDir(dirname(this.path))
-    await writeFile(this.path, JSON.stringify({ tokens: { ...current.tokens, [registry]: token } }, null, 2))
+    await writeFile(this.path, JSON.stringify({
+      ...current,
+      tokens: { ...current.tokens, [registry]: token }
+    }, null, 2))
     await applyCredentialPermissions(this.path)
   }
 
@@ -34,7 +38,7 @@ export class CredentialsStore {
     const tokens = { ...current.tokens }
     delete tokens[registry]
     await ensureDir(dirname(this.path))
-    await writeFile(this.path, JSON.stringify({ tokens }, null, 2))
+    await writeFile(this.path, JSON.stringify({ ...current, tokens }, null, 2))
     await applyCredentialPermissions(this.path)
   }
 }

--- a/cli/test/integration/auth-commands.test.ts
+++ b/cli/test/integration/auth-commands.test.ts
@@ -30,6 +30,42 @@ describe('auth commands', () => {
     expect(await Bun.file(`${env.home}/.skillhub/credentials.json`).json()).toMatchObject({ tokens: { [registry.url]: 'sk_ok' } })
   })
 
+  test('login and logout preserve compatible third-party state', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({ token: 'sk_ok', user: { handle: 'u1', displayName: 'User One' } })
+    const thirdPartyUser = { token: 'third-party-token', host: 'https://api.skillhub.cn' }
+    await Bun.write(`${env.home}/.skillhub/config.json`, JSON.stringify({
+      self_update_url: 'https://skillhub.example.com/version.json',
+      auto_self_upgrade: false
+    }))
+    await Bun.write(`${env.home}/.skillhub/credentials.json`, JSON.stringify({ user: thirdPartyUser }))
+
+    const login = await runCli(['login', '--registry', registry.url, '--token', 'sk_ok'], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    expect(login.exitCode).toBe(0)
+    expect(await Bun.file(`${env.home}/.skillhub/config.json`).json()).toEqual({
+      self_update_url: 'https://skillhub.example.com/version.json',
+      auto_self_upgrade: false,
+      registry: registry.url
+    })
+    expect(await Bun.file(`${env.home}/.skillhub/credentials.json`).json()).toEqual({
+      user: thirdPartyUser,
+      tokens: { [registry.url]: 'sk_ok' }
+    })
+
+    const logout = await runCli(['logout', '--registry', registry.url], {
+      HOME: env.home,
+      USERPROFILE: env.home
+    })
+    expect(logout.exitCode).toBe(0)
+    expect(await Bun.file(`${env.home}/.skillhub/credentials.json`).json()).toEqual({
+      user: thirdPartyUser,
+      tokens: {}
+    })
+  })
+
   test('login fails with invalid token', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({ token: 'sk_ok' })

--- a/cli/test/unit/stores/config-store.test.ts
+++ b/cli/test/unit/stores/config-store.test.ts
@@ -42,4 +42,23 @@ describe('ConfigStore', () => {
     expect(config.registry).toBe('https://new.com')
     expect(config.defaultAgent).toBe('codex')
   })
+
+  test('setRegistry() preserves third-party and unknown fields', async () => {
+    const home = await makeTempHome()
+    const store = new ConfigStore(home)
+    await store.write({
+      self_update_url: 'https://skillhub.example.com/version.json',
+      auto_self_upgrade: false,
+      futureField: { enabled: true }
+    })
+
+    await store.setRegistry('https://registry.example.com')
+
+    expect(await store.read()).toEqual({
+      self_update_url: 'https://skillhub.example.com/version.json',
+      auto_self_upgrade: false,
+      futureField: { enabled: true },
+      registry: 'https://registry.example.com'
+    })
+  })
 })

--- a/cli/test/unit/stores/credentials-store.test.ts
+++ b/cli/test/unit/stores/credentials-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { normalize } from 'path'
+import { readFile } from 'node:fs/promises'
+import { normalize } from 'node:path'
 import { createTempHome } from '../../helpers/temp-env'
 import { CredentialsStore } from '../../../src/stores/credentials-store'
 
@@ -11,5 +12,53 @@ describe('CredentialsStore', () => {
     expect(await store.getToken('https://registry.example.com')).toBe('sk_test')
     expect(normalize(store.path)).toBe(normalize(`${env.home}/.skillhub/credentials.json`))
     expect(await Bun.file(`${env.cwd}/credentials.json`).exists()).toBe(false)
+  })
+
+  test('treats a third-party credentials file without tokens as logged out', async () => {
+    const env = await createTempHome()
+    const store = new CredentialsStore(env.home)
+    await Bun.write(store.path, JSON.stringify({
+      user: { token: 'third-party-token', host: 'https://api.skillhub.cn' }
+    }))
+
+    expect(await store.getToken('https://registry.example.com')).toBeUndefined()
+  })
+
+  test('setToken preserves third-party and unknown fields', async () => {
+    const env = await createTempHome()
+    const store = new CredentialsStore(env.home)
+    await Bun.write(store.path, JSON.stringify({
+      user: { token: 'third-party-token', host: 'https://api.skillhub.cn' },
+      futureField: { enabled: true }
+    }))
+
+    await store.setToken('https://registry.example.com', 'sk_test')
+
+    const saved = JSON.parse(await readFile(store.path, 'utf-8'))
+    expect(saved).toEqual({
+      user: { token: 'third-party-token', host: 'https://api.skillhub.cn' },
+      futureField: { enabled: true },
+      tokens: { 'https://registry.example.com': 'sk_test' }
+    })
+  })
+
+  test('deleteToken removes only the selected first-party token', async () => {
+    const env = await createTempHome()
+    const store = new CredentialsStore(env.home)
+    await Bun.write(store.path, JSON.stringify({
+      user: { token: 'third-party-token', host: 'https://api.skillhub.cn' },
+      tokens: {
+        'https://registry-a.example.com': 'sk_a',
+        'https://registry-b.example.com': 'sk_b'
+      }
+    }))
+
+    await store.deleteToken('https://registry-a.example.com')
+
+    const saved = JSON.parse(await readFile(store.path, 'utf-8'))
+    expect(saved).toEqual({
+      user: { token: 'third-party-token', host: 'https://api.skillhub.cn' },
+      tokens: { 'https://registry-b.example.com': 'sk_b' }
+    })
   })
 })

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -83,6 +83,9 @@ skillhub login --token sk_xxx --registry https://skillhub.example.com
 
 `login` validates the token, stores it in `~/.skillhub/credentials.json`, and writes the registry to `~/.skillhub/config.json`.
 
+Both files are updated non-destructively: SkillHub CLI changes only its own `tokens` and `registry`
+fields and preserves unknown fields written by other compatible tools.
+
 When an API-token request is denied, the CLI shows the safe reason returned by the server and its `Request ID`. Use that ID to correlate the failure with server logs. Other authorization failures continue to use a generic message.
 
 ### Check Current Identity
@@ -494,6 +497,9 @@ skillhub login --token <token> [--registry <url>] [--json]
 ```
 
 Save token and registry configuration.
+
+The CLI preserves unknown fields in the shared configuration and credentials documents when it
+updates its own `registry` and `tokens` fields.
 
 ### logout
 

--- a/docs/skillhub/guide/cli.md
+++ b/docs/skillhub/guide/cli.md
@@ -461,6 +461,9 @@ skillhub login --token <token> [--registry <url>] [--json]
 
 保存 token 和 registry 配置。
 
+CLI 以非破坏方式更新 `~/.skillhub/credentials.json` 和 `~/.skillhub/config.json`：只修改
+自己使用的 `tokens` 和 `registry` 字段，保留其他兼容工具写入的未知字段。
+
 ### logout
 
 ```bash


### PR DESCRIPTION
## Summary

- preserve unknown fields in shared `~/.skillhub/config.json` and `credentials.json`
- treat credentials without first-party `tokens` as logged out instead of failing
- verify login/logout coexistence with compatible third-party `user` state

## Validation

- `bun test test/unit/stores/credentials-store.test.ts`
- `bun test test/unit/stores/config-store.test.ts`
- `bun test test/integration/auth-commands.test.ts`
- `bun run typecheck`
- `bun run lint`
- `make build-cli`
- `bash scripts/tests/publish-cli-test.sh`
- full CLI suite: 473 passed; one unrelated concurrency case failed once and passed 3/3 on immediate isolated rerun

## Follow-up

After merge, release CLI 0.1.12 before merging the built-in `@global/skillhub-cli` guide that pins that version.