### PR TITLE
feat(cli): add AStudio agent profile

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable CLI behavior changes are documented in this file.
 
 ### Added
 
+- Add the user-level `astron-studio` agent profile, with automatic detection of
+  `~/.acode/skills` on Linux, macOS, and Windows.
 - Add repeatable `sync pull --skill <slug>` selection for non-interactive and JSON workflows, with
   interactive multi-select in a TTY.
 - Add `skillhub upgrade <coordinate...>` for bounded, explicit upgrades of already-installed Skills,

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable CLI behavior changes are documented in this file.
 
 ### Added
 
-- Add the user-level `AStudio` agent profile, with automatic detection of
+- Add the user-level `astudio` agent profile, displayed as AStudio, with automatic detection of
   `~/.acode/skills` on Linux, macOS, and Windows.
 - Add repeatable `sync pull --skill <slug>` selection for non-interactive and JSON workflows, with
   interactive multi-select in a TTY.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable CLI behavior changes are documented in this file.
 
 ### Added
 
-- Add the user-level `astron-studio` agent profile, with automatic detection of
+- Add the user-level `AStudio` agent profile, with automatic detection of
   `~/.acode/skills` on Linux, macOS, and Windows.
 - Add repeatable `sync pull --skill <slug>` selection for non-interactive and JSON workflows, with
   interactive multi-select in a TTY.

--- a/cli/README.md
+++ b/cli/README.md
@@ -169,6 +169,9 @@ skillhub install pdf-parser --version 1.2.0
 # Install to specific Agent
 skillhub install pdf-parser --agent codex
 
+# Install to AstronStudio's fixed user-level directory
+skillhub install pdf-parser --agent astron-studio
+
 # Install to multiple Agents
 skillhub install pdf-parser --agent codex --agent claude-code
 
@@ -197,10 +200,11 @@ The CLI determines the installation location using the following logic:
 
 ### Install Paths
 
-Each Agent has both project-level and user-level skills directories. Use `--scope user|project` to control which one is used.
+Most Agents have both project-level and user-level skills directories. Use `--scope user|project` to control which one is used. AstronStudio uses its fixed user-level directory only.
 
 | Agent | Project-level Path | User-level Path |
 |-------|-------------------|-----------------|
+| `astron-studio` | Not supported | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |
@@ -217,7 +221,7 @@ Each Agent has both project-level and user-level skills directories. Use `--scop
 | `kilo` | `<project>/.kilo/skills/` | `~/.kilo/skills/` |
 | _fallback_ | `<project>/.agents/skills/` | `~/.agents/skills/` |
 
-For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
+For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. AstronStudio appears in that selector when `~/.acode/skills/` exists. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
 
 ### File Structure After Installation
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -170,7 +170,7 @@ skillhub install pdf-parser --version 1.2.0
 skillhub install pdf-parser --agent codex
 
 # Install to AStudio's fixed user-level directory
-skillhub install pdf-parser --agent AStudio
+skillhub install pdf-parser --agent astudio
 
 # Install to multiple Agents
 skillhub install pdf-parser --agent codex --agent claude-code
@@ -204,7 +204,7 @@ Most Agents have both project-level and user-level skills directories. Use `--sc
 
 | Agent | Project-level Path | User-level Path |
 |-------|-------------------|-----------------|
-| `AStudio` | Not supported | `~/.acode/skills/` |
+| `astudio` (AStudio) | Not supported | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |

--- a/cli/README.md
+++ b/cli/README.md
@@ -169,8 +169,8 @@ skillhub install pdf-parser --version 1.2.0
 # Install to specific Agent
 skillhub install pdf-parser --agent codex
 
-# Install to AstronStudio's fixed user-level directory
-skillhub install pdf-parser --agent astron-studio
+# Install to AStudio's fixed user-level directory
+skillhub install pdf-parser --agent AStudio
 
 # Install to multiple Agents
 skillhub install pdf-parser --agent codex --agent claude-code
@@ -200,11 +200,11 @@ The CLI determines the installation location using the following logic:
 
 ### Install Paths
 
-Most Agents have both project-level and user-level skills directories. Use `--scope user|project` to control which one is used. AstronStudio uses its fixed user-level directory only.
+Most Agents have both project-level and user-level skills directories. Use `--scope user|project` to control which one is used. AStudio uses its fixed user-level directory only.
 
 | Agent | Project-level Path | User-level Path |
 |-------|-------------------|-----------------|
