### PR TITLE
docs(publish): correct skill package metadata requirements

### DIFF
--- a/docs/skillhub/en/guide/skill-publish.md
+++ b/docs/skillhub/en/guide/skill-publish.md
@@ -49,10 +49,28 @@ New version has serious issues, need to point `latest` tag to previous stable ve
 
 1. **Prepare Skill Package**
 
-Ensure skill package conforms to SkillHub specification:
-- Contains `skill.md` (skill description)
-- Contains `package.json` or `SKILL.md` (metadata)
-- Clear file structure, no sensitive information
+Prepare a skill directory with `SKILL.md` at its root:
+
+- Put both YAML frontmatter and the skill instructions in `SKILL.md`.
+- The frontmatter must contain `name` and `description`. Set `version` there when you need an explicit version.
+- `package.json` does not supply or replace this skill metadata.
+- Keep the package structure clear and exclude sensitive information.
+
+For example, save this as `my-skill/SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: Summarize a short text as numbered steps.
+version: 1.0.0
+---
+
+Summarize the supplied text as numbered steps.
+```
+
+When packaging an existing skill, keep its required scripts, references,
+`agents/` metadata, and license files together. Pass that skill directory
+(`./my-skill` in this example) to the publish command below.
 
 2. **Publish via CLI (Recommended)**
 

--- a/docs/skillhub/guide/skill-publish.md
+++ b/docs/skillhub/guide/skill-publish.md
@@ -49,10 +49,27 @@ SkillHub 提供了类似 npm 的发布体验，但增加了企业级的权限控
 
 1. **准备技能包**
 
-确保技能包符合 SkillHub 规范：
-- 包含 `skill.md`（技能描述）
-- 包含 `package.json` 或 `SKILL.md`（元数据）
-- 文件结构清晰，无敏感信息
+准备一个根目录包含 `SKILL.md` 的技能目录：
+
+- 在 `SKILL.md` 中同时编写 YAML frontmatter 和技能指令。
+- frontmatter 必须包含 `name` 和 `description`；需要指定版本时，在其中设置 `version`。
+- `package.json` 不会提供或替代这些技能元数据。
+- 保持文件结构清晰，不包含敏感信息。
+
+例如，将以下内容保存为 `my-skill/SKILL.md`：
+
+```markdown
+---
+name: my-skill
+description: Summarize a short text as numbered steps.
+version: 1.0.0
+---
+
+Summarize the supplied text as numbered steps.
+```
+
+打包已有技能时，应一并保留其所需的脚本、参考文件、`agents/` 元数据和许可证文件。
+下一步发布命令的路径应指向该技能目录（本例为 `./my-skill`）。
 
 2. **使用 CLI 发布（推荐）**
 


### PR DESCRIPTION
## Summary

The English and Chinese publishing guides suggest that `package.json` can supply skill metadata. A package with plain Markdown instructions plus an npm manifest is actually rejected because required metadata is parsed from the skill Markdown's YAML frontmatter.

Correct the package-preparation step in both guides, show a complete `SKILL.md` example with `name`, `description`, and an explicit `version`, and identify the skill directory passed to the existing publish command. Preserve supporting files when packaging an existing skill.

Closes #851. Related to #327, whose version-source question was answered but whose affected documentation still contains the old guidance.

## Validation

- [x] Backend tests passed in GitHub CI (`Server Unit Tests`, full `make test-backend`).
- [x] Frontend typecheck and lint passed locally; `Web Build And Test` passed in GitHub CI.
- [x] OpenAPI SDK regeneration is not applicable; no API contract changed.
- [ ] Staging smoke test not run: Docker is not installed in the local Windows environment.

Completed checks:

- [GitHub PR Tests](https://github.com/iflytek/skillhub/actions/runs/34559312687) — Docs Build, Web Build And Test, and Server Unit Tests passed at commit `6138ae6`. Dependency Review, DCO, and CLA also passed; CodeQL was skipped by the existing workflow.

- `cd web && pnpm run typecheck && pnpm run lint` — passed using the declared pnpm 10.33.0 and frozen lockfile.

- `cd docs/skillhub && npm ci --no-audit --no-fund && npm run build` — VitePress build passed.
- `python weekly/scripts/build_site.py --source weekly/site --output docs/skillhub/.vitepress/dist/weekly` — built 8 reports.
- `python weekly/scripts/validate_site.py docs/skillhub/.vitepress/dist/weekly` — passed.
- Temporary Java 21 driver compiled the current production validator/parser and their dependencies, without mocks or HTTP calls: `package.json` alone rejected; plain `skill.md` plus `package.json` rejected; documented example accepted; an npm version did not supply a missing skill version. All four expectations passed.
- `git diff --check` — passed.
- Independent review checked translation parity, the copyable example, and the parser/validator behavior.

## Risk

- User-facing impact: documentation now matches the existing metadata contract.
- Deployment or migration impact: none; only two Markdown files change.
- Rollback: revert these documentation edits.

## Notes

The local Java 21 Maven `-pl skillhub-app -am test` run was stopped after the full backend suite passed in GitHub CI; the local run is not claimed as completed. Staging was not run because Docker is unavailable locally.

Filename case variants and supported wrapper-directory normalization are unchanged. The guide recommends the canonical `SKILL.md` layout without claiming that all other accepted forms are rejected. No skill was published to a registry during validation.
