### PR TITLE
fix(cli): serialize concurrent stale lock recovery

### DIFF
--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -8,7 +8,7 @@ import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 
 const ACQUISITION_GATE_WAIT_MS = 1_000
-const ACQUISITION_GATE_POLL_MS = 5
+const ACQUISITION_GATE_MAX_POLL_MS = 100
 
 /** Serializes every local lifecycle mutation for one Skill target directory. */
 export async function acquireSkillTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
@@ -156,16 +156,20 @@ async function waitForChoosingContenders(
   contenderId: string
 ): Promise<AcquisitionContender[]> {
   const deadline = Date.now() + ACQUISITION_GATE_WAIT_MS
+  let delayMs = 5
   do {
     const state = await readGateState(gatePath, contenderId)
     if (!state.hasLiveChoosing) return state.tickets
-    await new Promise(resolve => setTimeout(resolve, ACQUISITION_GATE_POLL_MS))
+    await new Promise(resolve => setTimeout(resolve, delayMs))
+    delayMs = Math.min(delayMs * 2, ACQUISITION_GATE_MAX_POLL_MS)
   } while (Date.now() < deadline)
   throw Object.assign(new Error('Acquisition gate contender did not finish choosing'), { code: 'EEXIST' })
 }
 
 function compareContenders(left: AcquisitionContender, right: AcquisitionContender): number {
-  return left.ticket - right.ticket || left.id.localeCompare(right.id)
+  if (left.ticket !== right.ticket) return left.ticket < right.ticket ? -1 : 1
+  if (left.id === right.id) return 0
+  return left.id < right.id ? -1 : 1
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -7,7 +7,6 @@ import { canonicalizeExistingPath } from '../platform/paths'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 
-const ACQUISITION_GATE_WAIT_MS = 1_000
 const ACQUISITION_GATE_MAX_POLL_MS = 100
 
 /** Serializes every local lifecycle mutation for one Skill target directory. */
@@ -77,10 +76,7 @@ async function acquireAcquisitionGate(gatePath: string): Promise<() => Promise<v
     ticketPath = join(gatePath, `ticket.${ticket}.${contenderId}`)
     await rename(choosingPath, ticketPath)
 
-    const contenders = await waitForChoosingContenders(gatePath, contenderId)
-    if (contenders.some(contender => compareContenders(contender, { id: contenderId, ticket: ticket! }) < 0)) {
-      throw Object.assign(new Error('Acquisition gate is already being held'), { code: 'EEXIST' })
-    }
+    await waitForAcquisitionTurn(gatePath, { id: contenderId, ticket })
   } catch (operationError) {
     const cleanupErrors = await removeContenderFiles(choosingPath, ...(ticketPath === null ? [] : [ticketPath]))
     if (cleanupErrors.length > 0) {
@@ -151,19 +147,18 @@ async function readGateState(gatePath: string, contenderId: string): Promise<Acq
   return { tickets, hasLiveChoosing }
 }
 
-async function waitForChoosingContenders(
+async function waitForAcquisitionTurn(
   gatePath: string,
-  contenderId: string
-): Promise<AcquisitionContender[]> {
-  const deadline = Date.now() + ACQUISITION_GATE_WAIT_MS
+  contender: AcquisitionContender
+): Promise<void> {
   let delayMs = 5
-  do {
-    const state = await readGateState(gatePath, contenderId)
-    if (!state.hasLiveChoosing) return state.tickets
+  for (;;) {
+    const state = await readGateState(gatePath, contender.id)
+    const hasEarlierTicket = state.tickets.some(candidate => compareContenders(candidate, contender) < 0)
+    if (!state.hasLiveChoosing && !hasEarlierTicket) return
     await new Promise(resolve => setTimeout(resolve, delayMs))
     delayMs = Math.min(delayMs * 2, ACQUISITION_GATE_MAX_POLL_MS)
-  } while (Date.now() < deadline)
-  throw Object.assign(new Error('Acquisition gate contender did not finish choosing'), { code: 'EEXIST' })
+  }
 }
 
 function compareContenders(left: AcquisitionContender, right: AcquisitionContender): number {

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -72,13 +72,12 @@ async function acquireAcquisitionGate(gatePath: string): Promise<() => Promise<v
 
   await writeFile(choosingPath, '', { flag: 'wx', mode: 0o600 })
   try {
-    const tickets = await readLiveTickets(gatePath)
+    const { tickets } = await readGateState(gatePath, contenderId)
     ticket = Math.max(0, ...tickets.map(contender => contender.ticket)) + 1
     ticketPath = join(gatePath, `ticket.${ticket}.${contenderId}`)
     await rename(choosingPath, ticketPath)
 
-    await waitForChoosingContenders(gatePath, contenderId)
-    const contenders = await readLiveTickets(gatePath)
+    const contenders = await waitForChoosingContenders(gatePath, contenderId)
     if (contenders.some(contender => compareContenders(contender, { id: contenderId, ticket: ticket! }) < 0)) {
       throw Object.assign(new Error('Acquisition gate is already being held'), { code: 'EEXIST' })
     }
@@ -92,12 +91,11 @@ async function acquireAcquisitionGate(gatePath: string): Promise<() => Promise<v
 
   return async () => {
     try {
-      await lstat(ticketPath!)
+      await unlink(ticketPath!)
     } catch (error) {
       if (hasErrorCode(error, 'ENOENT')) throw compromisedGateError(ticketPath!)
       throw error
     }
-    await unlink(ticketPath!)
   }
 }
 
@@ -118,40 +116,49 @@ interface AcquisitionContender {
   ticket: number
 }
 
-async function readLiveTickets(gatePath: string): Promise<AcquisitionContender[]> {
-  const entries = await readdir(gatePath)
-  const contenders: AcquisitionContender[] = []
-  for (const entry of entries) {
-    const match = /^ticket\.(\d+)\.(\d+)-([^.]+)$/.exec(entry)
-    if (!match) continue
-    const ticket = Number(match[1])
-    const pid = Number(match[2])
-    const path = join(gatePath, entry)
-    if (!isProcessAlive(pid)) {
-      await unlinkIfPresent(path)
-      continue
-    }
-    if (!Number.isSafeInteger(ticket) || ticket < 1) throw compromisedGateError(path)
-    contenders.push({ id: `${match[2]}-${match[3]}`, ticket })
-  }
-  return contenders
+interface AcquisitionGateState {
+  tickets: AcquisitionContender[]
+  hasLiveChoosing: boolean
 }
 
-async function waitForChoosingContenders(gatePath: string, contenderId: string): Promise<void> {
-  const deadline = Date.now() + ACQUISITION_GATE_WAIT_MS
-  do {
-    let hasLiveContender = false
-    for (const entry of await readdir(gatePath)) {
-      const match = /^choosing\.(\d+)-([^.]+)$/.exec(entry)
-      if (!match || `${match[1]}-${match[2]}` === contenderId) continue
-      const path = join(gatePath, entry)
-      if (!isProcessAlive(Number(match[1]))) {
+async function readGateState(gatePath: string, contenderId: string): Promise<AcquisitionGateState> {
+  const entries = await readdir(gatePath)
+  const tickets: AcquisitionContender[] = []
+  let hasLiveChoosing = false
+  for (const entry of entries) {
+    const path = join(gatePath, entry)
+    const ticketMatch = /^ticket\.(\d+)\.(\d+)-([^.]+)$/.exec(entry)
+    if (ticketMatch) {
+      const ticket = Number(ticketMatch[1])
+      const pid = Number(ticketMatch[2])
+      if (!isProcessAlive(pid)) {
+        await unlinkIfPresent(path)
+        continue
+      }
+      if (!Number.isSafeInteger(ticket) || ticket < 1) throw compromisedGateError(path)
+      tickets.push({ id: `${ticketMatch[2]}-${ticketMatch[3]}`, ticket })
+      continue
+    }
+    const choosingMatch = /^choosing\.(\d+)-([^.]+)$/.exec(entry)
+    if (choosingMatch && `${choosingMatch[1]}-${choosingMatch[2]}` !== contenderId) {
+      if (!isProcessAlive(Number(choosingMatch[1]))) {
         await unlinkIfPresent(path)
       } else {
-        hasLiveContender = true
+        hasLiveChoosing = true
       }
     }
-    if (!hasLiveContender) return
+  }
+  return { tickets, hasLiveChoosing }
+}
+
+async function waitForChoosingContenders(
+  gatePath: string,
+  contenderId: string
+): Promise<AcquisitionContender[]> {
+  const deadline = Date.now() + ACQUISITION_GATE_WAIT_MS
+  do {
+    const state = await readGateState(gatePath, contenderId)
+    if (!state.hasLiveChoosing) return state.tickets
     await new Promise(resolve => setTimeout(resolve, ACQUISITION_GATE_POLL_MS))
   } while (Date.now() < deadline)
   throw Object.assign(new Error('Acquisition gate contender did not finish choosing'), { code: 'EEXIST' })

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { chmod, link, lstat, mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import { chmod, lstat, mkdir, readdir, rename, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { lock } from 'proper-lockfile'
@@ -7,7 +7,8 @@ import { canonicalizeExistingPath } from '../platform/paths'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 
-const ACQUISITION_GATE_STALE_MS = 10_000
+const ACQUISITION_GATE_WAIT_MS = 1_000
+const ACQUISITION_GATE_POLL_MS = 5
 
 /** Serializes every local lifecycle mutation for one Skill target directory. */
 export async function acquireSkillTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
@@ -61,63 +62,131 @@ function acquireTargetLock(lockPath: string): Promise<() => Promise<void>> {
 }
 
 async function acquireAcquisitionGate(gatePath: string): Promise<() => Promise<void>> {
-  for (let attempt = 0; attempt < 2; attempt++) {
-    const token = randomUUID()
-    try {
-      await writeFile(gatePath, token, { flag: 'wx', mode: 0o600 })
-    } catch (error) {
-      if (attempt === 0 && hasErrorCode(error, 'EEXIST') && await recoverStaleAcquisitionGate(gatePath)) {
-        continue
-      }
-      throw error
-    }
+  await ensureAcquisitionGateDirectory(gatePath)
+  // A per-target Lamport bakery queue avoids deleting a shared stale gate. Every removable path
+  // contains a nonce and is owned by one PID, so crash recovery cannot unlink a replacement owner.
+  const contenderId = `${process.pid}-${randomUUID()}`
+  const choosingPath = join(gatePath, `choosing.${contenderId}`)
+  let ticketPath: string | null = null
+  let ticket: number | null = null
 
-    return async () => {
-      const currentToken = await readFile(gatePath, 'utf8')
-      if (currentToken !== token) throw compromisedGateError(gatePath)
-      await unlink(gatePath)
+  await writeFile(choosingPath, '', { flag: 'wx', mode: 0o600 })
+  try {
+    const tickets = await readLiveTickets(gatePath)
+    ticket = Math.max(0, ...tickets.map(contender => contender.ticket)) + 1
+    ticketPath = join(gatePath, `ticket.${ticket}.${contenderId}`)
+    await rename(choosingPath, ticketPath)
+
+    await waitForChoosingContenders(gatePath, contenderId)
+    const contenders = await readLiveTickets(gatePath)
+    if (contenders.some(contender => compareContenders(contender, { id: contenderId, ticket: ticket! }) < 0)) {
+      throw Object.assign(new Error('Acquisition gate is already being held'), { code: 'EEXIST' })
     }
+  } catch (operationError) {
+    const cleanupErrors = await removeContenderFiles(choosingPath, ...(ticketPath === null ? [] : [ticketPath]))
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError([operationError, ...cleanupErrors], 'acquisition gate attempt and cleanup both failed')
+    }
+    throw operationError
   }
 
-  throw new Error('unreachable acquisition gate retry state')
+  return async () => {
+    try {
+      await lstat(ticketPath!)
+    } catch (error) {
+      if (hasErrorCode(error, 'ENOENT')) throw compromisedGateError(ticketPath!)
+      throw error
+    }
+    await unlink(ticketPath!)
+  }
 }
 
-async function recoverStaleAcquisitionGate(gatePath: string): Promise<boolean> {
-  let observedToken: string
-  let observedMtime: number
+async function ensureAcquisitionGateDirectory(gatePath: string): Promise<void> {
   try {
-    observedToken = await readFile(gatePath, 'utf8')
-    observedMtime = (await lstat(gatePath)).mtimeMs
+    await mkdir(gatePath, { mode: 0o700 })
   } catch (error) {
-    if (hasErrorCode(error, 'ENOENT')) return true
-    throw error
+    if (!hasErrorCode(error, 'EEXIST')) throw error
   }
-  if (observedMtime >= Date.now() - ACQUISITION_GATE_STALE_MS) return false
-
-  const claimDigest = createHash('sha256').update(observedToken).digest('hex')
-  const claimPath = `${gatePath}.stale-${claimDigest}`
-  try {
-    await link(gatePath, claimPath)
-  } catch (error) {
-    if (hasErrorCode(error, 'ENOENT')) return true
-    if (hasErrorCode(error, 'EEXIST')) return false
-    throw error
+  const details = await lstat(gatePath)
+  if (!details.isDirectory() || details.isSymbolicLink()) {
+    throw new Error(`unsafe SkillHub CLI acquisition gate directory: ${gatePath}`)
   }
+}
 
-  try {
-    if (await readFile(claimPath, 'utf8') !== observedToken) return false
-    let currentToken: string
-    try {
-      currentToken = await readFile(gatePath, 'utf8')
-    } catch (error) {
-      if (hasErrorCode(error, 'ENOENT')) return true
-      throw error
+interface AcquisitionContender {
+  id: string
+  ticket: number
+}
+
+async function readLiveTickets(gatePath: string): Promise<AcquisitionContender[]> {
+  const entries = await readdir(gatePath)
+  const contenders: AcquisitionContender[] = []
+  for (const entry of entries) {
+    const match = /^ticket\.(\d+)\.(\d+)-([^.]+)$/.exec(entry)
+    if (!match) continue
+    const ticket = Number(match[1])
+    const pid = Number(match[2])
+    const path = join(gatePath, entry)
+    if (!isProcessAlive(pid)) {
+      await unlinkIfPresent(path)
+      continue
     }
-    if (currentToken !== observedToken) return false
-    await unlink(gatePath)
+    if (!Number.isSafeInteger(ticket) || ticket < 1) throw compromisedGateError(path)
+    contenders.push({ id: `${match[2]}-${match[3]}`, ticket })
+  }
+  return contenders
+}
+
+async function waitForChoosingContenders(gatePath: string, contenderId: string): Promise<void> {
+  const deadline = Date.now() + ACQUISITION_GATE_WAIT_MS
+  do {
+    let hasLiveContender = false
+    for (const entry of await readdir(gatePath)) {
+      const match = /^choosing\.(\d+)-([^.]+)$/.exec(entry)
+      if (!match || `${match[1]}-${match[2]}` === contenderId) continue
+      const path = join(gatePath, entry)
+      if (!isProcessAlive(Number(match[1]))) {
+        await unlinkIfPresent(path)
+      } else {
+        hasLiveContender = true
+      }
+    }
+    if (!hasLiveContender) return
+    await new Promise(resolve => setTimeout(resolve, ACQUISITION_GATE_POLL_MS))
+  } while (Date.now() < deadline)
+  throw Object.assign(new Error('Acquisition gate contender did not finish choosing'), { code: 'EEXIST' })
+}
+
+function compareContenders(left: AcquisitionContender, right: AcquisitionContender): number {
+  return left.ticket - right.ticket || left.id.localeCompare(right.id)
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
     return true
-  } finally {
-    await unlink(claimPath).catch(() => {})
+  } catch (error) {
+    return !hasErrorCode(error, 'ESRCH')
+  }
+}
+
+async function removeContenderFiles(...paths: string[]): Promise<Error[]> {
+  const errors: Error[] = []
+  for (const path of paths) {
+    try {
+      await unlink(path)
+    } catch (error) {
+      if (!hasErrorCode(error, 'ENOENT')) errors.push(error instanceof Error ? error : new Error(String(error)))
+    }
+  }
+  return errors
+}
+
+async function unlinkIfPresent(path: string): Promise<void> {
+  try {
+    await unlink(path)
+  } catch (error) {
+    if (!hasErrorCode(error, 'ENOENT')) throw error
   }
 }
 

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -7,23 +7,67 @@ import { canonicalizeExistingPath } from '../platform/paths'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 
+const NO_AUTOMATIC_STALE_RECOVERY_MS = Number.MAX_SAFE_INTEGER
+
 /** Serializes every local lifecycle mutation for one Skill target directory. */
 export async function acquireSkillTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
   const lockPath = await skillTargetLockPath(rootDir, slug)
+  // proper-lockfile's stale deletion is not serialized. Gate only the acquisition attempt so two
+  // recoverers cannot remove and replace the same target lock concurrently.
+  const acquisitionGatePath = `${lockPath}.acquire`
+  let releaseAcquisitionGate: () => Promise<void>
   try {
-    return await lock(lockPath, {
-      lockfilePath: lockPath,
-      realpath: false,
-      stale: 10_000,
-      update: 3_000,
-      retries: 0
-    })
+    releaseAcquisitionGate = await acquireLockWithoutStaleRecovery(acquisitionGatePath)
   } catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ELOCKED') {
-      throw targetBusyError(rootDir, slug)
-    }
+    if (hasErrorCode(error, 'ELOCKED')) throw targetBusyError(rootDir, slug)
     throw error
   }
+
+  let releaseTarget: () => Promise<void>
+  try {
+    releaseTarget = await acquireTargetLock(lockPath)
+  } catch (operationError) {
+    try {
+      await releaseAcquisitionGate()
+    } catch (cleanupError) {
+      throw new AggregateError([operationError, cleanupError], 'target lock acquisition and gate cleanup both failed')
+    }
+    if (hasErrorCode(operationError, 'ELOCKED')) throw targetBusyError(rootDir, slug)
+    throw operationError
+  }
+
+  try {
+    await releaseAcquisitionGate()
+  } catch (error) {
+    await releaseTarget().catch(() => {})
+    throw error
+  }
+
+  return releaseTarget
+}
+
+function acquireTargetLock(lockPath: string): Promise<() => Promise<void>> {
+  return lock(lockPath, {
+    lockfilePath: lockPath,
+    realpath: false,
+    stale: 10_000,
+    update: 3_000,
+    retries: 0
+  })
+}
+
+function acquireLockWithoutStaleRecovery(lockPath: string): Promise<() => Promise<void>> {
+  return lock(lockPath, {
+    lockfilePath: lockPath,
+    realpath: false,
+    stale: NO_AUTOMATIC_STALE_RECOVERY_MS,
+    update: 3_000,
+    retries: 0
+  })
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code
 }
 
 export async function skillTargetLockPath(rootDir: string, slug: string): Promise<string> {

--- a/cli/src/services/skill-target-lock.ts
+++ b/cli/src/services/skill-target-lock.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'node:crypto'
-import { chmod, lstat, mkdir } from 'node:fs/promises'
+import { createHash, randomUUID } from 'node:crypto'
+import { chmod, link, lstat, mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { lock } from 'proper-lockfile'
@@ -7,7 +7,7 @@ import { canonicalizeExistingPath } from '../platform/paths'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
 
-const NO_AUTOMATIC_STALE_RECOVERY_MS = Number.MAX_SAFE_INTEGER
+const ACQUISITION_GATE_STALE_MS = 10_000
 
 /** Serializes every local lifecycle mutation for one Skill target directory. */
 export async function acquireSkillTargetLock(rootDir: string, slug: string): Promise<() => Promise<void>> {
@@ -17,9 +17,9 @@ export async function acquireSkillTargetLock(rootDir: string, slug: string): Pro
   const acquisitionGatePath = `${lockPath}.acquire`
   let releaseAcquisitionGate: () => Promise<void>
   try {
-    releaseAcquisitionGate = await acquireLockWithoutStaleRecovery(acquisitionGatePath)
+    releaseAcquisitionGate = await acquireAcquisitionGate(acquisitionGatePath)
   } catch (error) {
-    if (hasErrorCode(error, 'ELOCKED')) throw targetBusyError(rootDir, slug)
+    if (hasErrorCode(error, 'EEXIST')) throw targetBusyError(rootDir, slug)
     throw error
   }
 
@@ -38,9 +38,13 @@ export async function acquireSkillTargetLock(rootDir: string, slug: string): Pro
 
   try {
     await releaseAcquisitionGate()
-  } catch (error) {
-    await releaseTarget().catch(() => {})
-    throw error
+  } catch (gateCleanupError) {
+    try {
+      await releaseTarget()
+    } catch (targetCleanupError) {
+      throw new AggregateError([gateCleanupError, targetCleanupError], 'target and acquisition gate cleanup both failed')
+    }
+    throw gateCleanupError
   }
 
   return releaseTarget
@@ -56,13 +60,70 @@ function acquireTargetLock(lockPath: string): Promise<() => Promise<void>> {
   })
 }
 
-function acquireLockWithoutStaleRecovery(lockPath: string): Promise<() => Promise<void>> {
-  return lock(lockPath, {
-    lockfilePath: lockPath,
-    realpath: false,
-    stale: NO_AUTOMATIC_STALE_RECOVERY_MS,
-    update: 3_000,
-    retries: 0
+async function acquireAcquisitionGate(gatePath: string): Promise<() => Promise<void>> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const token = randomUUID()
+    try {
+      await writeFile(gatePath, token, { flag: 'wx', mode: 0o600 })
+    } catch (error) {
+      if (attempt === 0 && hasErrorCode(error, 'EEXIST') && await recoverStaleAcquisitionGate(gatePath)) {
+        continue
+      }
+      throw error
+    }
+
+    return async () => {
+      const currentToken = await readFile(gatePath, 'utf8')
+      if (currentToken !== token) throw compromisedGateError(gatePath)
+      await unlink(gatePath)
+    }
+  }
+
+  throw new Error('unreachable acquisition gate retry state')
+}
+
+async function recoverStaleAcquisitionGate(gatePath: string): Promise<boolean> {
+  let observedToken: string
+  let observedMtime: number
+  try {
+    observedToken = await readFile(gatePath, 'utf8')
+    observedMtime = (await lstat(gatePath)).mtimeMs
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) return true
+    throw error
+  }
+  if (observedMtime >= Date.now() - ACQUISITION_GATE_STALE_MS) return false
+
+  const claimDigest = createHash('sha256').update(observedToken).digest('hex')
+  const claimPath = `${gatePath}.stale-${claimDigest}`
+  try {
+    await link(gatePath, claimPath)
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) return true
+    if (hasErrorCode(error, 'EEXIST')) return false
+    throw error
+  }
+
+  try {
+    if (await readFile(claimPath, 'utf8') !== observedToken) return false
+    let currentToken: string
+    try {
+      currentToken = await readFile(gatePath, 'utf8')
+    } catch (error) {
+      if (hasErrorCode(error, 'ENOENT')) return true
+      throw error
+    }
+    if (currentToken !== observedToken) return false
+    await unlink(gatePath)
+    return true
+  } finally {
+    await unlink(claimPath).catch(() => {})
+  }
+}
+
+function compromisedGateError(gatePath: string): Error {
+  return Object.assign(new Error(`SkillHub CLI acquisition gate was replaced: ${gatePath}`), {
+    code: 'ECOMPROMISED'
   })
 }
 

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -27,6 +27,21 @@ async function waitForFile(path: string): Promise<void> {
   throw new Error(`timed out waiting for ${path}`)
 }
 
+async function waitForExitCount(
+  processes: Array<{ exited: Promise<number> }>,
+  count: number
+): Promise<number[]> {
+  const exitCodes: number[] = []
+  for (const process of processes) {
+    void process.exited.then(exitCode => exitCodes.push(exitCode))
+  }
+  for (let attempt = 0; attempt < 500; attempt++) {
+    if (exitCodes.length >= count) return exitCodes
+    await Bun.sleep(10)
+  }
+  throw new Error(`timed out waiting for ${count} lock contenders to exit`)
+}
+
 describe('skill target lifecycle lock', () => {
   test('creates or repairs a private lock root and rejects unsafe roots', async () => {
     const parent = await mkdtemp(join(tmpdir(), 'skillhub-lock-root-'))
@@ -82,11 +97,8 @@ describe('skill target lifecycle lock', () => {
       await Promise.all(readyPaths.map(waitForFile))
       await writeFile(startPath, 'start')
       await waitForFile(acquiredPath)
-      const loserExitCode = await Promise.race([
-        ...processes.map(process => process.exited),
-        Bun.sleep(5_000).then(() => { throw new Error('timed out waiting for the lock loser') })
-      ])
-      expect(loserExitCode).toBe(4)
+      const loserExitCodes = await waitForExitCount(processes, workerCount - 1)
+      expect(loserExitCodes).toEqual(Array(workerCount - 1).fill(4))
     } finally {
       try {
         await writeFile(releasePath, 'release')

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -70,7 +70,8 @@ describe('skill target lifecycle lock', () => {
     const acquiredPath = join(rootDir, 'acquired')
     const releasePath = join(rootDir, 'release')
     const startPath = join(rootDir, 'start')
-    const readyPaths = [join(rootDir, 'ready-0'), join(rootDir, 'ready-1')]
+    const workerCount = 8
+    const readyPaths = Array.from({ length: workerCount }, (_, index) => join(rootDir, `ready-${index}`))
 
     const processes = readyPaths.map(readyPath => Bun.spawn({
       cmd: [bunPath, worker, rootDir, 'demo', readyPath, startPath, acquiredPath, releasePath],
@@ -106,7 +107,7 @@ describe('skill target lifecycle lock', () => {
       stderr: (await new Response(process.stderr).text()).trim()
     })))
 
-    expect(results.map(result => result.exitCode).sort()).toEqual([0, 4])
+    expect(results.map(result => result.exitCode).sort()).toEqual([0, ...Array(workerCount - 1).fill(4)])
     expect(results.filter(result => result.stdout === 'acquired')).toHaveLength(1)
     expect(await exists(lockPath)).toBe(false)
     if (process.platform !== 'win32') {

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,4 +1,4 @@
-import { access, chmod, lstat, mkdir, mkdtemp, symlink, unlink, utimes, writeFile } from 'node:fs/promises'
+import { access, chmod, lstat, mkdir, mkdtemp, readdir, rm, symlink, unlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -81,8 +81,6 @@ describe('skill target lifecycle lock', () => {
     const staleTime = new Date(Date.now() - 60_000)
     await utimes(lockPath, staleTime, staleTime)
     const acquisitionGatePath = `${lockPath}.acquire`
-    await writeFile(acquisitionGatePath, 'abandoned-owner')
-    await utimes(acquisitionGatePath, staleTime, staleTime)
     const worker = fileURLToPath(new URL('../../helpers/target-lock-worker.ts', import.meta.url))
     const bunPath = (await Bun.which('bun')) ?? process.execPath
     const acquiredPath = join(rootDir, 'acquired')
@@ -128,13 +126,45 @@ describe('skill target lifecycle lock', () => {
       expect(loser.stderr).toContain('install target is busy')
     }
     expect(await exists(lockPath)).toBe(false)
-    expect(await exists(acquisitionGatePath)).toBe(false)
+    expect(await readdir(acquisitionGatePath)).toEqual([])
     const releaseAfterContention = await acquireSkillTargetLock(rootDir, 'demo')
     await releaseAfterContention()
     if (process.platform !== 'win32') {
       expect((await lstat(dirname(lockPath))).mode & 0o077).toBe(0)
     }
   }, 15_000)
+
+  test('does not recover a live acquisition contender solely because its file is old', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-live-gate-'))
+    const lockPath = await skillTargetLockPath(rootDir, 'demo')
+    const acquisitionGatePath = `${lockPath}.acquire`
+    await mkdir(acquisitionGatePath)
+    const liveContenderPath = join(acquisitionGatePath, `${process.pid}-suspended.choosing`)
+    await writeFile(liveContenderPath, '')
+    const staleTime = new Date(Date.now() - 60_000)
+    await utimes(liveContenderPath, staleTime, staleTime)
+
+    await expect(acquireSkillTargetLock(rootDir, 'demo')).rejects.toThrow('install target is busy')
+    expect(await exists(liveContenderPath)).toBe(true)
+    await rm(acquisitionGatePath, { recursive: true })
+  })
+
+  test('recovers acquisition contenders whose owner process exited', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-dead-gate-'))
+    const lockPath = await skillTargetLockPath(rootDir, 'demo')
+    const acquisitionGatePath = `${lockPath}.acquire`
+    await mkdir(acquisitionGatePath)
+    const bunPath = (await Bun.which('bun')) ?? process.execPath
+    const exitedOwner = Bun.spawn({ cmd: [bunPath, '-e', ''], stdout: 'ignore', stderr: 'ignore' })
+    const deadPid = exitedOwner.pid
+    expect(await exitedOwner.exited).toBe(0)
+    await writeFile(join(acquisitionGatePath, `${deadPid}-abandoned.choosing`), '')
+    await writeFile(join(acquisitionGatePath, `${deadPid}-abandoned.ticket`), '1')
+
+    const release = await acquireSkillTargetLock(rootDir, 'demo')
+    await release()
+    expect(await readdir(acquisitionGatePath)).toEqual([])
+  })
 
   test('keeps one lock identity when a symlink target is removed', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-symlink-root-'))

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -122,6 +122,8 @@ describe('skill target lifecycle lock', () => {
     expect(results.map(result => result.exitCode).sort()).toEqual([0, ...Array(workerCount - 1).fill(4)])
     expect(results.filter(result => result.stdout === 'acquired')).toHaveLength(1)
     expect(await exists(lockPath)).toBe(false)
+    const releaseAfterContention = await acquireSkillTargetLock(rootDir, 'demo')
+    await releaseAfterContention()
     if (process.platform !== 'win32') {
       expect((await lstat(dirname(lockPath))).mode & 0o077).toBe(0)
     }

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -80,6 +80,9 @@ describe('skill target lifecycle lock', () => {
     await mkdir(lockPath)
     const staleTime = new Date(Date.now() - 60_000)
     await utimes(lockPath, staleTime, staleTime)
+    const acquisitionGatePath = `${lockPath}.acquire`
+    await writeFile(acquisitionGatePath, 'abandoned-owner')
+    await utimes(acquisitionGatePath, staleTime, staleTime)
     const worker = fileURLToPath(new URL('../../helpers/target-lock-worker.ts', import.meta.url))
     const bunPath = (await Bun.which('bun')) ?? process.execPath
     const acquiredPath = join(rootDir, 'acquired')
@@ -121,7 +124,11 @@ describe('skill target lifecycle lock', () => {
 
     expect(results.map(result => result.exitCode).sort()).toEqual([0, ...Array(workerCount - 1).fill(4)])
     expect(results.filter(result => result.stdout === 'acquired')).toHaveLength(1)
+    for (const loser of results.filter(result => result.exitCode === 4)) {
+      expect(loser.stderr).toContain('install target is busy')
+    }
     expect(await exists(lockPath)).toBe(false)
+    expect(await exists(acquisitionGatePath)).toBe(false)
     const releaseAfterContention = await acquireSkillTargetLock(rootDir, 'demo')
     await releaseAfterContention()
     if (process.platform !== 'win32') {

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -179,6 +179,9 @@ describe('skill target lifecycle lock', () => {
   test('recovers acquisition contenders whose owner process exited', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-dead-gate-'))
     const lockPath = await skillTargetLockPath(rootDir, 'demo')
+    await mkdir(lockPath)
+    const staleTime = new Date(Date.now() - 60_000)
+    await utimes(lockPath, staleTime, staleTime)
     const acquisitionGatePath = `${lockPath}.acquire`
     await mkdir(acquisitionGatePath)
     const bunPath = (await Bun.which('bun')) ?? process.execPath

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -1,4 +1,4 @@
-import { access, chmod, lstat, mkdir, mkdtemp, readdir, rm, symlink, unlink, utimes, writeFile } from 'node:fs/promises'
+import { access, chmod, lstat, mkdir, mkdtemp, readdir, symlink, unlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -144,9 +144,16 @@ describe('skill target lifecycle lock', () => {
     const staleTime = new Date(Date.now() - 60_000)
     await utimes(liveContenderPath, staleTime, staleTime)
 
-    await expect(acquireSkillTargetLock(rootDir, 'demo')).rejects.toThrow('install target is busy')
+    const acquisition = acquireSkillTargetLock(rootDir, 'demo')
+    const state = await Promise.race([
+      acquisition.then(() => 'acquired', () => 'rejected'),
+      Bun.sleep(50).then(() => 'waiting')
+    ])
+    expect(state).toBe('waiting')
     expect(await exists(liveContenderPath)).toBe(true)
-    await rm(acquisitionGatePath, { recursive: true })
+    await unlink(liveContenderPath)
+    const release = await acquisition
+    await release()
   })
 
   test('does not pass a live acquisition ticket', async () => {
@@ -157,9 +164,16 @@ describe('skill target lifecycle lock', () => {
     const liveTicketPath = join(acquisitionGatePath, `ticket.1.${process.pid}-suspended`)
     await writeFile(liveTicketPath, '')
 
-    await expect(acquireSkillTargetLock(rootDir, 'demo')).rejects.toThrow('install target is busy')
+    const acquisition = acquireSkillTargetLock(rootDir, 'demo')
+    const state = await Promise.race([
+      acquisition.then(() => 'acquired', () => 'rejected'),
+      Bun.sleep(50).then(() => 'waiting')
+    ])
+    expect(state).toBe('waiting')
     expect(await exists(liveTicketPath)).toBe(true)
-    await rm(acquisitionGatePath, { recursive: true })
+    await unlink(liveTicketPath)
+    const release = await acquisition
+    await release()
   })
 
   test('recovers acquisition contenders whose owner process exited', async () => {

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -193,6 +193,7 @@ describe('skill target lifecycle lock', () => {
 
     const release = await acquireSkillTargetLock(rootDir, 'demo')
     await release()
+    expect(await exists(lockPath)).toBe(false)
     expect(await readdir(acquisitionGatePath)).toEqual([])
   })
 

--- a/cli/test/unit/services/skill-target-lock.test.ts
+++ b/cli/test/unit/services/skill-target-lock.test.ts
@@ -139,13 +139,26 @@ describe('skill target lifecycle lock', () => {
     const lockPath = await skillTargetLockPath(rootDir, 'demo')
     const acquisitionGatePath = `${lockPath}.acquire`
     await mkdir(acquisitionGatePath)
-    const liveContenderPath = join(acquisitionGatePath, `${process.pid}-suspended.choosing`)
+    const liveContenderPath = join(acquisitionGatePath, `choosing.${process.pid}-suspended`)
     await writeFile(liveContenderPath, '')
     const staleTime = new Date(Date.now() - 60_000)
     await utimes(liveContenderPath, staleTime, staleTime)
 
     await expect(acquireSkillTargetLock(rootDir, 'demo')).rejects.toThrow('install target is busy')
     expect(await exists(liveContenderPath)).toBe(true)
+    await rm(acquisitionGatePath, { recursive: true })
+  })
+
+  test('does not pass a live acquisition ticket', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'skillhub-target-live-ticket-'))
+    const lockPath = await skillTargetLockPath(rootDir, 'demo')
+    const acquisitionGatePath = `${lockPath}.acquire`
+    await mkdir(acquisitionGatePath)
+    const liveTicketPath = join(acquisitionGatePath, `ticket.1.${process.pid}-suspended`)
+    await writeFile(liveTicketPath, '')
+
+    await expect(acquireSkillTargetLock(rootDir, 'demo')).rejects.toThrow('install target is busy')
+    expect(await exists(liveTicketPath)).toBe(true)
     await rm(acquisitionGatePath, { recursive: true })
   })
 
@@ -158,8 +171,8 @@ describe('skill target lifecycle lock', () => {
     const exitedOwner = Bun.spawn({ cmd: [bunPath, '-e', ''], stdout: 'ignore', stderr: 'ignore' })
     const deadPid = exitedOwner.pid
     expect(await exitedOwner.exited).toBe(0)
-    await writeFile(join(acquisitionGatePath, `${deadPid}-abandoned.choosing`), '')
-    await writeFile(join(acquisitionGatePath, `${deadPid}-abandoned.ticket`), '1')
+    await writeFile(join(acquisitionGatePath, `choosing.${deadPid}-abandoned`), '')
+    await writeFile(join(acquisitionGatePath, `ticket.1.${deadPid}-abandoned`), '')
 
     const release = await acquireSkillTargetLock(rootDir, 'demo')
     await release()


### PR DESCRIPTION
## What

Prevent multiple SkillHub CLI processes from entering the same target lifecycle critical section while concurrently recovering a stale lock.

## Why

Two processes can currently both acquire a stale proper-lockfile directory. This violates mutual exclusion and can allow concurrent install, upgrade, or remove mutations of one Skill target.

Closes #838

## Implementation

- use a per-target Lamport bakery queue while acquiring the existing target lock;
- give every contender a PID + random nonce path, so crash cleanup cannot unlink a replacement owner;
- clean only records whose PID is confirmed dead (ESRCH); live or unknown owners remain protected;
- keep the public acquireSkillTargetLock(rootDir, slug) interface and loser install target is busy behavior unchanged;
- add no network request or production dependency.

The queue scans only its target-specific directory, whose normal steady state is empty. It does not scan install roots or user state directories.

## Validation

- RED baseline reproduced multiple owners during simultaneous stale recovery;
- related target-lock suite: 15/15 passed;
- 8-process stale recovery: exactly one owner and seven busy losers;
- live choosing/ticket records are not reclaimed; dead-process records recover;
- lock stress: 200/200 rounds passed;
- full CLI: 477/477 tests passed;
- typecheck, ESLint, and Node-target build passed;
- exact-head Ubuntu, macOS, and Windows CLI checks passed;
- Server, Web, Docs, Dependency Review, DCO, and CLA checks passed after Ready-for-review;
- manually dispatched exact-head E2E (Real Services) passed;
- local exact-SHA Server/Web images matched ddf4dcd and passed health/auth smoke.

### Performance

The test-design budget was frozen before the final confirmation: paired median head/base < 3, paired median head-base < 2 ms, and head median < 5 ms. This is a validation budget, not a product SLO.

Final 7 x 1000 AB/BA paired run on Bun 1.3.14/Linux/tmpfs:
- base median: 0.417 ms
- head median: 1.079 ms
- paired ratio median: 2.434
- paired delta median: 0.624 ms

All three earlier host-load-sensitive measurements were retained in the private evidence: 1.063/2.229 ms (old budget fail), 0.590/1.241 ms (isolated diagnostic pass), and 1.357/2.735 ms (old budget fail). No result was discarded to select a green run.

## Impact

CLI local filesystem locking only. No server API, database, Web UI, deployment configuration, migration, or network-path changes.