-| `astron-studio` | Not supported | `~/.acode/skills/` |
+| `AStudio` | Not supported | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |
@@ -221,7 +221,7 @@ Most Agents have both project-level and user-level skills directories. Use `--sc
 | `kilo` | `<project>/.kilo/skills/` | `~/.kilo/skills/` |
 | _fallback_ | `<project>/.agents/skills/` | `~/.agents/skills/` |
 
-For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. AstronStudio appears in that selector when `~/.acode/skills/` exists. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
+For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. AStudio appears in that selector when `~/.acode/skills/` exists. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
 
 ### File Structure After Installation
 

--- a/cli/src/agents/detector.ts
+++ b/cli/src/agents/detector.ts
@@ -1,5 +1,5 @@
 import type { AgentProfile } from './types'
-import { astronStudioProfile } from './profiles/astron-studio'
+import { aStudioProfile } from './profiles/astudio'
 import { claudeCodeProfile } from './profiles/claude-code'
 import { codexProfile } from './profiles/codex'
 import { cursorProfile } from './profiles/cursor'
@@ -16,14 +16,14 @@ import { opencodeProfile } from './profiles/opencode'
 import { kiloProfile } from './profiles/kilo'
 
 export {
-  astronStudioProfile, claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
+  aStudioProfile, claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
   geminiCliProfile, openhandsProfile, windsurfProfile, openclawProfile,
   kiroCliProfile, rooProfile, traeProfile, traeCnProfile,
   opencodeProfile, kiloProfile
 }
 
 export const allProfiles: AgentProfile[] = [
-  astronStudioProfile, claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
+  aStudioProfile, claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
   geminiCliProfile, openhandsProfile, windsurfProfile, openclawProfile,
   kiroCliProfile, rooProfile, traeProfile, traeCnProfile,
   opencodeProfile, kiloProfile

--- a/cli/src/agents/detector.ts
+++ b/cli/src/agents/detector.ts
@@ -1,4 +1,5 @@
 import type { AgentProfile } from './types'
+import { astronStudioProfile } from './profiles/astron-studio'
 import { claudeCodeProfile } from './profiles/claude-code'
 import { codexProfile } from './profiles/codex'
 import { cursorProfile } from './profiles/cursor'
@@ -15,14 +16,14 @@ import { opencodeProfile } from './profiles/opencode'
 import { kiloProfile } from './profiles/kilo'
 
 export {
-  claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
+  astronStudioProfile, claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
   geminiCliProfile, openhandsProfile, windsurfProfile, openclawProfile,
   kiroCliProfile, rooProfile, traeProfile, traeCnProfile,
   opencodeProfile, kiloProfile
 }
 
 export const allProfiles: AgentProfile[] = [
-  claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
+  astronStudioProfile, claudeCodeProfile, codexProfile, cursorProfile, githubCopilotProfile,
   geminiCliProfile, openhandsProfile, windsurfProfile, openclawProfile,
   kiroCliProfile, rooProfile, traeProfile, traeCnProfile,
   opencodeProfile, kiloProfile

--- a/cli/src/agents/profiles/astron-studio.ts
+++ b/cli/src/agents/profiles/astron-studio.ts
@@ -1,0 +1,23 @@
+import { directoryExists } from '../../platform/paths'
+import type { AgentProfile } from '../types'
+
+function userSkillsRoot(home: string): string {
+  return home.replace(/\\/g, '/').replace(/\/+$/, '') + '/.acode/skills'
+}
+
+export const astronStudioProfile: AgentProfile = {
+  id: 'astron-studio',
+  displayName: 'AstronStudio',
+  projectRoots: () => [],
+  userRoots: home => [userSkillsRoot(home)],
+  async detectInstalled(_cwd, home) {
+    const rootDir = userSkillsRoot(home)
+    if (!await directoryExists(rootDir)) return []
+    return [{
+      agent: this.id,
+      rootDir,
+      scope: 'user',
+      source: 'detected'
+    }]
+  }
+}

--- a/cli/src/agents/profiles/astudio.ts
+++ b/cli/src/agents/profiles/astudio.ts
@@ -5,9 +5,9 @@ function userSkillsRoot(home: string): string {
   return home.replace(/\\/g, '/').replace(/\/+$/, '') + '/.acode/skills'
 }
 
-export const astronStudioProfile: AgentProfile = {
-  id: 'astron-studio',
-  displayName: 'AstronStudio',
+export const aStudioProfile: AgentProfile = {
+  id: 'AStudio',
+  displayName: 'AStudio',
   projectRoots: () => [],
   userRoots: home => [userSkillsRoot(home)],
   async detectInstalled(_cwd, home) {

--- a/cli/src/agents/profiles/astudio.ts
+++ b/cli/src/agents/profiles/astudio.ts
@@ -6,7 +6,7 @@ function userSkillsRoot(home: string): string {
 }
 
 export const aStudioProfile: AgentProfile = {
-  id: 'AStudio',
+  id: 'astudio',
   displayName: 'AStudio',
   projectRoots: () => [],
   userRoots: home => [userSkillsRoot(home)],

--- a/cli/src/agents/profiles/make-profile.ts
+++ b/cli/src/agents/profiles/make-profile.ts
@@ -1,9 +1,5 @@
-import { pathExists } from '../../platform/paths'
+import { directoryExists } from '../../platform/paths'
 import type { AgentProfile, AgentCandidate } from '../types'
-
-async function dirExists(path: string): Promise<boolean> {
-  return pathExists(path)
-}
 
 export function makeProfile(id: string, displayName: string, projectSkills: string, userSkills: string): AgentProfile {
   return {
@@ -15,7 +11,7 @@ export function makeProfile(id: string, displayName: string, projectSkills: stri
       const roots = [...this.projectRoots(cwd), ...this.userRoots(home)]
       const results: AgentCandidate[] = []
       for (const root of roots) {
-        if (await dirExists(root)) {
+        if (await directoryExists(root)) {
           results.push({
             agent: this.id,
             rootDir: root,

--- a/cli/src/agents/resolver.ts
+++ b/cli/src/agents/resolver.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'node:os'
 import { CliError } from '../shared/errors'
 import { EXIT } from '../shared/constants'
-import { canonicalizeExistingPath, pathExists } from '../platform/paths'
+import { canonicalizeExistingPath, directoryExists } from '../platform/paths'
 import type { AgentCandidate } from './types'
 import { allProfiles, profileMap } from './detector'
 
@@ -105,7 +105,7 @@ async function generateScopedCandidates(
   for (const profile of allProfiles) {
     const roots = scope === 'user' ? profile.userRoots(home) : profile.projectRoots(cwd)
     for (const root of roots) {
-      if (await pathExists(root)) {
+      if (await directoryExists(root)) {
         results.push({ agent: profile.id, rootDir: root, scope, source: 'detected' })
       }
     }
@@ -145,6 +145,11 @@ async function resolveExplicitAgents(
       const userRoots = home ? profile.userRoots(home) : []
       roots = userRoots.length > 0 ? userRoots : profile.projectRoots(cwd)
     }
+    if (roots.length === 0) {
+      throw new CliError(`agent ${agentId} does not support ${scope} scope`, EXIT.usage, {
+        next: 'choose a supported scope or omit --scope'
+      })
+    }
     const userRootSet = new Set(home ? profile.userRoots(home) : [])
     for (const root of roots) {
       const candidateScope: AgentCandidate['scope'] = scope !== undefined
@@ -183,7 +188,7 @@ async function selectTargetsInteractively(candidates: AgentCandidate[]): Promise
     name: 'selected',
     message: 'Select install targets',
     choices: candidates.map(c => ({
-      title: `${c.agent} (${c.rootDir})`,
+      title: `${profileMap.get(c.agent)?.displayName ?? c.agent} (${c.rootDir})`,
       value: c
     })),
     onRender: function (this: { cursor?: number }) {

--- a/cli/src/platform/paths.ts
+++ b/cli/src/platform/paths.ts
@@ -24,6 +24,15 @@ export async function pathExists(path: string): Promise<boolean> {
   }
 }
 
+export async function directoryExists(path: string): Promise<boolean> {
+  const { stat } = await import('node:fs/promises')
+  try {
+    return (await stat(path)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
 export async function canonicalizeExistingPath(path: string): Promise<string> {
   const { realpath } = await import('node:fs/promises')
   try {

--- a/cli/test/integration/install-command.test.ts
+++ b/cli/test/integration/install-command.test.ts
@@ -667,7 +667,7 @@ describe('install command — server errors', () => {
 // ---------------------------------------------------------------------------
 
 describe('install command — multi-agent & auto-detect', () => {
-  test('--agent AStudio installs into the fixed user-level .acode skills directory', async () => {
+  test('--agent astudio installs and persists the stable lowercase agent id', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({
       token: 'sk_ok',
@@ -679,7 +679,7 @@ describe('install command — multi-agent & auto-detect', () => {
     const result = await runCli(
       [
         'install', 'pdf-parser',
-        '--agent', 'AStudio',
+        '--agent', 'astudio',
         '--registry', registry.url,
         '--token', 'sk_ok',
         '--json'
@@ -690,17 +690,24 @@ describe('install command — multi-agent & auto-detect', () => {
     expect(result.exitCode).toBe(0)
     const parsed = JSON.parse(result.stdout) as { installed: Array<{ agent: string; dir: string }> }
     expect(parsed.installed).toEqual([{
-      agent: 'AStudio',
+      agent: 'astudio',
       dir: join(env.home, '.acode', 'skills', 'pdf-parser')
     }])
-    expect(await Bun.file(join(
+    const metadataPath = join(
       env.home,
       '.acode',
       'skills',
       'pdf-parser',
       '.skillhub',
       'metadata.json'
-    )).exists()).toBe(true)
+    )
+    expect(await Bun.file(metadataPath).exists()).toBe(true)
+    expect(JSON.parse(await readFile(metadataPath, 'utf-8')).agent).toBe('astudio')
+
+    const inventory = JSON.parse(await readFile(join(env.home, '.skillhub', 'inventory.json'), 'utf-8')) as {
+      items: Array<{ targets: Array<{ agent: string }> }>
+    }
+    expect(inventory.items[0]?.targets[0]?.agent).toBe('astudio')
   })
 
   test('multi --agent installs the same skill into every specified user-level dir', async () => {

--- a/cli/test/integration/install-command.test.ts
+++ b/cli/test/integration/install-command.test.ts
@@ -667,7 +667,7 @@ describe('install command — server errors', () => {
 // ---------------------------------------------------------------------------
 
 describe('install command — multi-agent & auto-detect', () => {
-  test('--agent astron-studio installs into the fixed user-level .acode skills directory', async () => {
+  test('--agent AStudio installs into the fixed user-level .acode skills directory', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({
       token: 'sk_ok',
@@ -679,7 +679,7 @@ describe('install command — multi-agent & auto-detect', () => {
     const result = await runCli(
       [
         'install', 'pdf-parser',
-        '--agent', 'astron-studio',
+        '--agent', 'AStudio',
         '--registry', registry.url,
         '--token', 'sk_ok',
         '--json'
@@ -690,7 +690,7 @@ describe('install command — multi-agent & auto-detect', () => {
     expect(result.exitCode).toBe(0)
     const parsed = JSON.parse(result.stdout) as { installed: Array<{ agent: string; dir: string }> }
     expect(parsed.installed).toEqual([{
-      agent: 'astron-studio',
+      agent: 'AStudio',
       dir: join(env.home, '.acode', 'skills', 'pdf-parser')
     }])
     expect(await Bun.file(join(

--- a/cli/test/integration/install-command.test.ts
+++ b/cli/test/integration/install-command.test.ts
@@ -667,6 +667,42 @@ describe('install command — server errors', () => {
 // ---------------------------------------------------------------------------
 
 describe('install command — multi-agent & auto-detect', () => {
+  test('--agent astron-studio installs into the fixed user-level .acode skills directory', async () => {
+    const env = await createTempHome()
+    registry = await startFakeRegistry({
+      token: 'sk_ok',
+      user: { handle: 'u', displayName: 'U' },
+      skills: [{ namespace: 'global', slug: 'pdf-parser', version: '1.0.0', zipBytes: makeSkillZip() }]
+    })
+    await runCli(['login', '--registry', registry.url, '--token', 'sk_ok'], { HOME: env.home, USERPROFILE: env.home })
+
+    const result = await runCli(
+      [
+        'install', 'pdf-parser',
+        '--agent', 'astron-studio',
+        '--registry', registry.url,
+        '--token', 'sk_ok',
+        '--json'
+      ],
+      { HOME: env.home, USERPROFILE: env.home }
+    )
+
+    expect(result.exitCode).toBe(0)
+    const parsed = JSON.parse(result.stdout) as { installed: Array<{ agent: string; dir: string }> }
+    expect(parsed.installed).toEqual([{
+      agent: 'astron-studio',
+      dir: join(env.home, '.acode', 'skills', 'pdf-parser')
+    }])
+    expect(await Bun.file(join(
+      env.home,
+      '.acode',
+      'skills',
+      'pdf-parser',
+      '.skillhub',
+      'metadata.json'
+    )).exists()).toBe(true)
+  })
+
   test('multi --agent installs the same skill into every specified user-level dir', async () => {
     const env = await createTempHome()
     registry = await startFakeRegistry({

--- a/cli/test/unit/agents/profiles.test.ts
+++ b/cli/test/unit/agents/profiles.test.ts
@@ -16,7 +16,7 @@ describe('agent profiles', () => {
 
   test('profileMap contains all profiles', () => {
     expect(profileMap.size).toBe(15)
-    expect(profileMap.has('AStudio')).toBe(true)
+    expect(profileMap.has('astudio')).toBe(true)
     expect(profileMap.has('claude-code')).toBe(true)
     expect(profileMap.has('codex')).toBe(true)
     expect(profileMap.has('cursor')).toBe(true)
@@ -41,7 +41,7 @@ describe('agent profiles', () => {
   })
 
   test('AStudio exposes only its fixed user-level directory on Linux, macOS, and Windows', () => {
-    const profile = profileMap.get('AStudio')!
+    const profile = profileMap.get('astudio')!
 
     expect(profile.displayName).toBe('AStudio')
     expect(profile.projectRoots('/repo')).toEqual([])
@@ -52,7 +52,7 @@ describe('agent profiles', () => {
 
   test('AStudio is detected only when the user .acode skills directory exists', async () => {
     const home = await mkdtemp(join(tmpdir(), 'skillhub-astudio-home-'))
-    const profile = profileMap.get('AStudio')!
+    const profile = profileMap.get('astudio')!
     const nativeRootDir = join(home, '.acode', 'skills')
     const profileRootDir = nativeRootDir.replace(/\\/g, '/')
 
@@ -67,7 +67,7 @@ describe('agent profiles', () => {
       await mkdir(nativeRootDir, { recursive: true })
 
       expect(await profile.detectInstalled('/repo', home)).toEqual([{
-        agent: 'AStudio',
+        agent: 'astudio',
         rootDir: profileRootDir,
         scope: 'user',
         source: 'detected'

--- a/cli/test/unit/agents/profiles.test.ts
+++ b/cli/test/unit/agents/profiles.test.ts
@@ -53,21 +53,22 @@ describe('agent profiles', () => {
   test('AstronStudio is detected only when the user .acode skills directory exists', async () => {
     const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-home-'))
     const profile = profileMap.get('astron-studio')!
-    const rootDir = join(home, '.acode', 'skills')
+    const nativeRootDir = join(home, '.acode', 'skills')
+    const profileRootDir = nativeRootDir.replace(/\\/g, '/')
 
     try {
       expect(await profile.detectInstalled('/repo', home)).toEqual([])
 
       await mkdir(join(home, '.acode'), { recursive: true })
-      await writeFile(rootDir, 'not a directory')
+      await writeFile(nativeRootDir, 'not a directory')
       expect(await profile.detectInstalled('/repo', home)).toEqual([])
 
-      await rm(rootDir)
-      await mkdir(rootDir, { recursive: true })
+      await rm(nativeRootDir)
+      await mkdir(nativeRootDir, { recursive: true })
 
       expect(await profile.detectInstalled('/repo', home)).toEqual([{
         agent: 'astron-studio',
-        rootDir,
+        rootDir: profileRootDir,
         scope: 'user',
         source: 'detected'
       }])

--- a/cli/test/unit/agents/profiles.test.ts
+++ b/cli/test/unit/agents/profiles.test.ts
@@ -16,7 +16,7 @@ describe('agent profiles', () => {
 
   test('profileMap contains all profiles', () => {
     expect(profileMap.size).toBe(15)
-    expect(profileMap.has('astron-studio')).toBe(true)
+    expect(profileMap.has('AStudio')).toBe(true)
     expect(profileMap.has('claude-code')).toBe(true)
     expect(profileMap.has('codex')).toBe(true)
     expect(profileMap.has('cursor')).toBe(true)
@@ -40,19 +40,19 @@ describe('agent profiles', () => {
     expect(profile.projectRoots('/repo')).toEqual(['/repo/.cursor/skills'])
   })
 
-  test('AstronStudio exposes only its fixed user-level directory on Linux, macOS, and Windows', () => {
-    const profile = profileMap.get('astron-studio')!
+  test('AStudio exposes only its fixed user-level directory on Linux, macOS, and Windows', () => {
+    const profile = profileMap.get('AStudio')!
 
-    expect(profile.displayName).toBe('AstronStudio')
+    expect(profile.displayName).toBe('AStudio')
     expect(profile.projectRoots('/repo')).toEqual([])
     expect(profile.userRoots('/home/alice')).toEqual(['/home/alice/.acode/skills'])
     expect(profile.userRoots('/Users/alice')).toEqual(['/Users/alice/.acode/skills'])
     expect(profile.userRoots('C:\\Users\\alice')).toEqual(['C:/Users/alice/.acode/skills'])
   })
 
-  test('AstronStudio is detected only when the user .acode skills directory exists', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-home-'))
-    const profile = profileMap.get('astron-studio')!
+  test('AStudio is detected only when the user .acode skills directory exists', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-astudio-home-'))
+    const profile = profileMap.get('AStudio')!
     const nativeRootDir = join(home, '.acode', 'skills')
     const profileRootDir = nativeRootDir.replace(/\\/g, '/')
 
@@ -67,7 +67,7 @@ describe('agent profiles', () => {
       await mkdir(nativeRootDir, { recursive: true })
 
       expect(await profile.detectInstalled('/repo', home)).toEqual([{
-        agent: 'astron-studio',
+        agent: 'AStudio',
         rootDir: profileRootDir,
         scope: 'user',
         source: 'detected'

--- a/cli/test/unit/agents/profiles.test.ts
+++ b/cli/test/unit/agents/profiles.test.ts
@@ -1,9 +1,12 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
 import { allProfiles, profileMap } from '../../../src/agents/detector'
 
 describe('agent profiles', () => {
-  test('has 14 tier 1 profiles', () => {
-    expect(allProfiles).toHaveLength(14)
+  test('has 15 tier 1 profiles', () => {
+    expect(allProfiles).toHaveLength(15)
   })
 
   test('all profiles have unique ids', () => {
@@ -12,7 +15,8 @@ describe('agent profiles', () => {
   })
 
   test('profileMap contains all profiles', () => {
-    expect(profileMap.size).toBe(14)
+    expect(profileMap.size).toBe(15)
+    expect(profileMap.has('astron-studio')).toBe(true)
     expect(profileMap.has('claude-code')).toBe(true)
     expect(profileMap.has('codex')).toBe(true)
     expect(profileMap.has('cursor')).toBe(true)
@@ -34,5 +38,41 @@ describe('agent profiles', () => {
   test('cursor profile returns correct roots', () => {
     const profile = profileMap.get('cursor')!
     expect(profile.projectRoots('/repo')).toEqual(['/repo/.cursor/skills'])
+  })
+
+  test('AstronStudio exposes only its fixed user-level directory on Linux, macOS, and Windows', () => {
+    const profile = profileMap.get('astron-studio')!
+
+    expect(profile.displayName).toBe('AstronStudio')
+    expect(profile.projectRoots('/repo')).toEqual([])
+    expect(profile.userRoots('/home/alice')).toEqual(['/home/alice/.acode/skills'])
+    expect(profile.userRoots('/Users/alice')).toEqual(['/Users/alice/.acode/skills'])
+    expect(profile.userRoots('C:\\Users\\alice')).toEqual(['C:/Users/alice/.acode/skills'])
+  })
+
+  test('AstronStudio is detected only when the user .acode skills directory exists', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-home-'))
+    const profile = profileMap.get('astron-studio')!
+    const rootDir = join(home, '.acode', 'skills')
+
+    try {
+      expect(await profile.detectInstalled('/repo', home)).toEqual([])
+
+      await mkdir(join(home, '.acode'), { recursive: true })
+      await writeFile(rootDir, 'not a directory')
+      expect(await profile.detectInstalled('/repo', home)).toEqual([])
+
+      await rm(rootDir)
+      await mkdir(rootDir, { recursive: true })
+
+      expect(await profile.detectInstalled('/repo', home)).toEqual([{
+        agent: 'astron-studio',
+        rootDir,
+        scope: 'user',
+        source: 'detected'
+      }])
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
   })
 })

--- a/cli/test/unit/agents/resolver-interactive.test.ts
+++ b/cli/test/unit/agents/resolver-interactive.test.ts
@@ -73,7 +73,7 @@ describe('resolveInstallTargets interactive prompt', () => {
         interactive: true
       })
 
-      expect(renderedChoices.some(choice => choice.value.agent === 'AStudio')).toBe(false)
+      expect(renderedChoices.some(choice => choice.value.agent === 'astudio')).toBe(false)
       expect(targets).toEqual([{
         agent: 'generic',
         rootDir: `${home}/.agents/skills`,

--- a/cli/test/unit/agents/resolver-interactive.test.ts
+++ b/cli/test/unit/agents/resolver-interactive.test.ts
@@ -35,8 +35,8 @@ afterEach(() => {
 const { resolveInstallTargets } = await import('../../../src/agents/resolver')
 
 describe('resolveInstallTargets interactive prompt', () => {
-  test('renders AstronStudio by display name when its directory was detected', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-resolver-'))
+  test('renders AStudio by display name when its directory was detected', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-astudio-resolver-'))
     const nativeRootDir = join(home, '.acode', 'skills')
     const profileRootDir = nativeRootDir.replace(/\\/g, '/')
 
@@ -51,14 +51,14 @@ describe('resolveInstallTargets interactive prompt', () => {
         interactive: true
       })
 
-      expect(renderedChoices[0]?.title).toBe(`AstronStudio (${profileRootDir})`)
+      expect(renderedChoices[0]?.title).toBe(`AStudio (${profileRootDir})`)
     } finally {
       await rm(home, { recursive: true, force: true })
     }
   })
 
-  test('does not render AstronStudio when .acode skills is a regular file', async () => {
-    const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-file-'))
+  test('does not render AStudio when .acode skills is a regular file', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-astudio-file-'))
     const rootDir = join(home, '.acode', 'skills')
 
     try {
@@ -73,7 +73,7 @@ describe('resolveInstallTargets interactive prompt', () => {
         interactive: true
       })
 
-      expect(renderedChoices.some(choice => choice.value.agent === 'astron-studio')).toBe(false)
+      expect(renderedChoices.some(choice => choice.value.agent === 'AStudio')).toBe(false)
       expect(targets).toEqual([{
         agent: 'generic',
         rootDir: `${home}/.agents/skills`,

--- a/cli/test/unit/agents/resolver-interactive.test.ts
+++ b/cli/test/unit/agents/resolver-interactive.test.ts
@@ -37,10 +37,11 @@ const { resolveInstallTargets } = await import('../../../src/agents/resolver')
 describe('resolveInstallTargets interactive prompt', () => {
   test('renders AstronStudio by display name when its directory was detected', async () => {
     const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-resolver-'))
-    const rootDir = join(home, '.acode', 'skills')
+    const nativeRootDir = join(home, '.acode', 'skills')
+    const profileRootDir = nativeRootDir.replace(/\\/g, '/')
 
     try {
-      await mkdir(rootDir, { recursive: true })
+      await mkdir(nativeRootDir, { recursive: true })
       await resolveInstallTargets({
         cwd: '/repo',
         home,
@@ -50,7 +51,7 @@ describe('resolveInstallTargets interactive prompt', () => {
         interactive: true
       })
 
-      expect(renderedChoices[0]?.title).toBe(`AstronStudio (${rootDir})`)
+      expect(renderedChoices[0]?.title).toBe(`AstronStudio (${profileRootDir})`)
     } finally {
       await rm(home, { recursive: true, force: true })
     }
@@ -75,7 +76,7 @@ describe('resolveInstallTargets interactive prompt', () => {
       expect(renderedChoices.some(choice => choice.value.agent === 'astron-studio')).toBe(false)
       expect(targets).toEqual([{
         agent: 'generic',
-        rootDir: join(home, '.agents', 'skills'),
+        rootDir: `${home}/.agents/skills`,
         scope: 'user',
         source: 'fallback'
       }])

--- a/cli/test/unit/agents/resolver-interactive.test.ts
+++ b/cli/test/unit/agents/resolver-interactive.test.ts
@@ -1,7 +1,11 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, describe, expect, mock, test } from 'bun:test'
 import type { AgentCandidate } from '../../../src/agents/types'
 
 interface PromptChoice {
+  title: string
   value: AgentCandidate
 }
 
@@ -13,9 +17,11 @@ interface PromptOptions {
 
 const defaultSelectedTargets = (options: PromptOptions): AgentCandidate[] => options.format?.([]) ?? []
 let selectPromptTargets = defaultSelectedTargets
+let renderedChoices: PromptChoice[] = []
 
 mock.module('prompts', () => ({
   default: (options: PromptOptions) => {
+    renderedChoices = options.choices ?? []
     options.onRender?.call({ cursor: 1 })
     return { selected: selectPromptTargets(options) }
   }
@@ -23,11 +29,61 @@ mock.module('prompts', () => ({
 
 afterEach(() => {
   selectPromptTargets = defaultSelectedTargets
+  renderedChoices = []
 })
 
 const { resolveInstallTargets } = await import('../../../src/agents/resolver')
 
 describe('resolveInstallTargets interactive prompt', () => {
+  test('renders AstronStudio by display name when its directory was detected', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-resolver-'))
+    const rootDir = join(home, '.acode', 'skills')
+
+    try {
+      await mkdir(rootDir, { recursive: true })
+      await resolveInstallTargets({
+        cwd: '/repo',
+        home,
+        agents: [],
+        scope: 'user',
+        json: false,
+        interactive: true
+      })
+
+      expect(renderedChoices[0]?.title).toBe(`AstronStudio (${rootDir})`)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  test('does not render AstronStudio when .acode skills is a regular file', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'skillhub-astron-studio-file-'))
+    const rootDir = join(home, '.acode', 'skills')
+
+    try {
+      await mkdir(join(home, '.acode'), { recursive: true })
+      await writeFile(rootDir, 'not a directory')
+      const targets = await resolveInstallTargets({
+        cwd: '/repo',
+        home,
+        agents: [],
+        scope: 'user',
+        json: false,
+        interactive: true
+      })
+
+      expect(renderedChoices.some(choice => choice.value.agent === 'astron-studio')).toBe(false)
+      expect(targets).toEqual([{
+        agent: 'generic',
+        rootDir: join(home, '.agents', 'skills'),
+        scope: 'user',
+        source: 'fallback'
+      }])
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   test('uses the highlighted target when Enter submits an empty multiselect', async () => {
     const detected: AgentCandidate[] = [
       { agent: 'codex', rootDir: '/repo/.codex/skills', scope: 'project', source: 'detected' },

--- a/cli/test/unit/agents/resolver.test.ts
+++ b/cli/test/unit/agents/resolver.test.ts
@@ -128,6 +128,17 @@ describe('resolveInstallTargets', () => {
     expect(targets).toEqual([{ agent: 'codex', rootDir: '/repo/.codex/skills', scope: 'project', source: 'explicit' }])
   })
 
+  test('rejects project scope for the user-only AstronStudio profile', async () => {
+    await expect(resolveInstallTargets({
+      cwd: '/repo',
+      home: '/home/u',
+      agents: ['astron-studio'],
+      scope: 'project',
+      json: false,
+      interactive: false
+    })).rejects.toThrow('agent astron-studio does not support project scope')
+  })
+
   test('scope=user + agent codex returns user root with user scope', async () => {
     const targets = await resolveInstallTargets({
       cwd: '/repo',

--- a/cli/test/unit/agents/resolver.test.ts
+++ b/cli/test/unit/agents/resolver.test.ts
@@ -128,15 +128,15 @@ describe('resolveInstallTargets', () => {
     expect(targets).toEqual([{ agent: 'codex', rootDir: '/repo/.codex/skills', scope: 'project', source: 'explicit' }])
   })
 
-  test('rejects project scope for the user-only AstronStudio profile', async () => {
+  test('rejects project scope for the user-only AStudio profile', async () => {
     await expect(resolveInstallTargets({
       cwd: '/repo',
       home: '/home/u',
-      agents: ['astron-studio'],
+      agents: ['AStudio'],
       scope: 'project',
       json: false,
       interactive: false
-    })).rejects.toThrow('agent astron-studio does not support project scope')
+    })).rejects.toThrow('agent AStudio does not support project scope')
   })
 
   test('scope=user + agent codex returns user root with user scope', async () => {

--- a/cli/test/unit/agents/resolver.test.ts
+++ b/cli/test/unit/agents/resolver.test.ts
@@ -132,11 +132,11 @@ describe('resolveInstallTargets', () => {
     await expect(resolveInstallTargets({
       cwd: '/repo',
       home: '/home/u',
-      agents: ['AStudio'],
+      agents: ['astudio'],
       scope: 'project',
       json: false,
       interactive: false
-    })).rejects.toThrow('agent AStudio does not support project scope')
+    })).rejects.toThrow('agent astudio does not support project scope')
   })
 
   test('scope=user + agent codex returns user root with user scope', async () => {

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -154,6 +154,9 @@ skillhub install pdf-parser --version 1.2.0
 # Install to specific Agent
 skillhub install pdf-parser --agent codex
 
+# Install to AstronStudio's fixed user-level directory
+skillhub install pdf-parser --agent astron-studio
+
 # Install to multiple Agents
 skillhub install pdf-parser --agent codex --agent claude-code
 
@@ -182,10 +185,11 @@ The CLI determines the installation location using the following logic:
 
 ### Install Paths
 
-Each Agent has both project-level and user-level skills directories. Use `--scope user|project` to control which one is used.
+Most Agents have both project-level and user-level skills directories. Use `--scope user|project` to control which one is used. AstronStudio uses its fixed user-level directory only.
 
 | Agent | Project-level Path | User-level Path |
 |-------|-------------------|-----------------|
+| `astron-studio` | Not supported | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |
@@ -202,7 +206,7 @@ Each Agent has both project-level and user-level skills directories. Use `--scop
 | `kilo` | `<project>/.kilo/skills/` | `~/.kilo/skills/` |
 | _fallback_ | `<project>/.agents/skills/` | `~/.agents/skills/` |
 
