### PR TITLE
docs: document optional upstream skill cue-omni-reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,22 @@ npx @astron-team/skillhub@latest publish ./skills/<category>/<skill-name>
 **In short: use collections like `anthropics/skills` for content, and SkillHub to
 distribute it across your organization under governance.**
 
+### Optional external skill: cue-omni-reader (not hosted in SkillHub)
+
+You can also install individual Agent Skills directly from their upstream open
+collections, bypassing any registry. For example, [`cue-omni-reader`](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader)
+(MIT) is an instruction-only skill that drives the official Cue Omni Reader MCP
+to parse an HTTP(S) URL or an authorized local document, audio, or video source
+into Markdown:
+
+```sh
+npx skills add sensedeal/cue-skills --skill cue-omni-reader
+```
+
+This is a **direct upstream install** — it does not mean the skill is published,
+hosted, or cataloged in any SkillHub registry, and it ships no SkillHub registry
+or server integration code.
+
 ## Usage with Agent Platforms
 
 SkillHub works as a skill registry backend for several agent platforms. Point any of the clients below at your SkillHub instance to publish, discover, and install skills.

--- a/README.md
+++ b/README.md
@@ -527,21 +527,13 @@ npx @astron-team/skillhub@latest publish ./skills/<category>/<skill-name>
 **In short: use collections like `anthropics/skills` for content, and SkillHub to
 distribute it across your organization under governance.**
 
-### Optional external skill: cue-omni-reader (not hosted in SkillHub)
+### Example: install a skill that is not in the registry
 
-You can also install individual Agent Skills directly from their upstream open
-collections, bypassing any registry. For example, [`cue-omni-reader`](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader)
-(MIT) is an instruction-only skill that drives the official Cue Omni Reader MCP
-to parse an HTTP(S) URL or an authorized local document, audio, or video source
-into Markdown:
+SkillHub governs what you publish inside an org. Users still hit materials the catalog does not cover — a URL, a PDF, a recording. [`cue-omni-reader`](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) (MIT) turns those into Markdown; install from GitHub, no SkillHub listing required:
 
 ```sh
 npx skills add sensedeal/cue-skills --skill cue-omni-reader
 ```
-
-This is a **direct upstream install** — it does not mean the skill is published,
-hosted, or cataloged in any SkillHub registry, and it ships no SkillHub registry
-or server integration code.
 
 ## Usage with Agent Platforms
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -412,19 +412,13 @@ npx @astron-team/skillhub@latest publish ./skills/<分类>/<技能名>
 
 **一句话总结：用 `anthropics/skills` 这类集合提供内容，用 SkillHub 在组织内进行受治理的分发。**
 
-### 可选的外部 skill：cue-omni-reader（非 SkillHub 托管）
+### 例子：注册中心里没有的 skill 怎么装
 
-你也可以不经过任何注册中心，直接从上游开源集合安装单个 Agent Skill。例如
-[`cue-omni-reader`](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader)
-（MIT）是一层纯指令的 skill，驱动官方 Cue Omni Reader MCP，把 HTTP(S) 网页与
-**已授权的本地文档、音频、视频**解析为 Markdown：
+SkillHub 管的是组织内分发。用户手头还有网页、PDF、录音——这些通常不在你们的 catalog 里。[`cue-omni-reader`](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader)（MIT）把它们收成 Markdown，从 GitHub 直接装即可，不必先上架 SkillHub：
 
 ```sh
 npx skills add sensedeal/cue-skills --skill cue-omni-reader
 ```
-
-这是**直接从上游安装**——不代表该 skill 已收录、发布或托管在任何 SkillHub
-注册中心，也不携带任何 SkillHub 注册中心或服务端集成代码。
 
 ## 与智能体平台集成
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -412,6 +412,20 @@ npx @astron-team/skillhub@latest publish ./skills/<分类>/<技能名>
 
 **一句话总结：用 `anthropics/skills` 这类集合提供内容，用 SkillHub 在组织内进行受治理的分发。**
 
+### 可选的外部 skill：cue-omni-reader（非 SkillHub 托管）
+
+你也可以不经过任何注册中心，直接从上游开源集合安装单个 Agent Skill。例如
+[`cue-omni-reader`](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader)
+（MIT）是一层纯指令的 skill，驱动官方 Cue Omni Reader MCP，把 HTTP(S) 网页与
+**已授权的本地文档、音频、视频**解析为 Markdown：
+
+```sh
+npx skills add sensedeal/cue-skills --skill cue-omni-reader
+```
+
+这是**直接从上游安装**——不代表该 skill 已收录、发布或托管在任何 SkillHub
+注册中心，也不携带任何 SkillHub 注册中心或服务端集成代码。
+
 ## 与智能体平台集成
 
 SkillHub 设计为与各种智能体平台和框架无缝集成。


### PR DESCRIPTION
> **Disclosure:** I'm a maintainer of [sensedeal/cue-skills](https://github.com/sensedeal/cue-skills) (MIT). This PR adds a note pointing to cue-omni-reader, which I help maintain.

SkillHub is the org registry. Users still bring URLs, PDFs, and recordings that will never be in `catalog.json`.

This PR adds a short example (en + zh) in the ecosystem section: install [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) from GitHub to turn those into Markdown. It is **not** a SkillHub listing and does not touch `builtin-skills/` or the catalog.

```
npx skills add sensedeal/cue-skills --skill cue-omni-reader
```