-For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
+For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. AstronStudio appears in that selector when `~/.acode/skills/` exists. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
 
 ### File Structure After Installation
 

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -155,7 +155,7 @@ skillhub install pdf-parser --version 1.2.0
 skillhub install pdf-parser --agent codex
 
 # Install to AStudio's fixed user-level directory
-skillhub install pdf-parser --agent AStudio
+skillhub install pdf-parser --agent astudio
 
 # Install to multiple Agents
 skillhub install pdf-parser --agent codex --agent claude-code
@@ -189,7 +189,7 @@ Most Agents have both project-level and user-level skills directories. Use `--sc
 
 | Agent | Project-level Path | User-level Path |
 |-------|-------------------|-----------------|
-| `AStudio` | Not supported | `~/.acode/skills/` |
+| `astudio` (AStudio) | Not supported | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |

--- a/docs/skillhub/en/guide/cli.md
+++ b/docs/skillhub/en/guide/cli.md
@@ -154,8 +154,8 @@ skillhub install pdf-parser --version 1.2.0
 # Install to specific Agent
 skillhub install pdf-parser --agent codex
 
-# Install to AstronStudio's fixed user-level directory
-skillhub install pdf-parser --agent astron-studio
+# Install to AStudio's fixed user-level directory
+skillhub install pdf-parser --agent AStudio
 
 # Install to multiple Agents
 skillhub install pdf-parser --agent codex --agent claude-code
@@ -185,11 +185,11 @@ The CLI determines the installation location using the following logic:
 
 ### Install Paths
 
-Most Agents have both project-level and user-level skills directories. Use `--scope user|project` to control which one is used. AstronStudio uses its fixed user-level directory only.
+Most Agents have both project-level and user-level skills directories. Use `--scope user|project` to control which one is used. AStudio uses its fixed user-level directory only.
 
 | Agent | Project-level Path | User-level Path |
 |-------|-------------------|-----------------|
-| `astron-studio` | Not supported | `~/.acode/skills/` |
+| `AStudio` | Not supported | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |
@@ -206,7 +206,7 @@ Most Agents have both project-level and user-level skills directories. Use `--sc
 | `kilo` | `<project>/.kilo/skills/` | `~/.kilo/skills/` |
 | _fallback_ | `<project>/.agents/skills/` | `~/.agents/skills/` |
 
-For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. AstronStudio appears in that selector when `~/.acode/skills/` exists. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
+For a custom path or an unsupported Agent directory, use `--dir` to specify the installation path. In interactive user scope, the `generic` target is offered alongside detected Agent targets. AStudio appears in that selector when `~/.acode/skills/` exists. When `--scope user|project` finds no matching agent directory, the CLI falls back to the `_fallback_` row above.
 
 ### File Structure After Installation
 

--- a/docs/skillhub/guide/cli.md
+++ b/docs/skillhub/guide/cli.md
@@ -150,8 +150,8 @@ skillhub install pdf-parser --version 1.2.0
 # 安装到指定 Agent
 skillhub install pdf-parser --agent codex
 
-# 安装到 AstronStudio 的固定用户级目录
-skillhub install pdf-parser --agent astron-studio
+# 安装到 AStudio 的固定用户级目录
+skillhub install pdf-parser --agent AStudio
 
 # 安装到多个 Agent
 skillhub install pdf-parser --agent codex --agent claude-code
@@ -181,11 +181,11 @@ CLI 按以下逻辑确定安装位置：
 
 ### 安装路径
 
-大多数 Agent 都有项目级和用户级两个 skills 目录。`--scope user|project` 决定使用哪一个。AstronStudio 仅使用固定的用户级目录。
+大多数 Agent 都有项目级和用户级两个 skills 目录。`--scope user|project` 决定使用哪一个。AStudio 仅使用固定的用户级目录。
 
 | Agent | 项目级路径 | 用户级路径 |
 |-------|-----------|-----------|
-| `astron-studio` | 不支持 | `~/.acode/skills/` |
+| `AStudio` | 不支持 | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |
@@ -202,7 +202,7 @@ CLI 按以下逻辑确定安装位置：
 | `kilo` | `<project>/.kilo/skills/` | `~/.kilo/skills/` |
 | _fallback_ | `<project>/.agents/skills/` | `~/.agents/skills/` |
 
-对于自定义路径或不在列表中的 Agent 目录，使用 `--dir` 显式指定安装路径。交互式 user scope 下会与已探测 Agent 目标一同提供 `generic` 目标；当 `~/.acode/skills/` 存在时，选择器会显示 AstronStudio。当 `--scope user|project` 找不到匹配的 agent 目录时，CLI 会回退到上表的 `_fallback_` 行。
+对于自定义路径或不在列表中的 Agent 目录，使用 `--dir` 显式指定安装路径。交互式 user scope 下会与已探测 Agent 目标一同提供 `generic` 目标；当 `~/.acode/skills/` 存在时，选择器会显示 AStudio。当 `--scope user|project` 找不到匹配的 agent 目录时，CLI 会回退到上表的 `_fallback_` 行。
 
 ### 安装后的文件结构
 

--- a/docs/skillhub/guide/cli.md
+++ b/docs/skillhub/guide/cli.md
@@ -150,6 +150,9 @@ skillhub install pdf-parser --version 1.2.0
 # 安装到指定 Agent
 skillhub install pdf-parser --agent codex
 
+# 安装到 AstronStudio 的固定用户级目录
+skillhub install pdf-parser --agent astron-studio
+
 # 安装到多个 Agent
 skillhub install pdf-parser --agent codex --agent claude-code
 
@@ -178,10 +181,11 @@ CLI 按以下逻辑确定安装位置：
 
 ### 安装路径
 
-每个 Agent 有项目级和用户级两个 skills 目录。`--scope user|project` 决定使用哪一个。
+大多数 Agent 都有项目级和用户级两个 skills 目录。`--scope user|project` 决定使用哪一个。AstronStudio 仅使用固定的用户级目录。
 
 | Agent | 项目级路径 | 用户级路径 |
 |-------|-----------|-----------|
+| `astron-studio` | 不支持 | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |
@@ -198,7 +202,7 @@ CLI 按以下逻辑确定安装位置：
 | `kilo` | `<project>/.kilo/skills/` | `~/.kilo/skills/` |
 | _fallback_ | `<project>/.agents/skills/` | `~/.agents/skills/` |
 
-对于自定义路径或不在列表中的 Agent 目录，使用 `--dir` 显式指定安装路径。交互式 user scope 下会与已探测 Agent 目标一同提供 `generic` 目标；当 `--scope user|project` 找不到匹配的 agent 目录时，CLI 会回退到上表的 `_fallback_` 行。
+对于自定义路径或不在列表中的 Agent 目录，使用 `--dir` 显式指定安装路径。交互式 user scope 下会与已探测 Agent 目标一同提供 `generic` 目标；当 `~/.acode/skills/` 存在时，选择器会显示 AstronStudio。当 `--scope user|project` 找不到匹配的 agent 目录时，CLI 会回退到上表的 `_fallback_` 行。
 
 ### 安装后的文件结构
 

--- a/docs/skillhub/guide/cli.md
+++ b/docs/skillhub/guide/cli.md
@@ -151,7 +151,7 @@ skillhub install pdf-parser --version 1.2.0
 skillhub install pdf-parser --agent codex
 
 # 安装到 AStudio 的固定用户级目录
-skillhub install pdf-parser --agent AStudio
+skillhub install pdf-parser --agent astudio
 
 # 安装到多个 Agent
 skillhub install pdf-parser --agent codex --agent claude-code
@@ -185,7 +185,7 @@ CLI 按以下逻辑确定安装位置：
 
 | Agent | 项目级路径 | 用户级路径 |
 |-------|-----------|-----------|
-| `AStudio` | 不支持 | `~/.acode/skills/` |
+| `astudio`（AStudio） | 不支持 | `~/.acode/skills/` |
 | `claude-code` | `<project>/.claude/skills/` | `~/.claude/skills/` |
 | `codex` | `<project>/.codex/skills/` | `~/.codex/skills/` |
 | `cursor` | `<project>/.cursor/skills/` | `~/.cursor/skills/` |


### PR DESCRIPTION
## 概述

为 SkillHub CLI 新增 AStudio agent profile，使用户可以将 Skill 安装到固定的用户级目录 `~/.acode/skills`，并在该目录存在时由交互式安装流程自动显示 AStudio。

## 变更内容

### CLI 实现

- 新增稳定 ID 为 `astudio` 的 profile，显示名为 `AStudio`。
- 固定使用用户级 `~/.acode/skills`，不创建虚假的项目级目标。
- 支持显式 `skillhub install <skill> --agent astudio`。
- 用户级交互安装只在 `.acode/skills` 是真实目录时显示 AStudio；普通文件不会被误判。
- profile home 路径兼容 Linux、macOS 与 Windows，并对 Windows 分隔符做稳定规范化。
- 对 `--scope project --agent astudio` 返回明确 usage error。
- 交互目标使用 profile `displayName`，同时在安装结果、inventory、metadata 中持久化小写 agent ID `astudio`。
- 通用 agent 目录探测由“路径存在”收紧为“目录存在”。

### 后端实现

- 无后端代码或 API 契约变更。
- 无 DB migration。

### 前端实现

- 无 Web 前端代码或 UI 变更。

### 文档

- 更新 CLI README 和 changelog。
- 同步中英文 VitePress CLI 用户指南。

## 测试覆盖

- Profile 单测：Linux `/home`、macOS `/Users`、Windows `C:\\Users` 路径。
- 探测单测：目录不存在、普通文件、真实目录。
- Resolver 单测：交互显示名、generic fallback、user-only scope rejection。
- Install 集成测试：显式 AStudio 安装、metadata 落盘和目标路径。
- PR CLI workflow 已配置 `ubuntu-latest`、`macos-latest`、`windows-latest` 三平台矩阵。

## 质量门禁

- [x] `make lint-cli`
- [x] `make typecheck-cli`
- [x] `make test-cli` — 480 passed, 0 failed
- [x] `make build-cli` — 188 modules, 0.44 MB bundle
- [x] `make typecheck-web`
- [x] `make lint-web`
- [x] `make test-frontend` — 733 passed, 0 failed（Node 20.20.0）
- [x] `TESTCONTAINERS_RYUK_DISABLED=true make test-backend-app` — 856 tests, 0 failures, 0 errors, 1 skipped
- [x] `make staging` — 15 smoke tests passed, 0 failed
- [x] `cd docs/skillhub && npm run build`
- [x] `git diff --check`

本机 OrbStack 无权读取 `~/Documents` bind mount，因此 staging 使用 `/tmp` 中与本分支 11/11 变更文件字节一致的源码副本执行。首次后端测试因 Docker Hub EOF 无法拉取 `testcontainers/ryuk:0.12.0`；复跑时仅禁用 Ryuk 资源清理容器，未跳过后端测试。

## 安全考虑

本次变更不涉及鉴权、密钥、网络请求或服务端权限。目录探测使用只读 `stat`，安装仍沿用现有冲突保护、锁和 metadata 所有权校验。

## 相关 Issue

N/A

## 测试说明

### 本地验证步骤

1. 创建 `~/.acode/skills`。
2. 在交互式终端执行 `skillhub install <skill>` 并选择 user scope。
3. 确认选择器显示 `AStudio (~/.acode/skills)`。
4. 或执行 `skillhub install <skill> --agent astudio`。
5. 确认 Skill 安装到 `~/.acode/skills/<skill>` 且生成 `.skillhub/metadata.json`。

### 回归测试范围

- 既有 agent 自动探测和多目标选择。
- 显式 `--agent` 与 `--scope` 解析。
- Linux、macOS、Windows 上的用户 home 路径。
- 安装 inventory 和 metadata 输出。

### 截图/录屏

无 Web UI 变更，不适用。